### PR TITLE
Access Wire to Various Objects

### DIFF
--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -10,6 +10,7 @@
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
   - !type:AiInteractWireAction
+  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   parent: Airlock
@@ -58,6 +59,7 @@
   - !type:DoorSafetyWireAction
   - !type:AiInteractWireAction
   dummyWires: 4
+  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   id: Vending
@@ -140,6 +142,7 @@
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
+  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   id: Defusable
@@ -176,12 +179,14 @@
   wires:
   - !type:PowerWireAction
   - !type:AiInteractWireAction
+  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   id: Computer
   dummyWires: 3
   wires:
   - !type:PowerWireAction
+  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   id: ComputerAi

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -51,7 +51,6 @@
 - type: wireLayout
   id: HighSec
   wires:
-  - !type:AccessWireAction # Euphoria
   - !type:PowerWireAction
     pulseTimeout: 10
   - !type:DoorBoltWireAction

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -51,6 +51,7 @@
 - type: wireLayout
   id: HighSec
   wires:
+  - !type:AccessWireAction # Euphoria
   - !type:PowerWireAction
     pulseTimeout: 10
   - !type:DoorBoltWireAction
@@ -59,7 +60,6 @@
   - !type:DoorSafetyWireAction
   - !type:AiInteractWireAction
   dummyWires: 4
-  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   id: Vending
@@ -134,6 +134,7 @@
   id: Docking
   dummyWires: 2
   wires:
+  - !type:AccessWireAction # Euphoria
   - !type:PowerWireAction
   - !type:PowerWireAction
     pulseTimeout: 15
@@ -142,7 +143,6 @@
   - !type:DoorBoltLightWireAction
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
-  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   id: Defusable

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -1,6 +1,7 @@
 - type: wireLayout
   id: Airlock
   wires:
+  - !type:AccessWireAction # Euphoria
   - !type:PowerWireAction
   - !type:PowerWireAction
     pulseTimeout: 15
@@ -10,7 +11,6 @@
   - !type:DoorTimingWireAction
   - !type:DoorSafetyWireAction
   - !type:AiInteractWireAction
-  - !type:AccessWireAction # Euphoria
 
 - type: wireLayout
   parent: Airlock

--- a/Resources/Prototypes/Wires/layouts.yml
+++ b/Resources/Prototypes/Wires/layouts.yml
@@ -185,13 +185,14 @@
   id: Computer
   dummyWires: 3
   wires:
-  - !type:PowerWireAction
   - !type:AccessWireAction # Euphoria
+  - !type:PowerWireAction
 
 - type: wireLayout
   id: ComputerAi
   dummyWires: 2
   wires:
+  - !type:AccessWireAction # Euphoria
   - !type:PowerWireAction
   - !type:AiInteractWireAction
 


### PR DESCRIPTION
## About the PR
This PR adds the Access Wire to
All Airlocks (Including High Security and Docks)
Anomaly Generator
Computers

## Why / Balance
Cutting the Access Wire makes the entity all access. For breaking and entering, currently one would disable the power to get in, thus leaving no doorlogs or emag the door or simply blow up the door or going through the wall. Doing this just gives the doorlogger more use. Engineering can also do this to set doors to all access in an emergency. It would return to what used to be normal on our old engine.

Adding the Access wire on the Anomaly Generator and Computers adds additional ways to sabotage or use something in an emergency without access.

![accesswire](https://github.com/user-attachments/assets/3154b13f-3fd3-45b8-b827-53cc521b64bf)


**Changelog**
:cl:
- add: Added Access Wire back to Airlocks, Computers etc

