### PR TITLE
Fix more error spam

### DIFF
--- a/Resources/Prototypes/Entities/Effects/puddle.yml
+++ b/Resources/Prototypes/Entities/Effects/puddle.yml
@@ -236,8 +236,8 @@
     drawdepth: FloorObjects
     color: "#FFFFFF80"
     # Floofstation - no
-#  - type: Physics
-#    bodyType: Static
+  - type: Physics
+    bodyType: Static
 #  - type: Fixtures
 #    fixtures:
 #      slipFixture:


### PR DESCRIPTION
## About the PR
In the call chain SPS.OnSolutionUpdate->UpdateSlow->SMCS.ChangeSpeedModifiers->PhysicsSystem.GetContactingEntities there's an assumption that the puddle has a PhysicsComponent. I'm not gonna try and find all codepaths that eventually converge to calls like this, the solution this time is to accept the inevitable and give footstep entities their Physics component with a static body type back.

**Changelog**
:cl:
- fix: Fixed more error spam caused by footprints.