### PR TITLE
Engineering Belt Loadout Fixes

### DIFF
--- a/Resources/Prototypes/_Floof/Catalog/Fills/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Fills/Fills/Items/belt.yml
@@ -58,17 +58,20 @@
   id: ClothingBeltUtilityAtmos
   parent: ClothingBeltUtility
   suffix: Engineering
+  name: utility belt tools atmos
   components:
-  - type: StorageFill
-    contents:
-      - id: CrowbarYellow
-      - id: Wrench
-      - id: Screwdriver
-      - id: Wirecutter
-      - id: Welder
-      - id: Multitool
-      - id: GasAnalyzer
-      - id: HolofanProjector
+  - type: EntityTableContainerFill
+    containers:
+      storagebase: !type:AllSelector
+        children:
+        - id: CrowbarYellow
+        - id: Wrench
+        - id: Screwdriver
+        - id: Wirecutter
+        - id: Welder
+        - id: Multitool
+        - id: GasAnalyzer
+        - id: HolofanProjector
 
 - type: entity
   id: ClothingHarnessSafetyAdvancedToolsEngineering

--- a/Resources/Prototypes/_Floof/Catalog/Fills/Fills/Items/belt.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Fills/Fills/Items/belt.yml
@@ -21,7 +21,7 @@
   id: ClothingBeltUtilityAdvancedToolsEngineering
   parent: ClothingBeltUtility
   suffix: Engineering
-  name: utility belt advanced tools
+  name: utility belt power tools
   components:
   - type: EntityTableContainerFill
     containers:
@@ -39,7 +39,7 @@
   id: ClothingBeltUtilityAdvancedToolsAtmos
   parent: ClothingBeltUtility
   suffix: Engineering
-  name: utility belt advanced tools atmos
+  name: utility belt power tools atmos
   components:
   - type: EntityTableContainerFill
     containers:
@@ -77,7 +77,7 @@
   id: ClothingHarnessSafetyAdvancedToolsEngineering
   parent: ClothingUncategorizedHarnessSafety
   suffix: Engineering
-  name: saftey harness advanced tools
+  name: saftey harness power tools
   components:
   - type: EntityTableContainerFill
     containers:
@@ -95,7 +95,7 @@
   id: ClothingHarnessSafetyAdvancedToolsAtmos
   parent: ClothingUncategorizedHarnessSafety
   suffix: Engineering
-  name: saftey harness advanced tools atmos
+  name: saftey harness power tools atmos
   components:
   - type: EntityTableContainerFill
     containers:

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/senior_clothing.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/senior_clothing.yml
@@ -23,6 +23,7 @@
   maxLimit: 1
   loadouts:
   - ClothingBeltUtility
+  - ClothingBeltUtilityAtmos
   - ClothingBeltUtilityAdvancedToolsEngineering
   - ClothingBeltUtilityAdvancedToolsAtmos
   - ClothingHarnessSafetyAdvancedToolsEngineering

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/belts.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/belts.yml
@@ -35,6 +35,11 @@
   equipment:
     belt: ClothingHarnessSafetyAdvancedToolsAtmos
 
+- type: loadout
+  id: ClothingBeltUtilityAtmos
+  equipment:
+    belt: ClothingBeltUtilityAtmos
+
 # timers for special options
 - type: loadoutEffectGroup
   id: FloofAdvancedEngineeringTimer


### PR DESCRIPTION
## About the PR
Small PR to fix a missing belt form engineering loadouts and rename the advanced tool belts.

## Why / Balance
Atmos players should be able to take a regular atmos tool belt if they so desire. The advanced tool belts were renamed to power tool belts (thank you for the suggestion through discord) since it better fits what the belt actually gives

## Technical details
Small yaml edits.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Engineers and Atmos can choose a standard atmos tool belt in loadouts.
- tweak: Renamed the engineering advanced tool belts power tool belts.
