### PR TITLE
added upgrade kits to protolathe

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -244,6 +244,7 @@
     - Surgery # Shitmed change
     # Floofstation section - add your recipes here
     - AdvancedTranslation
+    - UpgradeKits_Goob
     # Floofstation section end
   - type: EmagLatheRecipes
     emagDynamicPacks:


### PR DESCRIPTION
## About the PR
Added hyperconvection lathe upgrade kits (and the automation upgrade kits) to protolathe.

## Why / Balance
See Discord discussion: "Add (not move!) upgrade kits to the circuit or exosuit fabricator"
Giving Epi more opportunities to help upgrade the station is good.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

Please test this!
I have a lead on setting up a dev environment on Steam Deck, but it's not set up yet.

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [x] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: Added hyperconvection lathe upgrade kits (and the automation upgrade kits) to protolathe.
