### PR TITLE
Footprint fixes

### DIFF
--- a/Content.Client/_EE/FootPrint/FootPrintsVisualizerSystem.cs
+++ b/Content.Client/_EE/FootPrint/FootPrintsVisualizerSystem.cs
@@ -1,4 +1,5 @@
 ﻿using Content.Shared._EE.FootPrint;
+using Content.Shared._Floof.Util;
 using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Shared.Random;
@@ -47,7 +48,7 @@ public sealed class FootPrintsVisualizerSystem : VisualizerSystem<FootPrintCompo
             FootPrintVisuals.BareFootPrint => printsComponent.RightStep ? printsComponent.RightBarePrint : printsComponent.LeftBarePrint,
             FootPrintVisuals.ShoesPrint => printsComponent.ShoesPrint,
             FootPrintVisuals.SuitPrint => printsComponent.SuitPrint,
-            FootPrintVisuals.Dragging => _random.Pick(printsComponent.DraggingPrint),
+            FootPrintVisuals.Dragging => DeterministicRandom.Pick(printsComponent.DraggingPrint, uid.Id), // Floofstation - use deterministic random
             _ => throw new ArgumentOutOfRangeException($"Unknown {printVisuals} parameter.")
         }), printsComponent.RsiPath);
 

--- a/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
+++ b/Content.Shared/Movement/Systems/SpeedModifierContactsSystem.cs
@@ -58,7 +58,7 @@ public sealed class SpeedModifierContactsSystem : EntitySystem
 
     public void ChangeSpeedModifiers(EntityUid uid, float walkSpeed, float sprintSpeed, SpeedModifierContactsComponent? component = null)
     {
-        if (!Resolve(uid, ref component))
+        if (!Resolve(uid, ref component, logMissing: false)) // Floof - dont log missing
             return;
 
         component.WalkSpeedModifier = walkSpeed;

--- a/Content.Shared/_Floof/Util/DeterministicRandom.cs
+++ b/Content.Shared/_Floof/Util/DeterministicRandom.cs
@@ -1,0 +1,44 @@
+namespace Content.Shared._Floof.Util;
+
+public static class DeterministicRandom
+{
+    private const int LCG_MULTIPLIER = 1103515245;
+    private const int LCG_INCREMENT = 12345;
+
+    /// <summary>
+    ///     Generates a deterministic unsigned pseudo-random positive number using a linear congruential generator.
+    ///     Range: [0, max).
+    /// </summary>
+    public static int Prng(int seed, int max)
+    {
+        if (max == 0)
+            return 0; // Avoid division by 0
+
+        seed = (LCG_MULTIPLIER * seed + LCG_INCREMENT);
+        return Math.Abs(seed % max);
+    }
+
+    /// <summary>
+    ///     Generates a deterministic signed pseudo-random positive number using a linear congruential generator.
+    ///     Range: [min, max).
+    /// </summary>
+    public static int Prng(int seed, int min, int max)
+    {
+        if (min > max)
+            throw new ArgumentOutOfRangeException(nameof(max));
+        var b = Prng(seed, (max - min));
+        return min + b;
+    }
+
+    /// <summary>
+    ///     Picks a random value from the list deterministically based on the seed.
+    /// </summary>
+    public static T Pick<T>(IList<T> list, int seed)
+    {
+        if (list.Count == 0)
+            throw new IndexOutOfRangeException("List is empty");
+
+        var idx = Prng(seed, 0, list.Count);
+        return list[idx];
+    }
+}


### PR DESCRIPTION
## About the PR
- Makes it so that SpeedModifierContactsSystem doesn't log an error if a comp is missing when trying to refresh speed modifiers
- Changes FootPrintsVisualizerSystem to use deterministic random when picking a dragging sprite state (otherwise the dragging prints cycle between different states on each frame)

## Technical details
Wrote a sick new static helper class in Content.Shared._Floof.Util

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Fixed a couple issues with footprints. See PR 197 for more details.