### PR TITLE
Changed Sushi Slightly

### DIFF
--- a/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
+++ b/Resources/Prototypes/Recipes/Cooking/meal_recipes.yml
@@ -1316,7 +1316,7 @@
   time: 15
   group: Savory
   reagents:
-    TableSalt: 1
+    Soysauce: 1
   solids:
     FoodMeatFish: 2
 

--- a/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/sushi.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Consumable/Food/sushi.yml
@@ -1,5 +1,5 @@
 ﻿- type: entity
-  name: avocado sushi
+  name: avocado sushi roll
   parent: FoodMealBase
   id: FoodMealAvocadoSushi
   description: Where did the seaweed come from?
@@ -27,7 +27,7 @@
     slice: FoodMealAvocadoSushiSlice
 
 - type: entity
-  name: avocado sushi
+  name: avocado sushi roll slice
   parent: FoodInjectableBase
   id: FoodMealAvocadoSushiSlice
   description: Where did the seaweed come from?
@@ -52,7 +52,7 @@
           Quantity: .4
 
 - type: entity
-  name: carp sushi
+  name: carp sushi roll
   parent: FoodMealBase
   id: FoodMealCarpSushi
   description: Certainly worth the risk.
@@ -70,11 +70,11 @@
         maxVol: 45
         reagents:
         - ReagentId: Nutriment
-          Quantity: 20
+          Quantity: 25
         - ReagentId: Flavorol
           Quantity: 10
-        - ReagentId: CarpoToxin
-          Quantity: 5
+        #- ReagentId: CarpoToxin - Euphoria
+        #  Quantity: 5
         - ReagentId: CucumberWater
           Quantity: 2
   - type: SliceableFood
@@ -82,7 +82,7 @@
     slice: FoodMealCarpSushiSlice
 
 - type: entity
-  name: carp sushi
+  name: carp sushi roll slice
   parent: FoodInjectableBase
   id: FoodMealCarpSushiSlice
   description: Certainly worth the smaller risk.
@@ -100,10 +100,10 @@
         maxVol: 9
         reagents:
         - ReagentId: Nutriment
-          Quantity: 4
+          Quantity: 5
         - ReagentId: Flavorol
           Quantity: 2
-        - ReagentId: CarpoToxin
-          Quantity: 1
+        #- ReagentId: CarpoToxin - Euphoria
+        #  Quantity: 1
         - ReagentId: CucumberWater
           Quantity: .4


### PR DESCRIPTION
## About the PR
Fixes the name of sushi rolls, so they're rolls, and roll slices.
Removed the Carpotoxin from carp sushi rolls.
Changes Sashimi recipe to use soy sauce instead of salt.

## Why / Balance
So Sashimi which is also made of Carp doesn't have Carpotoxin, so this is more of a consistency thing. 
Also changing of the name of sushi to rolls so when someone makes a food update it's not just all "sushi", even tho it could be nigiri.

**Changelog**
:cl:
- tweak: Changed Carp Sushi Rolls to no longer have carpotoxin, the food health rating will be increasing.
- tweak: Changed Sashimi recipe to use soy sauce instead of salt.