### PR TITLE
Humanoid height tweaks

### DIFF
--- a/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
+++ b/Content.Shared/Humanoid/Prototypes/SpeciesPrototype.cs
@@ -142,13 +142,13 @@ public sealed partial class SpeciesPrototype : IPrototype
     /// The minimum height for this species
     /// </summary>
     [DataField("minHeight")]
-    public float MinHeight = 0.9f; // DeltaV - less trolling with the heights
+    public float MinHeight = 0.75f; // DeltaV - less trolling with the heights // Floofstation - more trolling with the heights
 
     /// <summary>
     /// The maximum height for this species
     /// </summary>
     [DataField("maxHeight")]
-    public float MaxHeight = 1.1f; // DeltaV - less trolling with the heights
+    public float MaxHeight = 1.25f; // DeltaV - less trolling with the heights // Floofstation - more trolling with the heights
 
     /// <summary>
     /// The default height for this species

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -238,9 +238,12 @@ namespace Content.Shared.Preferences
         {
             species ??= SharedHumanoidAppearanceSystem.DefaultSpecies;
 
+            var prototypeManager = IoCManager.Resolve<IPrototypeManager>(); // Floofstation
+            prototypeManager.Resolve<SpeciesPrototype>(species, out var speciesProto); // Floofstation
             return new()
             {
                 Species = species,
+                Height = speciesProto?.DefaultHeight ?? 1f, // Floofstation
                 Appearance = HumanoidCharacterAppearance.DefaultWithSpecies(species),
             };
         }
@@ -274,7 +277,7 @@ namespace Content.Shared.Preferences
             {
                 sex = random.Pick(speciesPrototype.Sexes);
                 age = random.Next(speciesPrototype.MinAge, speciesPrototype.OldAge); // people don't look and keep making 119 year old characters with zero rp, cap it at middle aged
-                // height = MathF.Round(random.NextFloat(speciesPrototype.MinHeight, speciesPrototype.MaxHeight), 2); // CD - Character Records // DeltaV - don't generate random heights
+                height = MathF.Round(random.NextFloat(speciesPrototype.MinHeight, speciesPrototype.MaxHeight), 2); // CD - Character Records // DeltaV - don't generate random heights // Floofstation - generate random heights
             }
 
             var gender = Gender.Epicene;

--- a/Resources/Prototypes/Species/reptilian.yml
+++ b/Resources/Prototypes/Species/reptilian.yml
@@ -11,6 +11,9 @@
   maleFirstNames: NamesReptilianMale
   femaleFirstNames: NamesReptilianFemale
   naming: FirstDashFirst
+  minHeight: 0.7 # Floofstation
+  maxHeight: 1.25 # Floofstation
+  defaultHeight: 0.95 # Floofstation
 
 - type: speciesBaseSprites
   id: MobReptilianSprites

--- a/Resources/Prototypes/_DV/Species/Oni.yml
+++ b/Resources/Prototypes/_DV/Species/Oni.yml
@@ -11,8 +11,10 @@
   femaleFirstNames: NamesOniFemale
   lastNames: NamesOniLocation
   naming: LastNoFirst
-  baseScale: "1.2, 1.2"
-  maxHeight: 1.05
+  # baseScale: "1.2, 1.2" # Floofstation
+  minHeight: 0.9 # Floofstation
+  maxHeight: 1.3 # Floofstation
+  defaultHeight: 1.2 # Floofstation
 
 - type: markingPoints
   id: MobOniMarkingLimits

--- a/Resources/Prototypes/_DV/Species/felinid.yml
+++ b/Resources/Prototypes/_DV/Species/felinid.yml
@@ -7,8 +7,10 @@
   markingLimits: MobFelinidMarkingLimits
   dollPrototype: MobFelinidDummy
   skinColoration: Hues
-  baseScale: "0.8, 0.8"
-  minHeight: 0.95
+  # baseScale: "0.8, 0.8" # Floofstation
+  minHeight: 0.65 # Floofstation
+  maxHeight: 1.1 # Floofstation
+  defaultHeight: 0.8 # Floofstation
 
 - type: markingPoints
   id: MobFelinidMarkingLimits

--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -7,8 +7,10 @@
   markingLimits: MobHarpyMarkingLimits
   dollPrototype: MobHarpyDummy
   skinColoration: HumanToned
-  baseScale: "0.9, 0.9"
-  minHeight: 0.90
+  # baseScale: "0.9, 0.9"
+  minHeight: 0.6 # Floofstation
+  maxHeight: 1.0 # Floofstation
+  defaultHeight: 0.8 # Floofstation
 
 - type: speciesBaseSprites
   id: MobHarpySprites

--- a/Resources/Prototypes/_DV/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Species/kitsune.yml
@@ -7,9 +7,12 @@
   markingLimits: MobKitsuneMarkingLimits
   dollPrototype: MobKitsuneDummy
   skinColoration: HumanToned
-  baseScale: 1, 1
-  minHeight: .85
-  maxHeight: 1.05
+  # baseScale: 1, 1 # Floofstation
+  # minHeight: .85 # Floofstation
+  # maxHeight: 1.05 # Floofstation
+  minHeight: 0.65 # Floofstation
+  maxHeight: 1.1 # Floofstation
+  defaultHeight: 0.8 # Floofstation
 
 - type: markingPoints
   id: MobKitsuneMarkingLimits

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -12,8 +12,11 @@
   femaleFirstNames: NamesRodentiaFemale
   lastNames: NamesRodentiaLast
   naming: LastFirst
-  baseScale: "0.8, 0.8"
-  minHeight: 0.95
+  # baseScale: "0.8, 0.8" # Floofstation
+  # minHeight: 0.95 # Floofstation
+  minHeight: 0.65 # Floofstation
+  maxHeight: 1.1 # Floofstation
+  defaultHeight: 0.8 # Floofstation
 
 - type: speciesBaseSprites
   id: MobRodentiaSprites


### PR DESCRIPTION
## About the PR
Brings the panta-rhei species height restrictions in-line with that of floofstation. Also re-enables random height generation for random humanoid spawners (delta-v disabled it for questionable balancing reasons) and makes it so that HumanoidCharacterProfile.DefaultWithSpecies actually respects SpeciesPrototype.DefaultHeight (this bug was present on floofstation too!)

## Technical details
<img width="1419" height="37" alt="image" src="https://github.com/user-attachments/assets/6452e489-7380-4383-881e-1ff3b9798010" />


## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="1121" height="777" alt="image" src="https://github.com/user-attachments/assets/75d6dcb2-c201-4197-bdc2-7f412bb714e6" />


</p></details>

## Licensing
N/A

**Changelog**
:cl:
- tweak: Brought character height restrictions and generation in-line with with that of Floofstation.