### PR TITLE
Emotional Support Collar Fix

### DIFF
--- a/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
+++ b/Content.Server/StationRecords/Systems/StationRecordsSystem.cs
@@ -92,7 +92,7 @@ public sealed class StationRecordsSystem : SharedStationRecordsSystem
             || !_prototypeManager.HasIndex<JobPrototype>(jobId))
             return;
 
-        if (!_inventory.TryGetSlotEntity(player, "id", out var idUid))
+        if (!_inventory.TryGetSlotEntity(player, "id", out var idUid) && (!_inventory.TryGetSlotEntity(player, "neck", out idUid))) // Floofstation Pet IDs to check neck slot
             return;
 
         TryComp<FingerprintComponent>(player, out var fingerprintComponent);

--- a/Content.Server/_CD/Records/CharacterRecordsSystem.cs
+++ b/Content.Server/_CD/Records/CharacterRecordsSystem.cs
@@ -89,7 +89,7 @@ public sealed class CharacterRecordsSystem : EntitySystem
 
     private StationRecordKey? FindStationRecordsKey(EntityUid uid)
     {
-        if (!_inventory.TryGetSlotEntity(uid, "id", out var idUid))
+        if (!_inventory.TryGetSlotEntity(uid, "id", out var idUid) && !_inventory.TryGetSlotEntity(uid, "neck", out idUid)) // Floofstation Pet IDs to check neck slot
             return null;
 
         var keyStorageEntity = idUid;

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
@@ -10,6 +10,7 @@
     id: EmotionalSupportIdCard
   - type: Sprite
     sprite: _Floof/Clothing/Neck/Collars/collar_black.rsi
+    scale: 1.0, 1.0 # Resize to standard size
     layers:
     - map: [ "enum.PdaVisualLayers.Base" ]
       state: icon


### PR DESCRIPTION
## About the PR
Allows players that use the emotional support collar pda to show up on manifest and station records.

## Why / Balance
It was a bug that they couldn't

## Technical details
Had to add a line to two more hard coded checks.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Those that use Emotional Support Collar PDAs will now properly show up on the crew manifest and station records.
