### PR TITLE
Linkable Digiboard

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/folders.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/folders.yml
@@ -474,6 +474,12 @@
     damage:
       types:
         Blunt: 10
+  # Floofstation additions start
+  - type: DeviceLinkSource
+    range: 200
+    ports:
+    - OrderSender
+  # Floofstation additions end
   - type: Tag
     tags:
     - Folder


### PR DESCRIPTION
## About the PR
Allows the LO's digiboard to be linked.

## Why / Balance
Small QoL that makes things a little nicer for LO/QM.

## Technical details
Small yaml edit.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

https://github.com/user-attachments/assets/9a9dcf9b-66fc-43dc-831e-c13039f40ee6


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Lo's Digiboard can be linked to cargo telepads again.