### PR TITLE
Fixed minor issue

### DIFF
--- a/Resources/Prototypes/_EE/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Species/tajaran.yml
@@ -6,7 +6,7 @@
   sprites: MobTajaranSprites
   markingLimits: MobTajaranMarkingLimits
   dollPrototype: MobTajaranDummy
-  skinColoration: HumanToned
+  skinColoration: Hues
   customName: true
   sexes:
   - Unsexed

--- a/Resources/Prototypes/_Floof/Species/resomi.yml
+++ b/Resources/Prototypes/_Floof/Species/resomi.yml
@@ -6,7 +6,7 @@
   sprites: MobResomiSprites
   markingLimits: MobResomiMarkingLimits
   dollPrototype: MobResomiDummy
-  skinColoration: HumanToned
+  skinColoration: Hues
   customName: true
   sexes:
   - Unsexed

--- a/Resources/Prototypes/_Floof/Species/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Species/shadowkin.yml
@@ -6,7 +6,7 @@
   sprites: MobShadowkinSprites
   markingLimits: MobShadowkinMarkingLimits
   dollPrototype: MobShadowkinDummy
-  skinColoration: HumanToned
+  skinColoration: Hues
   customName: true
   sexes:
   - Unsexed


### PR DESCRIPTION
This is literally a three line change, I changed placeholders that I overlooked so now you can actually use colours for shadowkin, tajaran and resomi. Previously they were humantoned because I rebuilt the species definitions over those but I forgot to edit that so here that is

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Changed Tajaran, Shadowkin and Resomi to use hsv colors instead of skintones.
