### PR TITLE
Disable borer

### DIFF
--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -42,8 +42,9 @@
       - id: MobWhimperlet # DeltaV - added Whimperlet
         weight: 0.03
       #- id: MobMouseCancer # DeltaV - no
-      - id: MobCorticalBorer # DeltaV - ported Borer
-        weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
+      #Euphoria - disable borer until consent details can be worked out
+      #- id: MobCorticalBorer # DeltaV - ported Borer
+      #  weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
 # Events always spawn a critter regardless of Probability https://github.com/space-wizards/space-station-14/issues/28480 I added the Rat King to their own event with a player cap.
 
 - type: entity
@@ -100,8 +101,9 @@
         weight: 0.05
       - id: MobWhimperlet # DeltaV - Added Whimperlet and its weight
         weight: 0.02
-      - id: MobCorticalBorer # DeltaV - ported Borer
-        weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
+        #Euphoria - disable borer until consent details can be worked out
+      #- id: MobCorticalBorer # DeltaV - ported Borer
+      #  weight: 0.015 # DeltaV - original probability was 0.001 but that seems WAY too low
 
 - type: entity
   id: SnailMigrationLowPop
@@ -150,5 +152,6 @@
       - id: MobSnailMoth
         weight: 0.07 # DeltaV - was 0.08
       #- id: MobSnailInstantDeath # DeltaV - no
-      - id: MobCorticalBorer # DeltaV - ported Borer
-        weight: 0.02 # DeltaV - 2% chance on snails
+      #Euphoria - disable borer until consent details can be worked out
+      #- id: MobCorticalBorer # DeltaV - ported Borer
+      #  weight: 0.02 # DeltaV - 2% chance on snails


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
removed the spawn of borers during mouse, snail, and roach events.

## Why / Balance
Consent problems

## Technical details
Borers still exist in the code, there just isnt any way for them to naturally spawn on the station.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- remove: Borers from spawning until consent can be worked out

