### PR TITLE
Hostile Humanoids: RadioGuard Fix & Salvager Mobs

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/salvage.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/salvage.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: Syndicate Guard
-  parent: BaseMobHuman
+  parent: MobHumanNPC
   id: MobRadioGuard
   description: "Mindwiped and hypno-indoctrinated into perfect loyalty by the Syndicate. They will throw their life away to defend their objective."
   components:
@@ -11,23 +11,23 @@
       thresholds:
         0: Alive
         100: Dead #Tweak for "Acidify on Crit"
-    - type: MindContainer
-      showExamineInfo: False
+    # - type: MindContainer | Euphoria mob reparent
+    #   showExamineInfo: False
     - type: Loadout
       prototypes:
         - RadioGuardGear
-    - type: InputMover
-    - type: MobMover
-    - type: HTN
-      rootTask:
-        task: SimpleHumanoidHostileCompound
-    - type: Respirator #Mobs can't turn on internals by themselves, so we have to simulate them having it on
-      damage:
-        types:
-          Asphyxiation: 0
-      damageRecovery:
-        types:
-          Asphyxiation: -1.0
+    # - type: InputMover | Euphoria mob reparent
+    # - type: MobMover
+    # - type: HTN
+    #   rootTask:
+    #     task: SimpleHumanoidHostileCompound
+    # - type: Respirator #Mobs can't turn on internals by themselves, so we have to simulate them having it on
+    #   damage:
+    #     types:
+    #       Asphyxiation: 0
+    #   damageRecovery:
+    #     types:
+    #       Asphyxiation: -1.0
     - type: Gun #Mobs currently cannot bolt a gun, so we have to simulate them firing it
       fireRate: 2
       soundGunshot: /Audio/Weapons/Guns/Gunshots/pistol.ogg
@@ -35,7 +35,7 @@
       selectedMode: SemiAuto
       availableModes:
         - SemiAuto
-    - type: CombatMode
+    # - type: CombatMode | Euphoria mob reparent
     - type: BasicEntityAmmoProvider
       proto: CartridgePistol
       capacity: 10
@@ -49,52 +49,52 @@
       - DeathAcidifierImplant
     - type: Sprite
       layers:
-      - map: [ "enum.HumanoidVisualLayers.Chest" ]
-      - map: [ "enum.HumanoidVisualLayers.Head" ]
-      - map: [ "enum.HumanoidVisualLayers.Snout" ]
-      - map: [ "enum.HumanoidVisualLayers.Eyes" ]
-      - map: [ "enum.HumanoidVisualLayers.RArm" ]
-      - map: [ "enum.HumanoidVisualLayers.LArm" ]
-      - map: [ "enum.HumanoidVisualLayers.RLeg" ]
-      - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-      - shader: StencilClear
-        sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
-        # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.
-        # sprite refactor when
-        state: l_leg
-      - shader: StencilMask
-        map: ["enum.HumanoidVisualLayers.StencilMask"]
-        sprite: Mobs/Customization/masking_helpers.rsi
-        state: unisex_full
-        visible: false
-      - map: ["jumpsuit"]
-      - map: ["enum.HumanoidVisualLayers.LFoot"]
-      - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
-      - map: [ "gloves" ]
-      - map: [ "shoes" ]
-      - map: [ "ears" ]
-      - map: [ "eyes" ]
-      - map: [ "belt" ]
-      - map: [ "id" ]
-      - map: [ "neck" ]
-      - map: [ "back" ]
-      - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
-      - map: [ "enum.HumanoidVisualLayers.Hair" ]
-      - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
-      - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ]
-      - map: [ "mask" ]
-      - map: [ "head" ]
-      - map: ["enum.HumanoidVisualLayers.Handcuffs"]
-        color: "#ffffff"
-        sprite: Objects/Misc/handcuffs.rsi
-        state: body-overlay-2
-        visible: false
-      - map: [ "clownedon" ] # Dynamically generated
-        sprite: "Effects/creampie.rsi"
-        state: "creampie_human"
-        visible: false
+      # - map: [ "enum.HumanoidVisualLayers.Chest" ] | Euphoria mob reparent
+      # - map: [ "enum.HumanoidVisualLayers.Head" ]
+      # - map: [ "enum.HumanoidVisualLayers.Snout" ]
+      # - map: [ "enum.HumanoidVisualLayers.Eyes" ]
+      # - map: [ "enum.HumanoidVisualLayers.RArm" ]
+      # - map: [ "enum.HumanoidVisualLayers.LArm" ]
+      # - map: [ "enum.HumanoidVisualLayers.RLeg" ]
+      # - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      # - shader: StencilClear
+      #   sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
+      #   # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.
+      #   # sprite refactor when
+      #   state: l_leg
+      # - shader: StencilMask
+      #   map: ["enum.HumanoidVisualLayers.StencilMask"]
+      #   sprite: Mobs/Customization/masking_helpers.rsi
+      #   state: unisex_full
+      #   visible: false
+      # - map: ["jumpsuit"]
+      # - map: ["enum.HumanoidVisualLayers.LFoot"]
+      # - map: ["enum.HumanoidVisualLayers.RFoot"]
+      # - map: ["enum.HumanoidVisualLayers.LHand"]
+      # - map: ["enum.HumanoidVisualLayers.RHand"]
+      # - map: [ "gloves" ]
+      # - map: [ "shoes" ]
+      # - map: [ "ears" ]
+      # - map: [ "eyes" ]
+      # - map: [ "belt" ]
+      # - map: [ "id" ]
+      # - map: [ "neck" ]
+      # - map: [ "back" ]
+      # - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
+      # - map: [ "enum.HumanoidVisualLayers.Hair" ]
+      # - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
+      # - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
+      # - map: [ "enum.HumanoidVisualLayers.Tail" ]
+      # - map: [ "mask" ]
+      # - map: [ "head" ]
+      # - map: ["enum.HumanoidVisualLayers.Handcuffs"]
+      #   color: "#ffffff"
+      #   sprite: Objects/Misc/handcuffs.rsi
+      #   state: body-overlay-2
+      #   visible: false
+      # - map: [ "clownedon" ] # Dynamically generated
+      #   sprite: "Effects/creampie.rsi"
+      #   state: "creampie_human"
+      #   visible: false
       - sprite: Objects/Weapons/Guns/Pistols/viper.rsi
         state: inhand-left

--- a/Resources/Prototypes/_Euphoria/Entities/Mobs/NPCs/salvage.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Mobs/NPCs/salvage.yml
@@ -7,15 +7,8 @@
     - type: NpcFactionMember
       factions:
         - SalvageMob
-    - type: MobThresholds
-      thresholds:
-        0: Alive
-        100: Critical
-        200: Dead
     - type: MindContainer
       showExamineInfo: False
-    - type: InputMover
-    - type: MobMover
     - type: HTN
       rootTask:
         task: SimpleHumanoidHostileCompound
@@ -26,56 +19,6 @@
       damageRecovery:
         types:
           Asphyxiation: -1.0
-    - type: CombatMode
-    - type: Sprite
-      layers:
-      - map: [ "enum.HumanoidVisualLayers.Chest" ]
-      - map: [ "enum.HumanoidVisualLayers.Head" ]
-      - map: [ "enum.HumanoidVisualLayers.Snout" ]
-      - map: [ "enum.HumanoidVisualLayers.Eyes" ]
-      - map: [ "enum.HumanoidVisualLayers.RArm" ]
-      - map: [ "enum.HumanoidVisualLayers.LArm" ]
-      - map: [ "enum.HumanoidVisualLayers.RLeg" ]
-      - map: [ "enum.HumanoidVisualLayers.LLeg" ]
-      - shader: StencilClear
-        sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
-        # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.
-        # sprite refactor when
-        state: l_leg
-      - shader: StencilMask
-        map: ["enum.HumanoidVisualLayers.StencilMask"]
-        sprite: Mobs/Customization/masking_helpers.rsi
-        state: unisex_full
-        visible: false
-      - map: ["jumpsuit"]
-      - map: ["enum.HumanoidVisualLayers.LFoot"]
-      - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
-      - map: [ "gloves" ]
-      - map: [ "shoes" ]
-      - map: [ "ears" ]
-      - map: [ "eyes" ]
-      - map: [ "belt" ]
-      - map: [ "id" ]
-      - map: [ "neck" ]
-      - map: [ "back" ]
-      - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
-      - map: [ "enum.HumanoidVisualLayers.Hair" ]
-      - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
-      - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ]
-      - map: [ "mask" ]
-      - map: [ "head" ]
-      - map: ["enum.HumanoidVisualLayers.Handcuffs"]
-        color: "#ffffff"
-        sprite: Objects/Misc/handcuffs.rsi
-        state: body-overlay-2
-        visible: false
-      - map: [ "clownedon" ] # Dynamically generated
-        sprite: "Effects/creampie.rsi"
-        state: "creampie_human"
-        visible: false
     - type: SSDIndicator
       updateInterval: 36000 # Won't fall asleep for 10 hours.
 

--- a/Resources/Prototypes/_Euphoria/Entities/Mobs/NPCs/salvage.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Mobs/NPCs/salvage.yml
@@ -1,0 +1,102 @@
+- type: entity
+  name: NPC hostile human
+  parent: BaseMobHuman
+  id: MobHumanNPC
+  description: "A humanoid with uncertain intent."
+  components:
+    - type: NpcFactionMember
+      factions:
+        - SalvageMob
+    - type: MobThresholds
+      thresholds:
+        0: Alive
+        100: Critical
+        200: Dead
+    - type: MindContainer
+      showExamineInfo: False
+    - type: InputMover
+    - type: MobMover
+    - type: HTN
+      rootTask:
+        task: SimpleHumanoidHostileCompound
+    - type: Respirator #Mobs can't turn on internals by themselves, so we have to simulate them having it on
+      damage:
+        types:
+          Asphyxiation: 0
+      damageRecovery:
+        types:
+          Asphyxiation: -1.0
+    - type: CombatMode
+    - type: Sprite
+      layers:
+      - map: [ "enum.HumanoidVisualLayers.Chest" ]
+      - map: [ "enum.HumanoidVisualLayers.Head" ]
+      - map: [ "enum.HumanoidVisualLayers.Snout" ]
+      - map: [ "enum.HumanoidVisualLayers.Eyes" ]
+      - map: [ "enum.HumanoidVisualLayers.RArm" ]
+      - map: [ "enum.HumanoidVisualLayers.LArm" ]
+      - map: [ "enum.HumanoidVisualLayers.RLeg" ]
+      - map: [ "enum.HumanoidVisualLayers.LLeg" ]
+      - shader: StencilClear
+        sprite: Mobs/Species/Human/parts.rsi #PJB on stencil clear being on the left leg: "...this is 'fine'" -https://github.com/space-wizards/space-station-14/pull/12217#issuecomment-1291677115
+        # its fine, but its still very stupid that it has to be done like this instead of allowing sprites to just directly insert a stencil clear.
+        # sprite refactor when
+        state: l_leg
+      - shader: StencilMask
+        map: ["enum.HumanoidVisualLayers.StencilMask"]
+        sprite: Mobs/Customization/masking_helpers.rsi
+        state: unisex_full
+        visible: false
+      - map: ["jumpsuit"]
+      - map: ["enum.HumanoidVisualLayers.LFoot"]
+      - map: ["enum.HumanoidVisualLayers.RFoot"]
+      - map: ["enum.HumanoidVisualLayers.LHand"]
+      - map: ["enum.HumanoidVisualLayers.RHand"]
+      - map: [ "gloves" ]
+      - map: [ "shoes" ]
+      - map: [ "ears" ]
+      - map: [ "eyes" ]
+      - map: [ "belt" ]
+      - map: [ "id" ]
+      - map: [ "neck" ]
+      - map: [ "back" ]
+      - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
+      - map: [ "enum.HumanoidVisualLayers.Hair" ]
+      - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
+      - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ]
+      - map: [ "mask" ]
+      - map: [ "head" ]
+      - map: ["enum.HumanoidVisualLayers.Handcuffs"]
+        color: "#ffffff"
+        sprite: Objects/Misc/handcuffs.rsi
+        state: body-overlay-2
+        visible: false
+      - map: [ "clownedon" ] # Dynamically generated
+        sprite: "Effects/creampie.rsi"
+        state: "creampie_human"
+        visible: false
+    - type: SSDIndicator
+      updateInterval: 36000 # Won't fall asleep for 10 hours.
+
+- type: entity
+  name: NPC hostile human [Randomized]
+  parent: MobHumanNPC
+  id: MobHumanNPCRandomized
+  components:
+    - type: RandomHumanoidAppearance
+
+- type: entity
+  name: NPC hostile human [Salvager]
+  parent: MobHumanNPC
+  id: MobHumanNPCSalvager
+  components:
+  - type: Loadout
+    prototypes: [ NPCHumanSalvagerGearAltA, NPCHumanSalvagerGearAltB, NPCHumanSalvagerGearAltC, NPCHumanSalvagerGearAltD ]
+
+- type: entity
+  name: NPC hostile human [Salvager, Randomized]
+  parent: MobHumanNPCSalvager
+  id: MobHumanNPCSalvagerRandomized
+  components:
+  - type: RandomHumanoidAppearance

--- a/Resources/Prototypes/_Euphoria/Roles/Jobs/NPC/salvagerNPCs.yml
+++ b/Resources/Prototypes/_Euphoria/Roles/Jobs/NPC/salvagerNPCs.yml
@@ -1,0 +1,40 @@
+- type: startingGear
+  id: NPCHumanSalvagerGear
+  equipment:
+    head: ClothingHeadHelmetHardsuitSpatio
+    jumpsuit: ClothingUniformJumpsuitSalvageSpecialist
+    shoes: ClothingShoesBootsSalvage
+    mask: ClothingMaskGasExplorer
+    belt: OreBag
+    back: ClothingBackpackSatchelSalvage
+    outerClothing: ClothingOuterHardsuitSpatio
+
+- type: startingGear
+  id: NPCHumanSalvagerGearAltA
+  parent: NPCHumanSalvagerGear
+  inhand:
+    - WeaponProtoKineticAccelerator
+
+- type: startingGear
+  id: NPCHumanSalvagerGearAltB
+  parent: NPCHumanSalvagerGear
+  inhand:
+    - MiningDrill
+
+- type: startingGear
+  id: NPCHumanSalvagerGearAltC
+  parent: NPCHumanSalvagerGear
+  equipment:
+    head: ClothingHeadHelmetHardsuitSalvage
+    outerClothing: ClothingOuterHardsuitSalvage
+  inhand:
+    - WeaponProtoKineticAccelerator
+
+- type: startingGear
+  id: NPCHumanSalvagerGearAltD
+  parent: NPCHumanSalvagerGear
+  equipment:
+    head: ClothingHeadHelmetHardsuitSalvage
+    outerClothing: ClothingOuterHardsuitSalvage
+  inhand:
+    - MiningDrill


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Addresses an issue with Syndicate Guards that caused them to fall asleep and never wake up after ten minutes.
Adds a better hostile humanoid mob base and some variants for admins/eventmins to work with.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
LPOs were scattered with eternally sleeping guards.
The process for making hostile humanoids slowed down making encounters for players.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Makes a new base hostile human mob. Sets the update interval on SSDIndicator for all non-player hostile humans that use this base to 36000 seconds (10 hours). SSDIndicator is inherited from the base species mob much higher on the parent chain and is the cause of humanoid NPCs going into a coma.

Reparents the RadioGuard to the new base hostile human. 

Adds a salvager variant that spawns with appropriate hardsuits and weapons.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="630" height="405" alt="image" src="https://github.com/user-attachments/assets/20a29d94-b3dc-4a95-8199-f0ab0295cd97" />
<img width="403" height="157" alt="image" src="https://github.com/user-attachments/assets/aefda10a-9c3b-49b4-859b-49c8e4b8431b" />
<img width="792" height="363" alt="image" src="https://github.com/user-attachments/assets/f62c2c82-389c-4aca-987f-2480fe95ec76" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- add: Added mad salvager NPC hostiles.
- fix: Fixed Syndicate Guards sleeping the shift away.
