### PR TITLE
More PDA options in PTech

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -35,6 +35,7 @@
     EncryptionKeySecurity: 1
 # End Delta-V subtractions
 # Begin Floofstation Additions
+    EncryptionKeyJustice: 2
     CargoAssistantPDA: 2
     CargoPDA: 2
     SalvagePDA: 2

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cart.yml
@@ -28,12 +28,32 @@
     MusicianPDA: 1
 # End Delta-V additions
 # Begin Delta-V subtractions
-  #  EncryptionKeyCargo: 2
-  #  EncryptionKeyEngineering: 2
-  #  EncryptionKeyMedical: 2
-  #  EncryptionKeyScience: 2
-  #  EncryptionKeySecurity: 1
+    EncryptionKeyCargo: 2
+    EncryptionKeyEngineering: 2
+    EncryptionKeyMedical: 2
+    EncryptionKeyScience: 2
+    EncryptionKeySecurity: 1
 # End Delta-V subtractions
+# Begin Floofstation Additions
+    CargoAssistantPDA: 2
+    CargoPDA: 2
+    SalvagePDA: 2
+    MailCarrierPDA: 2
+    TechnicalAssistantPDA: 2
+    EngineerPDA: 2
+    AtmosPDA: 2
+    MedicalInternPDA: 2
+    MedicalPDA: 2
+    ParamedicPDA: 2
+    ChemistryPDA: 2
+    ResearchAssistantPDA: 2
+    SciencePDA: 2
+    RoboticistPDA: 2
+    SecurityCadetPDA: 1
+    SecurityPDA: 1
+    LawyerPDA: 2
+    ProsecutorPDA: 2
+# End Floofstation Additions
   contrabandInventory:
     BalloonNT: 2
     LuxuryPen: 1

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -46,17 +46,17 @@
   # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
   # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
   # Begin DeltaV Removals - fuck all of this HoP is a service role
-  - Chemistry
-  - Engineering
-  - Research
-  - Detective
-  - Salvage
-  - Security # NoooOoOo!! My HoPcurity!1
+  #- Chemistry
+  #- Engineering
+  #- Research
+  #- Detective
+  #- Salvage
+  #- Security # NoooOoOo!! My HoPcurity!1
   #- Brig
-  - Lawyer # Lawyer is now part of the justice dept
-  - Cargo
-  - Atmospherics
-  - Medical
+  #- Lawyer # Lawyer is now part of the justice dept
+  #- Cargo
+  #- Atmospherics
+  #- Medical
   # End DeltaV Removals
   # Begin DeltaV Additions - fine-grained service accesses
   - Boxer
@@ -66,21 +66,6 @@
   - Reporter
   - Zookeeper
   # End DeltaV Additions
-  # Begin Floofstation Additions
-  - Prosecutor
-  - Orders
-  - Mail
-  - Corpsman
-  - Justice
-  - Funding
-  - Clerk
-  - Surgery
-  - Psychologist
-  - Paramedic
-  - Robotics
-  - Library
-  - Mantis
-  # End Floofstation Additions
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -38,7 +38,7 @@
   - Janitor
   - Theatre
   - Kitchen
-  #- Chapel # DeltaV - Chapel is in Epistemics
+  - Chapel # DeltaV - Chapel is in Epistemics
   - Hydroponics
   - External
   - Cryogenics
@@ -46,17 +46,17 @@
   # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
   # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
   # Begin DeltaV Removals - fuck all of this HoP is a service role
-  #- Chemistry
-  #- Engineering
-  #- Research
-  #- Detective
-  #- Salvage
-  #- Security # NoooOoOo!! My HoPcurity!1
+  - Chemistry
+  - Engineering
+  - Research
+  - Detective
+  - Salvage
+  - Security # NoooOoOo!! My HoPcurity!1
   #- Brig
-  #- Lawyer # Lawyer is now part of the justice dept
-  #- Cargo
-  #- Atmospherics
-  #- Medical
+  - Lawyer # Lawyer is now part of the justice dept
+  - Cargo
+  - Atmospherics
+  - Medical
   # End DeltaV Removals
   # Begin DeltaV Additions - fine-grained service accesses
   - Boxer
@@ -66,6 +66,22 @@
   - Reporter
   - Zookeeper
   # End DeltaV Additions
+  # Begin Floofstation Additions
+  - Prosecutor
+  - Orders
+  - Mail
+  - Corpsman
+  - Armory
+  - Justice
+  - Funding
+  - Clerk
+  - Surgery
+  - Psychologist
+  - Paramedic
+  - Robotics
+  - Library
+  - Mantis
+  # End Floofstation Additions
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -38,7 +38,7 @@
   - Janitor
   - Theatre
   - Kitchen
-  - Chapel # DeltaV - Chapel is in Epistemics
+  #- Chapel # DeltaV - Chapel is in Epistemics
   - Hydroponics
   - External
   - Cryogenics

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -71,7 +71,6 @@
   - Orders
   - Mail
   - Corpsman
-  - Armory
   - Justice
   - Funding
   - Clerk


### PR DESCRIPTION
## About the PR
Adds more PDA options into the PTech allowing for HoP to hire for more departments giving them back responsibilities from before the rebase.


<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

## Why / Balance
https://discord.com/channels/1255902263667331193/1487600994333229056/1487600994333229056
The issue at play is that HoP cannot hire or fire for most departments currently, which is different than before the rebase. 

There is currently no SoP for HoP in the guidebook, and the command section seems out of date anyway, if issues come about we should implement a SoP and/or down grade some of the accesses.

This option was discussed in the US dev meeting, and this was decided to be a reasonable change to accomplish close to the same thing as budget AA.
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="554" height="1200" alt="image" src="https://github.com/user-attachments/assets/f34b3ec7-8d62-4759-a42d-a4479de875c2" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: PTech inventory expanded for HoP
