### PR TITLE
Update Required Time For HoP

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -20,9 +20,12 @@
     #  department: Security
     #  time: 2.5h
     # Floofstation changes end
+    #- !type:DepartmentTimeRequirement
+    #  department: Command
+    #  time: 5h # Floofstation changed from 2.5h to 5h
     - !type:DepartmentTimeRequirement
-      department: Command
-      time: 5h # Floofstation changed from 2.5h to 5h
+      department: Service
+      time: 10h # More in line with what Floof was. 
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -26,6 +26,12 @@
     - !type:DepartmentTimeRequirement
       department: Civilian
       time: 10h # More in line with what Floof was. 
+    - !type:RoleTimeRequirement
+      role: JobChef
+      time: 2h
+    - !type:RoleTimeRequirement
+      role: JobBotanist
+      time: 2h
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear
   icon: "JobIconHeadOfPersonnel"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -24,7 +24,7 @@
     #  department: Command
     #  time: 5h # Floofstation changed from 2.5h to 5h
     - !type:DepartmentTimeRequirement
-      department: Service
+      department: Civilian
       time: 10h # More in line with what Floof was. 
   weight: 10 # DeltaV - Changed HoP weight from 20 to 10 due to them not being more important than other Heads
   startingGear: HoPGear


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
The time requirement for HoP was 5 hours of Command, nothing else. 
It is now 10 hours of Service, with 2 hours in Chef, and 2 hours in Botany. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Requiring hours in Command in order to get into a Command role makes it kind of impossible for a Service-main to become the Head of Service. No other Heads have this requirement. 
However, other Heads do have requirements for hours within their departments, and some specific jobs. 
As well, the requirement for HoP back in Floof was just hours in Service. 

This change makes the HoP requirements more aligned with the other Heads, and what it used to be on Floof. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just a change to one yml file.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
(Without any time)
<img width="1440" height="667" alt="image" src="https://github.com/user-attachments/assets/5b042ba4-48e6-4761-946c-4d4b165a6195" />

(With required time)
<img width="1161" height="660" alt="image" src="https://github.com/user-attachments/assets/20cc06f3-fce3-463f-a770-0f5e47f721fc" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Adjusted HoP requirements to not require Command time, and instead require Service time (overall, and Chef and Botany specifically too).
