### PR TITLE
Adds Katana Belt to Security Loadout

### DIFF
--- a/Resources/Prototypes/_Floof/Loadouts/Groups/security_weapons.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/security_weapons.yml
@@ -12,6 +12,7 @@
   - FloofWeaponLaserSvalinn
   - FloofPlasteelArmingSword
   - FloofWeaponEnergyGunMini
+  - FloofClothingBeltKatanaSheathFilled
 
 - type: loadoutGroup
   id: FloofSecurityFirearmAmmo

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/security_weapons.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/security_weapons.yml
@@ -47,6 +47,11 @@
     back:
     - PlasteelArmingSword
 
+- type: loadout
+  id: FloofClothingBeltKatanaSheathFilled
+  equipment: # Replaces Belt
+    belt: ClothingBeltKatanaSheathFilled
+
 # Special options (these will require timers see the timer section below)
 - type: loadout
   id: FloofWeaponEnergyGunMini


### PR DESCRIPTION
## About the PR
Adds Katana Belt to security firearm loadout (because arming sword is in there).

I considered buffing the katana to deal extra limb damage, but a little out of scope at the moment.

The future plan would be to making it so katanas can dismember easier by adding a body part damage modifier to it, adding an odachi which should be 2 handed, which swings slower and has slightly longer reach. and has a back slot sheath.

## Why / Balance
Adds a more thematic weapon choice for Onis and some Kitsune, but anyone in general can take it.
And Vox have been eating too good.

**Changelog**
:cl:
- add: Added Katana Belt to Security Loadout (firearms)
