### PR TITLE
Herbals fix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cigarette.yml
@@ -79,6 +79,8 @@
       smokable:
         maxVol: 45
         reagents:
+          - ReagentId: Saline # Euphoria - Added Saline back in from old codebase
+            Quantity: 15
           - ReagentId: Omnizine # Euphoria - Down from 30 to 15
             Quantity: 15
           - ReagentId: Dylovene

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -186,7 +186,7 @@
   id: CigPackSyndicate
   parent: CigPackBase
   name: Interdyne herbals packet
-  description: Premium medicinal cigarettes from the Interdyne Corporation. Nicotine free!
+  description: Premium medicinal cigarettes from the Interdyne Corporation. Smoke healthier, smoke smarter, smoke Interdynes.
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/syndicate.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -183,8 +183,8 @@
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/black.rsi
 
 - type: entity
-  id: CigPackSyndicate # Euphoria - Removed Contraband Tag
-  parent: CigPackBase
+  id: CigPackSyndicate
+  parent: CigPackBase # Euphoria - Removed Contraband Tag
   name: Interdyne herbals packet
   description: Premium medicinal cigarettes from the Interdyne Corporation. Smoke healthier, smoke smarter, smoke Interdynes. # Euphoria - Changed to use a less syndicate related description
   components:

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -184,9 +184,9 @@
 
 - type: entity
   id: CigPackSyndicate
-  parent: [CigPackBase, BaseSyndicateContraband]
+  parent: CigPackBase
   name: Interdyne herbals packet
-  description: Elite cigarettes for elite syndicate agents. Infused with medicine for when you need to do more than calm your nerves.
+  description: Premium medicinal cigarettes from the Interdyne Corporation. Nicotine free!
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/syndicate.rsi

--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/packs.yml
@@ -183,10 +183,10 @@
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/black.rsi
 
 - type: entity
-  id: CigPackSyndicate
+  id: CigPackSyndicate # Euphoria - Removed Contraband Tag
   parent: CigPackBase
   name: Interdyne herbals packet
-  description: Premium medicinal cigarettes from the Interdyne Corporation. Smoke healthier, smoke smarter, smoke Interdynes.
+  description: Premium medicinal cigarettes from the Interdyne Corporation. Smoke healthier, smoke smarter, smoke Interdynes. # Euphoria - Changed to use a less syndicate related description
   components:
   - type: Sprite
     sprite: Objects/Consumable/Smokeables/Cigarettes/Packs/syndicate.rsi


### PR DESCRIPTION
## About the PR
Fixes Herbals -
Removes the Contraband Tag.
Changed the description to mostly the EE one, but removed Terra-gov because we don't use that. Added a corpo slogan to it instead.
Fixed the recipe to include Saline (Formerly Iron in EE, then Saline in old code base, due to iron not working on copper blood based creatures)

**Changelog**
:cl:
- tweak: Tweaked Interdyne Herbals description and contents.

