### PR TITLE
Max Language increase

### DIFF
--- a/Resources/Prototypes/_Floof/Traits/categories.yml
+++ b/Resources/Prototypes/_Floof/Traits/categories.yml
@@ -1,7 +1,7 @@
 - type: traitCategory
   id: Languages
   name: trait-category-languages
-  maxTraits: 2 # Either foreigner + additional language, or 2 additional languages. No multilingual traits yet.
+  maxTraits: 5 # Either foreigner + additional language, or 2 additional languages. No multilingual traits yet.
   priority: 1000 # At the bottom
   accentColor: "#418b60"
   defaultExpanded: false


### PR DESCRIPTION
## About the PR
Increases max number of languages taken from 2 to 5
They currently cost 1 point each so it would cost 3 more points for 3 more languages.

**Changelog**
:cl:
- tweak: Increased max number of languages taken from 2 to 5
