### PR TITLE
Fix Senior Officer Access

### DIFF
--- a/Resources/Prototypes/_Floof/Roles/Jobs/Security/senior_officer.yml
+++ b/Resources/Prototypes/_Floof/Roles/Jobs/Security/senior_officer.yml
@@ -16,8 +16,10 @@
   - Security
   #- Brig # Delta V: Removed
   - Maintenance
-  - Service
+  #- Service # Floofstation - sec doesn't need service access
   - External
+  - GenpopEnter # Floofstation - give senior officer genpop access like other sec roles
+  - GenpopLeave  # Floofstation - give senior officer genpop access like other sec roles
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]


### PR DESCRIPTION
## About the PR
Seems I missed fixing senior officers access when I reenabled it.

## Why / Balance
Senior officer (and the rest of security) do not need service access, I missed senior officers having it when i reenabled them two months ago. My guess here is delta-v removed the access from the rest of sec a while ago but since they don't use senior roles they just didn't update that yaml. I also gave senior officer genpop access to fall in line with the rest of security incase we ever decide to use it.

## Technical details
Small yaml edits.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Senior Officer now has Genpop access like the rest of security.
- remove: Senior Officer no longer has service access to fall in line with the rest of security.