### PR TITLE
Revert the increase of head (top) marking points

### DIFF
--- a/Resources/Prototypes/Species/arachnid.yml
+++ b/Resources/Prototypes/Species/arachnid.yml
@@ -73,7 +73,7 @@
       points: 1
       required: false
     HeadSide:
-      points: 6
+      points: 1
       required: true
       defaultMarkings: [ ArachnidCheliceraeDownwards ]
     HeadTop:

--- a/Resources/Prototypes/_DV/Species/Oni.yml
+++ b/Resources/Prototypes/_DV/Species/Oni.yml
@@ -38,11 +38,11 @@
       points: 1
       required: false
     HeadTop:
-      points: 6
+      points: 1
       required: true
       defaultMarkings: [ OniHornDoubleCurved ]
     HeadSide:
-      points: 6
+      points: 1
       required: false
       defaultMarkings: [ PointyEarsUpwards ]
     Hair:

--- a/Resources/Prototypes/_DV/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Species/kitsune.yml
@@ -40,7 +40,7 @@
       points: 6
       required: false
     HeadTop:
-      points: 6
+      points: 1
       required: true
       defaultMarkings: [ KitsuneEarsDefault ]
     Hair:

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -70,7 +70,7 @@
       points: 1
       required: false
     HeadTop:
-      points: 6 # This could backfire due to shitty rendering bug not removing default markings
+      points: 1
       required: true
       defaultMarkings: [ RodentiaHeadTopEarDefault ]
     HeadSide:

--- a/Resources/Prototypes/_DV/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Species/vulpkanin.yml
@@ -67,7 +67,7 @@
       points: 6
       required: false
     HeadTop:
-      points: 6 # This could also backfire
+      points: 1
       required: true
       defaultMarkings: [ VulpEar ]
     Hair:

--- a/Resources/Prototypes/_Impstation/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Species/thaven.yml
@@ -69,7 +69,7 @@
       points: 1
       required: false
     HeadSide:
-      points: 6
+      points: 1
       required: true
       defaultMarkings: [ ThavenEars1 ]
     HeadTop:


### PR DESCRIPTION
## About the PR
I love having a forced second set of ears

**Changelog**
:cl:
- fix: Reduced head (top) marking points back down to 1. Please report if there are any other marking points with a limit greater than 1 and forced default markings.