### PR TITLE
Weight Traits Fix

### DIFF
--- a/Content.Shared/_Floof/Traits/Effects/ModifyDensityEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyDensityEffect.cs
@@ -1,0 +1,34 @@
+using Content.Shared._DV.Traits.Effects;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.Shared._Floof.Traits.Effects;
+
+/// <summary>
+/// Effect that modifies the density of an entity.
+/// </summary>
+public sealed partial class ModifyDensityEffect : BaseTraitEffect
+{
+    /// <summary>
+    /// The factor to multiply density by.
+    /// </summary>
+    [DataField(required: true)]
+    public float Factor = 1f;
+
+    public override void Apply(TraitEffectContext ctx)
+    {
+        //Abort if attempting to apply to entity with no fixtures
+        if (!ctx.EntMan.TryGetComponent<FixturesComponent>(ctx.Player, out var fixcmp))
+            return;
+
+        //Adjust each fixture on the entity
+        foreach (var (id, fix) in fixcmp.Fixtures)
+        {
+            var result = fix.Density * Factor;
+            ctx.EntMan.EntitySysManager.GetEntitySystem<SharedPhysicsSystem>().SetDensity(ctx.Player, id, fix, result, update: false, fixcmp);
+        }
+
+        //Update all changes
+        ctx.EntMan.EntitySysManager.GetEntitySystem<FixtureSystem>().FixtureUpdate(ctx.Player, true, true, fixcmp);
+    }
+}

--- a/Resources/Prototypes/_Floof/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Floof/Traits/disabilities.yml
@@ -16,8 +16,8 @@
     - Kitsune # Floof - M3739 - #937 - They are light enough as it is.
     invert: true
   effects:
-  - !type:ModifyFixtureEffect
-    factor: 0.7746 # Square root of 0.6 as this modifies the radius
+  - !type:ModifyDensityEffect
+    factor: 0.6
   conflicts:
     - Heavyweight
 
@@ -40,5 +40,5 @@
   conflicts:
     - Lightweight
   effects:
-  - !type:ModifyFixtureEffect
-    factor: 1.1832 # Square root of 1.4 as this affects the radius, opposite of lightweight.
+  - !type:ModifyDensityEffect
+    factor: 1.4


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Changes the weight traits to just modify density instead of fixture radius.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People got stuck in doors.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Creates the new ModifyDensityEffect and changes the two traits to use it.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Lightweight:
<img width="651" height="426" alt="image" src="https://github.com/user-attachments/assets/fe2fe951-821f-49af-bdd5-aabc8b597347" />
Normal:
<img width="587" height="386" alt="image" src="https://github.com/user-attachments/assets/9d8466d1-a288-4ab5-8ff8-2b22f4bd0b75" />
Heavyweight:
<img width="592" height="396" alt="image" src="https://github.com/user-attachments/assets/0ab1a134-92d6-47a9-a62f-0fb03d4ed6d7" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None that I know of.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- fix: Heavyweight should no longer get people stuck.
