### PR TITLE
Add missing guidebook localization

### DIFF
--- a/Resources/Locale/en-US/_Floof/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/_Floof/guidebook/guides.ftl
@@ -15,7 +15,6 @@ guide-entry-sm = Supermatter Engine (SM)
 guide-entry-singularity = Singularity / Tesla
 guide-entry-teg = Thermo-electric Generator (TEG)
 guide-entry-rtg = RTG
-guide-entry-radio = Radio
 guide-entry-jobs = Jobs
 guide-entry-cargo = Logistics
 guide-entry-cargo-bounties = Cargo Bounties


### PR DESCRIPTION
## About the PR
Fixes this:
<img width="290" height="433" alt="image" src="https://github.com/user-attachments/assets/6a5185b2-a686-4bf1-9836-4e621b43ac2f" />
<img width="289" height="35" alt="image" src="https://github.com/user-attachments/assets/f4f2caab-444a-4e00-adb3-ee2345e61b4b" />


## Media
after
<img width="414" height="631" alt="image" src="https://github.com/user-attachments/assets/8d2d24c1-561f-4496-8fc5-15b55d010e84" />
<img width="350" height="637" alt="image" src="https://github.com/user-attachments/assets/aa98a683-2e40-4776-9473-9bab5d9c5487" />
<img width="357" height="560" alt="image" src="https://github.com/user-attachments/assets/db3a8ec4-0ea9-4595-9a8b-e7fdea5c2773" />


**Changelog**
:cl:
- fix: Fixed some guidebook entries appearing with the wrong text. (no localization)
