### PR TITLE
Remove interaction popups from most playable species

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -371,9 +371,9 @@
   - type: SlavedBorg # DeltaV: NT borgs are enslaved to the AI by default
     law: ObeyAI
   - type: ShowJobIcons
-  - type: InteractionPopup
-    interactSuccessSound:
-      path: /Audio/Ambience/Objects/periodic_beep.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessSound:
+#      path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
   id: BaseBorgChassisSyndicate
@@ -591,9 +591,9 @@
   - type: AccessReader
     access: [["Xenoborg"]]
   - type: ShowJobIcons # not sure if it is needed
-  - type: InteractionPopup
-    interactSuccessSound:
-      path: /Audio/Ambience/Objects/periodic_beep.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessSound:
+#      path: /Audio/Ambience/Objects/periodic_beep.ogg
   - type: Fiber # DeltaV - xenoborgs have replicated plasteel fibers
     fiberMaterial: fibers-replicated-plasteel
   - type: LanguageKnowledge # Floofstation.

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/borg_chassis.yml
@@ -24,9 +24,9 @@
       sprite: Mobs/Silicon/chassis.rsi
       state: robot
     name: cyborg
-  - type: InteractionPopup
-    interactSuccessString: petting-success-generic-cyborg
-    interactFailureString: petting-failure-generic-cyborg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessString: petting-success-generic-cyborg
+#    interactFailureString: petting-failure-generic-cyborg
   - type: BorgSwitchableType
     inherentRadioChannels:
     - Common
@@ -109,11 +109,11 @@
           - BorgModuleSyndicateAssault
       hasMindState: synd_sec_e
       noMindState: synd_sec
-    - type: InteractionPopup
-      interactSuccessString: petting-success-syndicate-cyborg
-      interactFailureString: petting-failure-syndicate-cyborg
-      interactSuccessSound:
-        path: /Audio/Ambience/Objects/periodic_beep.ogg
+#    - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#      interactSuccessString: petting-success-syndicate-cyborg
+#      interactFailureString: petting-failure-syndicate-cyborg
+#      interactSuccessSound:
+#        path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
   id: BorgChassisSyndicateMedical
@@ -145,11 +145,11 @@
       damageContainers: # DeltaV
       - Biological
       - BiologicalMetaphysical # Kitsune
-    - type: InteractionPopup
-      interactSuccessString: petting-success-syndicate-cyborg
-      interactFailureString: petting-failure-syndicate-cyborg
-      interactSuccessSound:
-        path: /Audio/Ambience/Objects/periodic_beep.ogg
+#    - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#      interactSuccessString: petting-success-syndicate-cyborg
+#      interactFailureString: petting-failure-syndicate-cyborg
+#      interactSuccessSound:
+#        path: /Audio/Ambience/Objects/periodic_beep.ogg
     - type: SolutionScanner
     - type: FootstepModifier
       footstepSoundCollection:
@@ -187,11 +187,11 @@
       damageContainers:
       - Inorganic
       - Silicon
-    - type: InteractionPopup
-      interactSuccessString: petting-success-syndicate-cyborg
-      interactFailureString: petting-failure-syndicate-cyborg
-      interactSuccessSound:
-        path: /Audio/Ambience/Objects/periodic_beep.ogg
+#    - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#      interactSuccessString: petting-success-syndicate-cyborg
+#      interactFailureString: petting-failure-syndicate-cyborg
+#      interactSuccessSound:
+#        path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
   id: BorgChassisDerelict
@@ -219,11 +219,11 @@
     noMindState: derelict_e_r
   - type: Construction
     node: derelictcyborg
-  - type: InteractionPopup
-    interactSuccessString: petting-success-derelict-cyborg
-    interactFailureString: petting-failure-derelict-cyborg
-    interactSuccessSound:
-      path: /Audio/Ambience/Objects/periodic_beep.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessString: petting-success-derelict-cyborg
+#    interactFailureString: petting-failure-derelict-cyborg
+#    interactSuccessSound:
+#      path: /Audio/Ambience/Objects/periodic_beep.ogg
 
 - type: entity
   parent: BaseBorgChassisDerelict

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -181,11 +181,11 @@
   - type: MindContainer
     showExamineInfo: true
   - type: CanEnterCryostorage
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 1
+#    interactSuccessString: hugging-success-generic
+#    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+#    messagePerceivedByOthers: hugging-success-generic-others
   - type: CanHostGuardian
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/blast_door.yml
@@ -44,11 +44,11 @@
     - board
   - type: StaticPrice
     price: 500
-  - type: InteractionPopup
-    interactSuccessString: comp-window-knock
-    messagePerceivedByOthers: comp-window-knock
-    interactSuccessSound:
-      path: /Audio/Effects/glass_knock.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessString: comp-window-knock
+#    messagePerceivedByOthers: comp-window-knock
+#    interactSuccessSound:
+#      path: /Audio/Effects/glass_knock.ogg
 
 - type: entity
   id: BlastDoorOpen

--- a/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/plastitanium.yml
@@ -25,11 +25,11 @@
     bodyType: Static
   - type: ExaminableDamage
     messages: WindowMessages
-  - type: InteractionPopup
-    interactSuccessString: comp-window-knock
-    messagePerceivedByOthers: comp-window-knock
-    interactSuccessSound:
-      path: /Audio/Effects/glass_knock.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessString: comp-window-knock
+#    messagePerceivedByOthers: comp-window-knock
+#    interactSuccessSound:
+#      path: /Audio/Effects/glass_knock.ogg
   - type: Appearance
   - type: StaticPrice
     price: 100

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/Oni.yml
@@ -5,11 +5,11 @@
   id: MobOni
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 1
+#    interactSuccessString: hugging-success-generic
+#    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+#    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Player/felinid.yml
@@ -5,11 +5,11 @@
   id: MobFelinid
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 1
+#    interactSuccessString: hugging-success-generic
+#    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+#    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/harpy.yml
@@ -5,11 +5,11 @@
   id: MobHarpy
   components:
   - type: CombatMode
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 1
+#    interactSuccessString: hugging-success-generic
+#    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+#    messagePerceivedByOthers: hugging-success-generic-others
   - type: MindContainer
     showExamineInfo: true
   - type: Input

--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/kitsune.yml
@@ -6,13 +6,13 @@
   components:
   - type: HumanoidAppearance
     species: Kitsune
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-soft-floofy-kitsune
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/fox_squeak.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 0.5
+#    interactSuccessString: petting-success-soft-floofy-kitsune
+#    interactFailureString: petting-failure-generic
+#    interactSuccessSpawn: EffectHearts
+#    interactSuccessSound:
+#      path: /Audio/Animals/fox_squeak.ogg
   - type: MeleeWeapon
     soundHit:
       path: /Audio/Items/hiss.ogg

--- a/Resources/Prototypes/_DV/Entities/Mobs/Player/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Player/vulpkanin.yml
@@ -5,11 +5,11 @@
   id: MobVulpkanin
   components:
     - type: CombatMode
-    - type: InteractionPopup
-      successChance: 1
-      interactSuccessString: hugging-success-generic
-      interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-      messagePerceivedByOthers: hugging-success-generic-others
+#    - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#      successChance: 1
+#      interactSuccessString: hugging-success-generic
+#      interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+#      messagePerceivedByOthers: hugging-success-generic-others
     - type: MindContainer
       showExamineInfo: true
     - type: Input

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
@@ -40,13 +40,13 @@
     naturalLanguage: Kagebun
   - type: TypingIndicator
     proto: kitsune
-  - type: InteractionPopup
-    successChance: 0.5
-    interactSuccessString: petting-success-soft-floofy-kitsune
-    interactFailureString: petting-failure-generic
-    interactSuccessSpawn: EffectHearts
-    interactSuccessSound:
-      path: /Audio/Animals/fox_squeak.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 0.5
+#    interactSuccessString: petting-success-soft-floofy-kitsune
+#    interactFailureString: petting-failure-generic
+#    interactSuccessSpawn: EffectHearts
+#    interactSuccessSound:
+#      path: /Audio/Animals/fox_squeak.ogg
   - type: Kitsune
   - type: PsionicBonusChance
     flatBonus: 0.5

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -28,11 +28,11 @@
     lockTime: 5
     unlockTime: 5
     breakOnAccessBreaker: false # DeltaV - cant be emagged
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    successChance: 1
+#    interactSuccessString: hugging-success-generic
+#    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
+#    messagePerceivedByOthers: hugging-success-generic-others
   - type: NpcFactionMember
     factions:
       - NanoTrasen

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/taur.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/taur.yml
@@ -176,11 +176,6 @@
   - type: MindContainer
     showExamineInfo: true
   - type: CanEnterCryostorage
-  - type: InteractionPopup
-    successChance: 1
-    interactSuccessString: hugging-success-generic
-    interactSuccessSound: /Audio/Effects/thudswoosh.ogg
-    messagePerceivedByOthers: hugging-success-generic-others
   - type: CanHostGuardian
   - type: NpcFactionMember
     factions:

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Windows/windows.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Windows/windows.yml
@@ -101,11 +101,11 @@
   components:
   - type: Airtight
   - type: Repairable
-  - type: InteractionPopup
-    interactSuccessString: comp-window-knock
-    messagePerceivedByOthers: comp-window-knock
-    interactSuccessSound:
-      path: /Audio/Effects/glass_knock.ogg
+#  - type: InteractionPopup # Floofstation - interaction verb system replaces popups
+#    interactSuccessString: comp-window-knock
+#    messagePerceivedByOthers: comp-window-knock
+#    interactSuccessSound:
+#      path: /Audio/Effects/glass_knock.ogg
   - type: DamageVisuals
     thresholds: [4, 8, 12]
     damageDivisor: 2


### PR DESCRIPTION
## About the PR
Replaced by the interaction verb system. When you click one of these, a stripping ui will open instead of a generic "you hug Urist McHands" popup.

**Changelog**
:cl:
- remove: Removed interaction popups from most playable species, windows, etc. These things are replaced by interaction verbs.
