### PR TITLE
Harpy wing layering bugfix

### DIFF
--- a/Resources/Prototypes/_DV/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Species/harpy.yml
@@ -107,8 +107,8 @@
       required: false
     Arms:
       points: 10
-      required: false
-      defaultMarkings: [ HarpyWingDefaultHuescale ]
+      required: true
+      # defaultMarkings: [ HarpyWingDefaultHuescale ] # breaks the layering if kept. Is ugly but the way this stuff is implemented makes it impossible to do anything else
 
 - type: humanoidBaseSprite
   id: MobHarpyHead


### PR DESCRIPTION
## About the PR
Basically harpies had a default wing marking which didnt get overwritten causing it to not get removed and being rendered underneath any other wing.
Only solution is to remove the default marking, which means that harpies in character creation will not have any wings. They need to be manually added during the character creation as markings.
Does it look bad? Yes, is there another way to fix it? Not that I have found one

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- remove: Removed harpy default marking