### PR TITLE
Return of the small trait

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/skills.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/skills.ftl
@@ -6,6 +6,9 @@ trait-spearmaster-desc =
     You have an outstanding proficiency with spears, wielding them as an extension of your body.
     Your melee Piercing bonus is increased to 35%, but your melee Blunt bonus is reduced to 25%.
 
+trait-small-name = Small
+trait-small-desc = You are able to climb into spaces others would not normally be able to fit into, such as duffel bags.
+
 trait-swashbuckler-name = Swashbuckler
 trait-swashbuckler-desc =
     You are an expert in swordsmanship, wielding swords, knives, and other blades with unrivaled finesse.

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -16,6 +16,32 @@
     components:
     - type: FootstepVolumeModifier
       volume: -10 # same as EE, makes it 2x quieter
+
+- type: trait
+  id: Small
+  name: trait-small-name
+  description: trait-small-desc
+  category: Skills
+  cost: 2
+  conditions:
+  - !type:OneOfSpeciesCondition
+     invert: true    
+     species:
+      - Felinid # Felinids/Tajaran already have this feature by default.
+      - Tajaran # Floof - Tajaran Update b7660b9
+      - Rodentia # Floof - Rodentia
+      - Resomi # Floof - have this by default after porting Goob changes
+      - Kitsune # Floof - M3739 - #937 - Kitsune have this by default.
+  effects:
+    - !type:OverrideCompsEffect
+      components:
+        - type: PseudoItem
+          storedOffset: 0,17
+          shape:
+            - 0,0,1,4
+            - 0,2,3,4
+            - 4,0,5,4
+
 # =================================================== #
 
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -24,14 +24,9 @@
   category: Skills
   cost: 2
   conditions:
-  - !type:OneOfSpeciesCondition
-     invert: true    
-     species:
-      - Felinid # Felinids/Tajaran already have this feature by default.
-      - Tajaran # Floof - Tajaran Update b7660b9
-      - Rodentia # Floof - Rodentia
-      - Resomi # Floof - have this by default after porting Goob changes
-      - Kitsune # Floof - M3739 - #937 - Kitsune have this by default.
+  - !type:HasCompCondition
+    invert: true  
+    component: PseudoItem
   effects:
     - !type:OverrideCompsEffect
       components:


### PR DESCRIPTION
## About the PR
Adds a new trait called small that has the same features as previously on floof but rewritten to be adjusted with the new code.

## Why / Balance
People miss it for roleplay purposes . During discussion most people prefer if it didnt have a size limit hence why only species that already are baggable are limited from having this trait. I kept the previous cost of 2 points for consistency.

<img width="1429" height="315" alt="Screenshot 2026-04-08 044522" src="https://github.com/user-attachments/assets/3386222b-680f-4103-a438-c5aecfccf7ec" />
<img width="1434" height="368" alt="Screenshot 2026-04-08 044637" src="https://github.com/user-attachments/assets/703b455b-f2c4-4948-8ca9-727cd79ce0ef" />

<img width="854" height="574" alt="Screenshot 2026-04-08 044825" src="https://github.com/user-attachments/assets/7550fcff-5295-42d4-b7de-4315dfa1df44" />
<img width="426" height="520" alt="Screenshot 2026-04-08 044857" src="https://github.com/user-attachments/assets/a731a5ee-d012-4849-b6f7-22979329a563" />




<img width="621" height="365" alt="Screenshot 2026-04-08 044750" src="https://github.com/user-attachments/assets/b04c72ef-7f7c-4c4c-9b34-19a3e2e11e70" />
<img width="478" height="456" alt="Screenshot 2026-04-08 044759" src="https://github.com/user-attachments/assets/c35ace44-bb24-4f1b-89c0-17a844f190d5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Return of the small trait