### PR TITLE
Wizard - Frozen Orb

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -1,0 +1,37 @@
+- type: entity
+  name: frozen orb
+  parent: [BaseWeaponBattery, PonderingOrb]
+  id: WeaponFreezingOrbWizard
+  description: Freezing, man... Really ice cold.
+  suffix: WizardWeapon
+  components:
+  - type: Sprite
+    sprite: Objects/Fun/pondering_orb.rsi
+    layers:
+    - state: icon
+      shader: unshaded
+  - type: Gun
+    fireRate: 2
+    soundGunshot:
+      path: /Audio/Weapons/Guns/Gunshots/Magic/staff_animation.ogg
+  - type: BatteryAmmoProvider
+    proto: ProjectileIcicle
+    fireCost: 100
+  - type: BatteryWeaponFireModes
+    fireModes:
+    - proto: ProjectileIcicle
+      fireCost: 100
+    - proto: ColdLaser
+      fireCost: 50
+    - proto: BulletDisablerSmgSpread
+      fireCost: 50
+      pacifismAllowedMode: true
+  - type: Battery
+    maxCharge: 1000
+    startingCharge: 1000
+  - type: BatterySelfRecharger #Delta V - Self recharging not removed
+    autoRechargeRate: 200
+    autoRechargePauseTime: 10
+  - type: Tag
+    tags:
+    - WizardWand

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -3,7 +3,7 @@
   parent: [BaseWeaponBattery, PonderingOrb]
   id: WeaponFreezingOrbWizard
   description: Freezing, man... Really ice cold.
-  suffix: WizardWeapon
+  suffix: WizardWeapon, Admeme
   components:
   - type: Sprite
     sprite: Objects/Fun/pondering_orb.rsi

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -10,6 +10,9 @@
     layers:
     - state: icon
       shader: unshaded
+  - type: Item
+    size: Normal
+    sprite: Objects/Fun/pondering_orb.rsi
   - type: Gun
     fireRate: 2
     soundGunshot:


### PR DESCRIPTION
## About the PR
Adds an Orb weapon for Wizards that shoots icicles, cold beams and disabler spread shots.
Intended to be for Wizards and admemes. So it's not very well balanced.
Currently not in any fills or mapped, so someone will have to spawn one for the wizard.

**Changelog**
:cl:
- add: Added a toy for Wizards.
