### PR TITLE
Glimmer Event: Database Corruption

### DIFF
--- a/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
+++ b/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
@@ -1,0 +1,16 @@
+using Content.Server.StationEvents.Events;
+using Content.Server._Floof.StationEvents.Events;
+using Robust.Shared.Audio;
+
+namespace Content.Server._Floof.StationEvents.Components;
+
+[RegisterComponent, Access(typeof(GlimmerResearchStealerRule))]
+public sealed partial class GlimmerResearchStealerRuleComponent : Component
+{
+    [DataField]
+    public int MinToSteal = 1;
+    [DataField]
+    public int MaxToSteal = 8;
+    [DataField]
+    public SoundSpecifier GlimmerStealSound = new SoundPathSpecifier("/Audio/_DV/CosmicCult/ability_siphon.ogg");
+}

--- a/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
+++ b/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
@@ -13,4 +13,7 @@ public sealed partial class GlimmerResearchStealerRuleComponent : Component
     public int MaxToSteal = 8;
     [DataField]
     public SoundSpecifier GlimmerStealSound = new SoundPathSpecifier("/Audio/_DV/CosmicCult/ability_siphon.ogg");
+    
+   [DataField]
+   public ProtoId<RadioChannelPrototype> AnnouncementChannel = "Science"; 
 }

--- a/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
+++ b/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
@@ -1,6 +1,7 @@
-using Content.Server.StationEvents.Events;
 using Content.Server._Floof.StationEvents.Events;
+using Content.Shared.Radio;
 using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
 
 namespace Content.Server._Floof.StationEvents.Components;
 
@@ -13,7 +14,6 @@ public sealed partial class GlimmerResearchStealerRuleComponent : Component
     public int MaxToSteal = 8;
     [DataField]
     public SoundSpecifier GlimmerStealSound = new SoundPathSpecifier("/Audio/_DV/CosmicCult/ability_siphon.ogg");
-    
-   [DataField]
-   public ProtoId<RadioChannelPrototype> AnnouncementChannel = "Science"; 
+    [DataField]
+    public ProtoId<RadioChannelPrototype> AnnouncementChannel = "Science";
 }

--- a/Content.Server/_Floof/StationEvents/Events/GlimmerResearchStealerRule.cs
+++ b/Content.Server/_Floof/StationEvents/Events/GlimmerResearchStealerRule.cs
@@ -1,0 +1,70 @@
+using Content.Server._Floof.StationEvents.Components;
+using Content.Server.Research.Systems;
+using Content.Server.StationEvents.Events;
+using Content.Shared.GameTicking.Components;
+using Content.Shared.Research.Components;
+using Content.Shared.Research.Systems;
+using Robust.Shared.Random;
+using Content.Shared.Popups;
+using Robust.Shared.Audio.Systems;
+using Content.Server.Radio.EntitySystems;
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Floof.StationEvents.Events;
+
+internal sealed class GlimmerResearchStealerRule : StationEventSystem<GlimmerResearchStealerRuleComponent>
+{
+    [Dependency] private readonly SharedResearchSystem _research = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly RadioSystem _radioSystem = default!;
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    protected override void Started(EntityUid uid, GlimmerResearchStealerRuleComponent comp, GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        //Populate list with all servers that have technology unlocked
+        List<EntityUid> serverList = new();
+        var query = EntityQueryEnumerator<ResearchServerComponent, TechnologyDatabaseComponent>();
+        while (query.MoveNext(out var server, out _, out var servercomp))
+        {
+            if (servercomp.UnlockedTechnologies.Count != 0)
+                serverList.Add(server);
+        }
+
+        //If no servers have technology unlocked, end the event
+        if (serverList.Count == 0)
+            return;
+
+        //Declare the server with the most technology the target of the event
+        var target = serverList[0];
+        foreach (var serv in serverList)
+        {
+            if (EnsureComp<TechnologyDatabaseComponent>(target).UnlockedTechnologies.Count < EnsureComp<TechnologyDatabaseComponent>(serv).UnlockedTechnologies.Count)
+                target = serv;
+        }
+
+        //Remove a random amount of technologies from the target server
+        var ev = new ResearchStolenEvent(uid, target, new());
+        var database = EnsureComp<TechnologyDatabaseComponent>(target);
+        var count = _random.Next(comp.MinToSteal, comp.MaxToSteal + 1);
+        for (var i = 0; i < count; i++)
+        {
+            if (database.UnlockedTechnologies.Count == 0)
+                break;
+
+            var toRemove = _random.Pick(database.UnlockedTechnologies);
+            if (_research.TryRemoveTechnology((target, database), toRemove))
+                ev.Techs.Add(toRemove);
+        }
+
+        //Play sound and produce effect when event occurs
+        _popup.PopupEntity(Loc.GetString("glimmer-tech-steal", ("count", count)), target);
+        _audio.PlayPvs(comp.GlimmerStealSound, target);
+
+        //Announce the event on the epistemics radio channel
+        var message = Loc.GetString("glimmer-tech-steal-message");
+        var channel = _prototypeManager.Index<RadioChannelPrototype>("Science");
+        _radioSystem.SendRadioMessage(target, message, channel, target, escapeMarkup: false);
+    }
+}

--- a/Content.Server/_Floof/StationEvents/Events/GlimmerResearchStealerRule.cs
+++ b/Content.Server/_Floof/StationEvents/Events/GlimmerResearchStealerRule.cs
@@ -38,9 +38,13 @@ internal sealed class GlimmerResearchStealerRule : StationEventSystem<GlimmerRes
 
         //Declare the server with the most technology the target of the event
         var target = serverList[0];
+        int targetCount;
+        int servCount;
         foreach (var serv in serverList)
         {
-            if (EnsureComp<TechnologyDatabaseComponent>(target).UnlockedTechnologies.Count < EnsureComp<TechnologyDatabaseComponent>(serv).UnlockedTechnologies.Count)
+            targetCount = EnsureComp<TechnologyDatabaseComponent>(target).UnlockedTechnologies.Count;
+            servCount = EnsureComp<TechnologyDatabaseComponent>(serv).UnlockedTechnologies.Count;
+            if (targetCount < servCount)
                 target = serv;
         }
 

--- a/Content.Server/_Floof/StationEvents/Events/GlimmerResearchStealerRule.cs
+++ b/Content.Server/_Floof/StationEvents/Events/GlimmerResearchStealerRule.cs
@@ -64,7 +64,7 @@ internal sealed class GlimmerResearchStealerRule : StationEventSystem<GlimmerRes
 
         //Announce the event on the epistemics radio channel
         var message = Loc.GetString("glimmer-tech-steal-message");
-        var channel = _prototypeManager.Index<RadioChannelPrototype>("Science");
+        var channel = _prototypeManager.Index<RadioChannelPrototype>(comp.AnnouncementChannel);
         _radioSystem.SendRadioMessage(target, message, channel, target, escapeMarkup: false);
     }
 }

--- a/Resources/Locale/en-US/_Floof/station-events/glimmer/research-stealer-event.ftl
+++ b/Resources/Locale/en-US/_Floof/station-events/glimmer/research-stealer-event.ftl
@@ -1,0 +1,2 @@
+glimmer-tech-steal = The total technology count display ticks down by {$count}!
+glimmer-tech-steal-message = Glimmer corruption detected on the server. Removing corrupted files.

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -19,6 +19,7 @@
     - id: MinorMassMindSwap # Delta V
     - id: GlimmerFoxfireSpawn
     - id: GlimmerRestyle
+    - id: GlimmerResearchStealer # Euphoria
 
 - type: entity
   parent: BaseGameRule
@@ -232,3 +233,14 @@
     minimumGlimmer: 300
     maximumGlimmer: 700
   - type: GlimmerRestyleRule
+
+#Euphoria
+- type: entity
+  parent: BaseGlimmerEvent
+  id: GlimmerResearchStealer
+  components:
+  - type: GlimmerEvent
+    minimumGlimmer: 600
+    glimmerBurnLower: 25
+    glimmerBurnUpper: 75
+  - type: GlimmerResearchStealerRule


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Adds a new high glimmer event that corrupts data in the research server. Every time the event triggers it will remove between 1 and 8 (the max a ninja can grab) technologies randomly from the most advanced research server present.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This event adds something for epistemics to fear for as long as glimmer is a bit above the code white range, discouraging them from running up glimmer and letting the rest of the station deal with the consequences.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Adds the new event rule and component for the Glimmer Event Scheduler to roll.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="659" height="549" alt="image" src="https://github.com/user-attachments/assets/17817a4d-590f-441e-b439-a5065050556a" />
<img width="347" height="169" alt="image" src="https://github.com/user-attachments/assets/4139a396-5a1d-4492-9cd6-5b8a82d44240" />
<img width="658" height="537" alt="image" src="https://github.com/user-attachments/assets/0c8a3aeb-8dd6-46dd-987b-b9dcdabc5c9a" />
<img width="549" height="103" alt="image" src="https://github.com/user-attachments/assets/6f41dd51-7f09-4c25-aabf-ed0d7eb0f711" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- add: The research server can potentially start corrupting at high glimmer levels.