### PR TITLE
Make survival less chaotic

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -544,17 +544,16 @@
   - type: NextEvent # DeltaV: Queue Event for precognition
   - type: RampingStationEventScheduler
     timeKeyPoints: # DeltaV
-    - 10, 10
-    - 10, 6
-    - 10, 1
-    - 10, 3
-    - 15, 5
-    - 15, 4
-    - 20, 2
-    - 10, 1
-    - 10, 4
-    - 10, 3
-    - 70, 4
+    # Floofstation section - replaced
+    - 30, 10 # First 30m, 3 events on average
+    - 30, 8  # 30-60m, 3.5 events
+    - 30, 6  # 60-90m, 5 events
+    - 45, 10 # 90-135m, back to 4.5 events
+    - 35, 6  # 135-170m, back to 5 events
+    - 70, 5  # 170-240m, 12 events/hour past the 3 hour mark
+    - 30, 4  # 240-270, some actual chaos
+    - 180, 8 # past the 4.5 hour mark, calmness
+    # Floofstation section end
     scheduledGameRules: !type:NestedSelector
       tableId: BasicGameRulesTable
 


### PR DESCRIPTION
## About the PR
Instead of ramping to 1 event every minute at the 30 hour mark, going back to 1 event every 10 minutes at 1:30, and then ramping back up by 2:30, the event frequency will now slowly ramp up throughout 0-240m and then drop to 1 event every 10 minutes past 4:30

Average number of events throughout the first 150 minutes before this change: 66 (1 event every 2.5 minutes)
Average after this change: 22 (1 event every 7.5 minutes)
Average after this change, between 150m and 240m: 21 (1 event every 4.5 minutes)

**Changelog**
:cl:
- tweak: The survival gamemode (ramping event scheduler) will now spam roughly 3 times less events throughout the shift, and there will be no spike of events at the 30m mark (1 event every minute) like there used to be.
