### PR TITLE
Coffin Anti-Rot

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -744,6 +744,7 @@
     node: cratecoffin
     containers:
     - entity_storage
+  - type: AntiRottingContainer # Euphoria - Funerals tend to go on too long
 
 - type: entity
   parent: CrateGeneric


### PR DESCRIPTION
## About the PR
Adds AntiRottingContainer Component to Coffin

## Why / Balance
Funerals tend to go too long on our server, and the person rotting and exploding inside the coffin ain't a good look.

**Changelog**
:cl:
- tweak: Coffins now stop Rot, so long funerals can be conducted without needing to keep the dearly departed in a unceremonial body bag.
