### PR TITLE
Borg Crew Monitor fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -940,7 +940,7 @@
     hands:
     - item: HandheldHealthAnalyzerUnpowered
     - item: DefibrillatorOneHandedUnpowered
-    - item: HandheldCrewMonitorUnpowered # DeltaV
+    - item: HandheldCrewMonitorBorg # Euphoria
     - item: BorgFireExtinguisher
     - item: BorgHandheldGPSBasic
     - item: HandLabeler

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/handheld_crew_monitor.yml
@@ -1,0 +1,13 @@
+- type: entity
+  id: HandheldCrewMonitorBorg
+  parent: HandheldCrewMonitor
+  suffix: Borg
+  components:
+  - type: ItemSlots
+    slots:
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: PowerCellMicroreactor
+        disableEject: true
+        swap: false
+# copied handheld mass scanner for borgs. unless you break rate limit, the power for it won't be dying.


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Micro-powered crew monitors that you can't eject the battery out of by accident. 
You can still see the battery charge, but it's essentially the same as the borg version of the handheld mass scanners
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This shouldn't be an issue for medical borgs.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
copy handheld mass scanner code
change mass scanner code for new proto
win

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
[File Garden Link to Video cause it won't let me embed](https://file.garden/ZgrUje9PayWvPehO/MedalTVScreenRecording20260303235146242-1772607316.mp4)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Medical Cyborgs can now use their crew monitor without worrying about power conservation and ejecting the cell!
