### PR TITLE
Added Potential Psionic to Silicon Base, and Offer Item to IPC and Arachne base.

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -115,6 +115,8 @@
     canDisarm: true
   - type: SnoutHelmet # DeltaV - IPC Snouts
     replacementRace: vulpkanin
+  - type: Hands # Floofstation
+  - type: OfferItem # Floofstation - Fixes Offer for IPCs
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/ipc.yml
@@ -115,7 +115,6 @@
     canDisarm: true
   - type: SnoutHelmet # DeltaV - IPC Snouts
     replacementRace: vulpkanin
-  - type: Hands # Floofstation
   - type: OfferItem # Floofstation - Fixes Offer for IPCs
 
 - type: entity

--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
@@ -309,8 +309,8 @@
         # - ForcedSleep
         - TemporaryBlindness
         - Pacified
-        # - PsionicsDisabled
-        # - PsionicallyInsulated
+        - PsionicsDisabled
+        - PsionicallyInsulated
         - Flashed # Goobstation
     - type: Blindable
     - type: FireVisuals
@@ -350,3 +350,4 @@
       naturalLanguage: Binary
     - type: FootPrints # Floofstation - delta-v removed these, we're keeping them
     - type: RMCSetPose # DeltaV - RMC pose port
+    - type: PotentialPsionic # Euphoria - ALL species can be psionic

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/taur.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/taur.yml
@@ -231,6 +231,7 @@
   - type: CosmicCenserTarget # DeltaV - Cosmic Cult
   - type: Carriable # DeltaV
   - type: GrappleTarget # DeltaV - Allow targets to be grappled
+  - type: OfferItem # Floofstation - Fixes Offer for Arachne too
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
So someone was wondering why the Oracle wasn't talking to their Psionic IPC character, and as it turns out, even if the trait that gives an IPC psionics makes them a Psionic, it doesn't give them PotentialPsionic which allows the oracle to talk to them.

This change allows them to talk to the Oracle. Also technically, they were immune to the effects of tinfoil hats and most likely could cast wearing them.

This PR also fixes IPCs and Arachne missing the Offeritem Comp.

**Changelog**
:cl:
- fix: Fixed IPCs missing a component that allowed them to talk to the Oracle, despite being psionic.
- fix: Fixed IPCs and Arachne not being able to offer things.