### PR TITLE
Fix AdminManager not loading toolshed command permissions into the permission manager

### DIFF
--- a/Content.Server/Administration/Managers/AdminManager.cs
+++ b/Content.Server/Administration/Managers/AdminManager.cs
@@ -301,9 +301,10 @@ namespace Content.Server.Administration.Managers
             if (_res.TryContentFileRead(new ResPath("/toolshedEngineCommandPerms.yml"), out var toolshedPerms))
             {
                 _toolshedCommandPermissions.LoadPermissionsFromStream(toolshedPerms);
-                // Floofstation - mirror command perms
-                _commandPermissions.LoadPermissionsFromStream(toolshedPerms);
             }
+            // Floofstation - mirror command perms
+            if (_res.TryContentFileRead(new ResPath("/toolshedEngineCommandPerms.yml"), out var toolshedPerms2))
+                _commandPermissions.LoadPermissionsFromStream(toolshedPerms2);
 
             _toolshed.ActivePermissionController = this;
 


### PR DESCRIPTION
## About the PR
This is a bug I fixed 2 years ago on EE, apparently wizden still has it?!

Testing with an admin account that has only +ADMIN and +DEBUG (the command /self requires +DEBUG):
Before (~150 commands available):
<img width="557" height="180" alt="image" src="https://github.com/user-attachments/assets/afd85260-6e13-4e28-aa22-b825f0c19f44" />

After (~300 commands available):
<img width="571" height="217" alt="image" src="https://github.com/user-attachments/assets/dc07fd92-a81b-42ba-a502-5f60a1e60588" />

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: Fixed a command permission bug that prevented admins from executing any toolshed commands. Apparently this is a 2 year old bug from wizden.
