### PR TITLE
Fix the footprints I hate

### DIFF
--- a/Content.Shared/Fluids/SharedAbsorbentSystem.cs
+++ b/Content.Shared/Fluids/SharedAbsorbentSystem.cs
@@ -277,7 +277,11 @@ public abstract class SharedAbsorbentSystem : EntitySystem
 
         if (!SolutionContainer.ResolveSolution(target, puddle.SolutionName, ref puddle.Solution, out var puddleSolution)
             || puddleSolution.Volume <= 0)
-            return false;
+        {
+            // Floofstation - bandaid fix for empty footprints: simply nuke it.
+            QueueDel(target);
+            return true; // Also return true
+        }
 
         var (_, absorber, useDelay) = absorbEnt;
 

--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -49,19 +49,6 @@ public abstract partial class SharedPuddleSystem
             if (!_solutionContainerSystem.ResolveSolution(uid, puddle.SolutionName, ref puddle.Solution, out var puddleSolution))
                 continue;
 
-            // Floofstation section - delete all puddles that contain no liquid
-            // There is an unresolved bug with footprints sometimes ending up with 0 liquid inside
-            // I suspect it's happening during reagent transfer, but I'm unable to reproduce it in dev.
-            if (puddleSolution.Volume <= 0)
-            {
-                #if TOOLS || DEBUG
-                Log.Info("FIXME: deleting an empty footprint, this shouldnt happen!");
-                #endif
-                PredictedQueueDel(uid);
-                continue;
-            }
-            // Floofstation section end
-
             // If we have multiple evaporating reagents in one puddle, just take the average evaporation speed and apply
             // that to all of them.
             var evaporationSpeeds = GetEvaporationSpeeds(puddleSolution);

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -32,7 +32,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockClothesFilled
-  cost: 4500 # DeltaV
+  cost: 4750 # DeltaV # Floofstation
   category: cargoproduct-category-name-service
   group: market
 


### PR DESCRIPTION
## About the PR
I lost the battle but not the war

Mops can be used to clean empty footprints now. 

## Media
https://github.com/user-attachments/assets/d27ac0c3-002f-4e65-b966-6bb6bff55c64


**Changelog**
:cl:
- fix: Mops can clean empty footprints now. The cause of empty footprints still remains a partial mystery.