### PR TITLE
Tajaran Missing Marking Restoration

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/tattoos.yml
@@ -34,7 +34,7 @@
   id: TattooSilverburghLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune] # DeltaV - Felinid-Kitsune
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune, Tajaran] # DeltaV - Felinid-Kitsune | Floof - Tajaran
   coloring:
     default:
       type:
@@ -48,7 +48,7 @@
   id: TattooSilverburghRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune] # DeltaV - Felinid-Kitsune
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune, Tajaran] # DeltaV - Felinid-Kitsune | Floof - Tajaran
   coloring:
     default:
       type:
@@ -62,7 +62,7 @@
   id: TattooCampbellLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune] # DeltaV - Felinid-Kitsune
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune, Tajaran] # DeltaV - Felinid-Kitsune | Floof - Tajaran
   coloring:
     default:
       type:
@@ -76,7 +76,7 @@
   id: TattooCampbellRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune] # DeltaV - Felinid-Kitsune
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune, Tajaran] # DeltaV - Felinid-Kitsune | Floof - Tajaran
   coloring:
     default:
       type:
@@ -90,7 +90,7 @@
   id: TattooCampbellLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune] # DeltaV - Felinid-Kitsune
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune, Tajaran] # DeltaV - Felinid-Kitsune | Floof - Tajaran
   coloring:
     default:
       type:
@@ -104,7 +104,7 @@
   id: TattooCampbellRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune] # DeltaV - Felinid-Kitsune
+  speciesRestriction: [Human, Dwarf, Felinid, Oni, Kitsune, Tajaran] # DeltaV - Felinid-Kitsune | Floof - Tajaran
   coloring:
     default:
       type:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Customization/Markings/felinid.yml
@@ -4,7 +4,7 @@
   id: FelinidEarsBasic
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: basic_outer
@@ -15,7 +15,7 @@
   id: FelinidEarsCurled
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: curled_outer
@@ -26,7 +26,7 @@
   id: FelinidEarsDroopy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: droopy_outer
@@ -37,7 +37,7 @@
   id: FelinidEarsFuzzy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: basic_outer
@@ -48,7 +48,7 @@
   id: FelinidEarsStubby
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: stubby_outer
@@ -59,7 +59,7 @@
   id: FelinidEarsTall
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: tall_outer
@@ -72,7 +72,7 @@
   id: FelinidEarsTorn
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: torn_outer
@@ -83,7 +83,7 @@
   id: FelinidEarsWide
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_ears.rsi
     state: wide_outer
@@ -96,7 +96,7 @@
   id: FelinidTailBasic
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip
@@ -109,7 +109,7 @@
   id: FelinidTailBasicWithBow
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip
@@ -124,7 +124,7 @@
   id: FelinidTailBasicWithBell
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip
@@ -139,7 +139,7 @@
   id: FelinidTailBasicWithBowAndBell
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran, IPC] # FLOOF CHANGE IPCs get furry parts, Tajaran
   sprites:
   - sprite: Nyanotrasen/Mobs/Customization/felinid_tails.rsi
     state: basic_tail_tip

--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/felinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/felinid.yml
@@ -2,7 +2,7 @@
   id: FelinidFluffyTailRings
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_tails.rsi
     state: Felinid_fluffy_tail_full
@@ -13,7 +13,7 @@
   id: FelinidFluffyTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_tails.rsi
     state: Felinid_fluffy_tail_full
@@ -22,7 +22,7 @@
   id: FelinidAlternativeTail
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
     - sprite: _DV/Mobs/Customization/Felinid/alternative_tail.rsi
       state: m_waggingtail_cat_FRONT
@@ -31,7 +31,7 @@
   id: FelinidTiger
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
     - sprite: _DV/Mobs/Customization/Felinid/tiger_tail.rsi
       state: m_tail_tiger_primary
@@ -44,7 +44,7 @@
   id: FurredLeftArm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_arm
@@ -53,7 +53,7 @@
   id: FurredRightArm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_arm
@@ -62,7 +62,7 @@
   id: FurredLeftLeg
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_leg
@@ -71,7 +71,7 @@
   id: FurredRightLeg
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_leg
@@ -80,7 +80,7 @@
   id: FurredLeftFoot
   bodyPart: LFoot
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_foot
@@ -89,7 +89,7 @@
   id: FurredRightFoot
   bodyPart: RFoot
   markingCategory: Legs
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_foot
@@ -98,7 +98,7 @@
   id: FurredLeftHand
   bodyPart: LHand
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_l_hand
@@ -107,7 +107,7 @@
   id: FurredRightHand
   bodyPart: RHand
   markingCategory: Arms
-  speciesRestriction: [Felinid]
+  speciesRestriction: [Felinid, Tajaran] #Floof - Tajaran
   sprites:
   - sprite: _DV/Mobs/Customization/Felinid/felinid_limbs.rsi
     state: furred_r_hand


### PR DESCRIPTION
## About the PR
Returns some of the missing marking permissions for shared markings between Tajaran and Felinid. Also readds permission for IPC for some Felinid markings because they had them on Floof.

## Why / Balance
Floof parity.

## Technical details
Just adds Tajaran and IPC to some species restrictions that weren't inverted.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="919" height="383" alt="image" src="https://github.com/user-attachments/assets/37df8b93-6163-483a-b6cf-15fbc7bf64f0" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- tweak: Increased marking availability for Tajaran and IPC.