### PR TITLE
vox are space proof again

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -97,7 +97,7 @@
         Cold: 0 #per second, scales with temperature & other constants
     heatDamage:
       types:
-        Heat: 1.5 #floof/euphoria changes start here
+        Heat: 1.5 #floof/euphoria changes end here
   - type: PassiveDamage
     # Augment normal health regen to be able to tank some Poison damage
     # This allows Vox to take their mask off temporarily to eat something without needing a trip to medbay afterwards.


### PR DESCRIPTION
## About the PR
intergalactic streaking is possible again (for vox only)
also i will add stuff to the guide book when vox lore is in a more stable state

## Why / Balance
was in old ee and vox dont have perks and have been deemed the "challenge race" from lack of attention from wizden THIS FIXES IT and keeps it in line with current vox lore

## Technical details
shit code thru and thru mostly cuz most species are now parented to a new species base that forces the barotrauma component and i had to tack a new one on for vox please read the code comments and breaking changes for more info

## Media
<img width="632" height="557" alt="image" src="https://github.com/user-attachments/assets/3ad97e20-bd7e-4053-a011-dda5f9e6642f" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
this code is a shit show lmao WAS GONNA try and make it so vox die from high pressures as well but barotrauma component dont do that sadly and pressure protection aint shit and seems is just for clothes (you still catch on fire and overheat from plasma fires tho)

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: THE SHOAL HAS RE-ENABLED VOX SPACE-PROOFING, PRAISE THE AURALIS!!!
