### PR TITLE
Shadekin fixes

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -29,6 +29,7 @@
     - Kitsune
     - Avali
     # End DeltaV additions
+    - Shadowkin #floof - specific survival box seems unneeeded
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox
@@ -97,6 +98,7 @@
     - Kitsune
     - Avali
     # End DeltaV additions
+    - Shadowkin #floof - specific survival box seems unneeeded
 
 - type: loadoutEffectGroup
   id: OxygenBreatherMimeMoth

--- a/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
@@ -94,9 +94,6 @@
   - type: Metabolizer
     maxReagents: 1
     metabolizerTypes: [Shadowkin]
-    groups:
-    - id: Alcohol
-      rateModifier: 0.1
 
 - type: entity
   id: OrganShadowkinKidneys

--- a/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
@@ -94,6 +94,9 @@
   - type: Metabolizer
     maxReagents: 1
     metabolizerTypes: [Shadowkin]
+    #groups:
+    #- id: Alcohol
+    #  rateModifier: 0.1 # Floof Removal - lowest value is theoretically 0.2
 
 - type: entity
   id: OrganShadowkinKidneys

--- a/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
@@ -94,9 +94,6 @@
   - type: Metabolizer
     maxReagents: 1
     metabolizerTypes: [Shadowkin]
-    #groups:
-    #- id: Alcohol
-    #  rateModifier: 0.1 # Floof Removal - lowest value is theoretically 0.2
 
 - type: entity
   id: OrganShadowkinKidneys


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Shadekin currently can't get drunk or process alcohol and will start throwing up constantly if they get too much alcohol. This fixes that by making it so their liver processes alcohol at a normal rate.
edit: found another simple fix for shadekin, they now spawn with survival kits

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

alcohol immunity + throwing up is just not realistic.
shadekin didn't spawn with survival kits, they should for parity.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
There was a modifier being applied that put the ethanol change below the smallest increment that the system could register and thus no change was occurring. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>
Drunk effect restored
<img width="796" height="311" alt="image" src="https://github.com/user-attachments/assets/06b0c620-81d0-4628-9232-0a4731c261b7" />

<img width="446" height="1015" alt="image" src="https://github.com/user-attachments/assets/e66b059c-ec63-4d2a-a70a-7f999fb758f1" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Shadekin process ethanol correctly
- fix: Shadekin now spawn with survival kits
