### PR TITLE
Updated Head Severing Threshold 

### DIFF
--- a/Resources/Prototypes/_DV/Body/Parts/base.yml
+++ b/Resources/Prototypes/_DV/Body/Parts/base.yml
@@ -2,14 +2,14 @@
   abstract: true
   id: BaseHeadDV
   components:
-  - type: BodyPart
+  - type: BodyPart # Euphoria - makes it so explosives don't blow your head off and round remove you too easily
     severThresholds:
     - types:
-        Piercing: 100
+        Piercing: 300
     - types:
-        Slash: 100
+        Slash: 150
     - types:
-        Blunt: 100
+        Blunt: 300
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
This might be a mald PR but I had 2 potato bombs tossed at me with no armor on and my head got gibbed, (and security put my brain in a locked locker and forgot about it) so I've increased the threshold damage heads need to take before coming off.

**Changelog**
:cl:
- tweak: Heads are less likely to come off and gib in an explosion, the rest of the body though...
