### PR TITLE
Locker Circuit update

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/heads.yml
@@ -62,7 +62,6 @@
       storagebase: !type:AllSelector
         children:
         - id: IDComputerCircuitboard
-        #- id: FundingAllocationComputerCircuitboard # DeltaV - HoP doesn't have funding access
         - id: FundingAllocationComputerCircuitboard
         - id: ServiceTechFabCircuitboard # DeltaV
 
@@ -126,6 +125,7 @@
         - id: CommsComputerCircuitboard
         - id: StationRecordsComputerCircuitboard
         - id: IDComputerCircuitboard # DeltaV
+        - id: FundingAllocationComputerCircuitboard # Euphoria
 
 - type: entity
   name: circuit tote [CMO]
@@ -142,6 +142,8 @@
         - id: IDComputerCircuitboard # DeltaV
         - id: MedicalBiofabMachineBoard # DeltaV
         - id: AutoclaveMachineCircuitboard # DeltaV
+        - id: MedicalRecordsComputerCircuitboard # Euphoria
+        - id: CrewMonitoringComputerCircuitboard # Euphoria
 
 - type: entity
   name: circuit tote [MG] # DeltaV - Changed to MG
@@ -154,7 +156,7 @@
       storagebase: !type:AllSelector
         children:
         - id: CircuitImprinterMachineCircuitboard
-        #- id: ProtolatheMachineCircuitboard # DeltaV - Replaced with Epi fab
+        - id: ProtolatheMachineCircuitboard # DeltaV - Replaced with Epi fab # Euphoria - Undone
         - id: ResearchComputerCircuitboard
         - id: CargoRequestScienceComputerCircuitboard
         - id: RoboticsConsoleCircuitboard


### PR DESCRIPTION
## About the PR
This PR changes
Adds Medical Records Computer Circuit and Spare Crew Monitor Computer Circuit to CMO bag
Re-enables Protolathe Circuit in MG bag (DV disabled it for departmental lathes but we re-enabled it but it was forgotten here)
Adds a Funding Allocation Computer Circuit to the Captain bag (incase it wasn't mapped) HoP does already have one but an extra just in case.
Removes a duplicate line. (I don't know what DV was cooking here)

**Changelog**
:cl:
- add: Added Medical Records Circuit to CMO locker, and some others to other heads.
