### PR TITLE
[HOTFIX] Prevent admins from disabling events or autoevac when using "Mapping"

### DIFF
--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server.Administration;
 using Content.Server.GameTicking;
 using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
 using Robust.Shared.Console;
 using Robust.Shared.ContentPack;
 using Robust.Shared.EntitySerialization;
@@ -19,6 +20,7 @@ namespace Content.Server.Mapping
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly MappingSystem _mappingSystem = default!;
         [Dependency] private readonly MapLoaderSystem _mapLoader = default!;
+        [Dependency] private readonly ISharedAdminManager _admin = default!; // Frontier
 
         public override string Command => "mapping";
 
@@ -151,9 +153,14 @@ namespace Content.Server.Mapping
                 shell.ExecuteCommand("aghost");
             }
 
-            // don't interrupt mapping with events or auto-shuttle
-            shell.ExecuteCommand("changecvar events.enabled false");
-            shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
+            // Frontier: check if user is the host before disabling events
+            if (_admin.HasAdminFlag(player, AdminFlags.Host))
+            {
+                // don't interrupt mapping with events or auto-shuttle
+                shell.ExecuteCommand("changecvar events.enabled false");
+                shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
+            }
+            // End Frontier: check if user is the host before disabling events
 
             if (grid != null)
                 _mappingSystem.ToggleAutosave(grid.Value.Owner, toLoad ?? "NEWGRID");

--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -1,8 +1,7 @@
 using System.Linq;
-using Content.Server.Administration; // Frontier
+using Content.Server.Administration;
 using Content.Server.GameTicking;
 using Content.Shared.Administration;
-using Content.Shared.Administration.Managers;
 using Robust.Shared.Console;
 using Robust.Shared.ContentPack;
 using Robust.Shared.EntitySerialization;
@@ -20,7 +19,6 @@ namespace Content.Server.Mapping
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly MappingSystem _mappingSystem = default!;
         [Dependency] private readonly MapLoaderSystem _mapLoader = default!;
-        [Dependency] private readonly ISharedAdminManager _admin = default!; // Frontier
 
         public override string Command => "mapping";
 
@@ -153,14 +151,9 @@ namespace Content.Server.Mapping
                 shell.ExecuteCommand("aghost");
             }
 
-            // Frontier: check if user is the host before disabling events
-            if (_admin.HasAdminFlag(player, AdminFlags.Host))
-            {
-                // don't interrupt mapping with events or auto-shuttle
-                shell.ExecuteCommand("changecvar events.enabled false");
-                shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
-            }
-            // End Frontier: check if user is the host before disabling events
+            // don't interrupt mapping with events or auto-shuttle
+            shell.ExecuteCommand("changecvar events.enabled false");
+            shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
 
             if (grid != null)
                 _mappingSystem.ToggleAutosave(grid.Value.Owner, toLoad ?? "NEWGRID");

--- a/Content.Server/Mapping/MappingCommand.cs
+++ b/Content.Server/Mapping/MappingCommand.cs
@@ -1,7 +1,8 @@
 using System.Linq;
-using Content.Server.Administration;
+using Content.Server.Administration; // Frontier
 using Content.Server.GameTicking;
 using Content.Shared.Administration;
+using Content.Shared.Administration.Managers;
 using Robust.Shared.Console;
 using Robust.Shared.ContentPack;
 using Robust.Shared.EntitySerialization;
@@ -19,6 +20,7 @@ namespace Content.Server.Mapping
         [Dependency] private readonly SharedMapSystem _mapSystem = default!;
         [Dependency] private readonly MappingSystem _mappingSystem = default!;
         [Dependency] private readonly MapLoaderSystem _mapLoader = default!;
+        [Dependency] private readonly ISharedAdminManager _admin = default!; // Frontier
 
         public override string Command => "mapping";
 
@@ -151,9 +153,14 @@ namespace Content.Server.Mapping
                 shell.ExecuteCommand("aghost");
             }
 
-            // don't interrupt mapping with events or auto-shuttle
-            shell.ExecuteCommand("changecvar events.enabled false");
-            shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
+            // Frontier: check if user is the host before disabling events
+            if (_admin.HasAdminFlag(player, AdminFlags.Host))
+            {
+                // don't interrupt mapping with events or auto-shuttle
+                shell.ExecuteCommand("changecvar events.enabled false");
+                shell.ExecuteCommand("changecvar shuttle.auto_call_time 0");
+            }
+            // End Frontier: check if user is the host before disabling events
 
             if (grid != null)
                 _mappingSystem.ToggleAutosave(grid.Value.Owner, toLoad ?? "NEWGRID");


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Title, taken from [frontier](https://github.com/new-frontiers-14/frontier-station-14/pull/3496)

## Why / Balance
Event handler has been randomly broken for a while. This is probably why.

## Technical details
Check if the person is the host, if they are not, don't disable event handler or auto evac.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Mapping for non-hosts no longer disables events or auto evac 
