### PR TITLE
Disable station AI role

### DIFF
--- a/Euphoria Station/Euphoria Station.sln
+++ b/Euphoria Station/Euphoria Station.sln
@@ -1,0 +1,8 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -80,7 +80,7 @@
   - ERTSecurity
   - ERTEngineer
   - DeathSquad
-  - StationAi # DeltaV - added for playtime trackers
+  #- StationAi # Euphoria - Removed addition originally from DeltaV along with removing Station AI
   primary: false
   weight: 100
 
@@ -153,7 +153,7 @@
   - Borg
   - MedicalBorg # DeltaV - roundstart mediborg job
   - SecurityBorg # Delta-V : Security Borg
-  - StationAi
+  #- StationAi # Euphoria - removed Station AI
   primary: false # DeltaV - removed from primary dept
 
 - type: department


### PR DESCRIPTION
## About the PR
 I disable the option to role for Station AI.

## Why / Balance
Floof never had a station AI role, the station structure functioned just fine, and I believe that makes for a better experience to the server for many reasons. Massive text ahead, and a lot of criticism for the role of station AI in the game, but they are my reasons as to why I believe this role should be disabled. But in short, I believe it removes roleplay interaction between departments and players in general, streamlining and facilitating actions, or otherwise disrupting other departments or roles.

**Antagonists:**
 The presence of station AI makes the role of antagonists significantly harder and unpredictable. AI's have cameras in most parts of the station and with incredibly easy access, unlike the warden for example, who has to cycle through cameras and pick where to watch. AI's can control entrances and exits, as well as being capable of dealing damage with electrified doors, and even worse, suffocate or otherwise deal pressure damage through air alarms. This makes antagonism difficult in a way I don't believe is fun to engage with at all. You can avoid these circumstances as an antagonists, but the ways to do so are either difficult or unfun for other players. You can remove or disable the AI from the game, which will put the AI's player out of playing (bad), put a massive target on the person who did it (this just makes their situation worse when they are trying to facilitate their situation by removing the AI), and is also very difficult, costing either a lot of TC or a lot of time and preparation, may not even work in the first place, and might even be fixed before you are able to execute the plan you prepared for. You also have the option of snipping wires, removing cameras, etc. But this will most likely have a response from the AI asking for support at the region that was sabotaged, which, yes, would prevent you from being trapped by bolted doors, for example, but the problem of easily having yourself observed and your location reported to authorities is still there, since the AI will either notice the missing camera, or notice you removing it. I personally see no issue with having a warden report this activity through cameras, which are slow to reach and puts someone who is already a member of security to observe, secure, and ultimately just play their role, instead of having that function allocated to another role that is arguably completely unrelated to security. I also see no issue with nearby workers noticing suspicious activity and deciding if they want to report it or not; it adds the possibility of the assailant to be able to convince the witnesses of otherwise, to lie, bribe, or otherwise socially engineer, to ROLEPLAY (very good thing to have in this game). And yes, AIs don't have to report crimes, but often nothing stops them of doing so, and they often do report them. You CAN try to convince the AI not to, but it is difficult to reach to the AI without doing so in a public department channel, or through a holopad which everyone will hear. Plus, some lawsets just do not allow the AI to comply to such requests (robocop, NT default, corporate).

**Security**: 
I will give context that I am a security main and this comes from my perspective as one.
 As I lightly mentioned in the paragraph before, the AI often interferes with security's job, in ways that are positive and negative for the role, but I believe in either cases they are _negative_ for the overall experience. Yes AI can report crimes to security, detain suspects between bolted doors, but this takes the interaction of security officers with other people, takes away investigation from crimes (the AI can just tell you they saw it and you have little reason to not believe them), little engagement with people reporting suspicious activity, and being stripped of being able to give chase, ask to comply, or detain, as the AI has already bolted the escape routes. This forces the hands of both antagonists and security, and in my opinion it less so makes it "working with the AI", and more working FOR the AI, as they will have handled everything for you and just order you a location and to do the menial task of cuffing and transporting. At worse moments, the AI may act as the diplomat and communicator between negotiations with criminals which I find robs security of roleplay even more. And in the less beneficial aspects for security, Station AI's can downright disrupt the department if their law says so. Security wants to arm up to take down a threat they have ample reason to believe is armed and lethal? If they possess a crew ID and AI is crewsimov, it can bolt the armory and shut off the power, leaving very little for security to respond with, and having being in these situations, it is just not fun to deal with, because we might not have the tools to, the people that do might not be available, and it just leaves us to stand around or vandalize our department for our own gear. Yes, AI doesn't need to do this, and yes it could lead to the threat injuring more people than if security armed, but AIs are incentivized to make their own interpretations, and this is an interpretation of the crewsimov law, and I have witnessed it happen. There are also worse situations in OTHER lawsets. NT Default killing people who they deem to not be beneficial for station assets, robocop interfering with with security, Ion lawed AIs being incentivized to disrupt departments. Of course obstacles and solutions for these obstacles are welcome, but an AIs obstacles are NOT fun to deal with and neither are the solutions. To solve issues with an AIs laws (if they are faulty or wrong), it will always be to storm into the core with a sufficient team and perhaps an engineer to breach doors, and to change the laws. I've also seen an issue of AI's instructing and bickering in security channels when officers do things the AI's laws do not support, and it clogs the channel with instructions from a role who does not have authority in the department.

**Roleplay:**
 Station AIs for the average crew member streamline the process of reaching out to other station members with different accesses, knowledge and departments. AIs have access to every door and every channel, if you have an issue, you do not need to talk to someone else, you don't need to convince anyone, you don't need to lie or bribe. You can ask for access (in crewsimov lawset) and the AI will grant it to you. The same goes for asking for help. You ask the AI, they will see your specific location and get you immediate help without having to talk to communicate with anyone else. The medium can always be the AI, as it has access to everything almost immediately.

 I don't believe any of these issues stated are issues with people who play Station AI, this is what the role encourages and I believe we were doing just fine without it. This is a role I can see being very useful in lower RP environments where people want to make their activities easier and streamlined, but something I absolutely do not see as being needed in Floof, which I found to be the highest roleplay quality server out of all the MRP servers I have tried.
 Overall 
## Technical details
 I disabled AI from being able to be rolled, I'm not aware of any issues this could be causing. Testing looked good.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl: LadyDeathsHead
- remove: Station AI
