### PR TITLE
Multi MarkingPoint defaultMarking fix

### DIFF
--- a/Content.Shared/Humanoid/Markings/MarkingsSet.cs
+++ b/Content.Shared/Humanoid/Markings/MarkingsSet.cs
@@ -292,6 +292,7 @@ public sealed partial class MarkingSet
 
         foreach (var (category, points) in Points)
         {
+            //Floof change, added an additional or clause. Needed due to default markings otherwise rendering under markings if not all marking points are used in categories with more than one point
             if (points.Points <= 0 || points.DefaultMarkings.Count <= 0 || (Markings.TryGetValue(category, out var markings) && markings.Count > 0))
             {
                 continue;


### PR DESCRIPTION
## About the PR
Fixes an annoying bug that causes default markings to get applied to categories with more than one marking point.
The reason for this is that in the EnsureDefault method a small if clause gets run that only checks if the leftover points are 0 or if no defaultMarkings exist. By adding an additional clause to check if the overall markings are bigger than 0 any additionally added marking causes this skip clause to also take effect. In a nutshell, if your character has no markings the list of markings has a length of 0, if it has literally any marking it is bigger than 0, meaning adding a single custom marking fires the clause. Removing the markings also causes the defaultMarking to be reapplied again.
In non-programmer witchcraft speak: I can now readd multiple marking points for slots with defaultmarkings without causing shitty clipping. Aka harpies can have wings again by default while also being customizable now

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
Literally adds an additional length check clause to the EnsureDefault() method in the if cycle.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Fixed game adding defaultMarkings to categories with more than one trait point
