### PR TITLE
Add Tiny Trait

### DIFF
--- a/Content.Shared/_DV/Carrying/CarryingSystem.cs
+++ b/Content.Shared/_DV/Carrying/CarryingSystem.cs
@@ -304,7 +304,7 @@ public sealed class CarryingSystem : EntitySystem
         // Floofstation - store virtual items and add a special component to them
         if (_virtualItem.TrySpawnVirtualItemInHand(carried, carrier, out var virt))
             EnsureComp<OfferableVirtualItemComponent>(virt.Value);
-        if (_virtualItem.TrySpawnVirtualItemInHand(carried, carrier, out virt))
+        if (TryComp<CarriableComponent>(carried, out var carriableComp) && (carriableComp.FreeHandsRequired > 1) && _virtualItem.TrySpawnVirtualItemInHand(carried, carrier, out virt))
             EnsureComp<OfferableVirtualItemComponent>(virt.Value);
         // Floofstation section end
     }

--- a/Resources/Locale/en-US/_Floof/traits/skills.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/skills.ftl
@@ -9,6 +9,10 @@ trait-spearmaster-desc =
 trait-small-name = Small
 trait-small-desc = You are able to climb into spaces others would not normally be able to fit into, such as duffel bags.
 
+trait-tiny-name = Tiny
+trait-tiny-desc = You are able to climb into extremely small places! Beware, you are not as strong. 
+examine-tiny-trait-message
+
 trait-swashbuckler-name = Swashbuckler
 trait-swashbuckler-desc =
     You are an expert in swordsmanship, wielding swords, knives, and other blades with unrivaled finesse.

--- a/Resources/Locale/en-US/_Floof/traits/skills.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/skills.ftl
@@ -11,7 +11,7 @@ trait-small-desc = You are able to climb into spaces others would not normally b
 
 trait-tiny-name = Tiny
 trait-tiny-desc = You are able to climb into extremely small places! Beware, you are not as strong. 
-examine-tiny-trait-message
+examine-tiny-trait-message = This person is very small, be careful!
 
 trait-swashbuckler-name = Swashbuckler
 trait-swashbuckler-desc =

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -67,7 +67,7 @@
               Slash: 0.9
               Piercing: 0.9
     - !type:ModifyStaminaThresholdEffect #Possible additional downside. Would probably need to conflict with stamina traits?
-      multiplier: 0.8
+      multiplier: 0.7
 
 # =================================================== #
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -59,7 +59,7 @@
             - 4,0,5,4
         - type: Carriable
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand
-          pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.
+          #pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.
         - type: BonusMeleeDamage
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -57,6 +57,9 @@
             - 0,0,1,4
             - 0,2,3,4
             - 4,0,5,4
+        #- type: Carriable
+        #  freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand
+        #  pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.
         - type: BonusMeleeDamage
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -56,10 +56,10 @@
     - !type:OverrideCompsEffect
       components:
         - type: PseudoItem
-          size: Normal
+          size: Normal #2x2, just like it was on Floof.
         - type: Carriable
-          freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand
-          #pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.
+          freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand. A bit bugged, as picking up with 2 free hands will occupy both hands.
+          #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.
         - type: BonusMeleeDamage
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.
@@ -67,7 +67,7 @@
               Slash: 0.9
               Piercing: 0.9
     - !type:ModifyStaminaThresholdEffect 
-      multiplier: 0.8
+      multiplier: 0.8 #Have less stamina. Takes 1 less shot with a disabler to stun, compared to human Urist. Could mitigate with Vigor trait if you want to use the points.
 
 # =================================================== #
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -23,6 +23,8 @@
   description: trait-small-desc
   category: Skills
   cost: 1
+  conflicts:
+  - Tiny
   conditions:
   - !type:HasCompCondition
     invert: true  
@@ -64,8 +66,8 @@
               Blunt: 0.9
               Slash: 0.9
               Piercing: 0.9
-    #- !type:ModifyStaminaThresholdEffect Possible additional downside. Would probably need to conflict with stamina traits?
-    #  multiplier: 0.8
+    - !type:ModifyStaminaThresholdEffect Possible additional downside. Would probably need to conflict with stamina traits?
+      multiplier: 0.8
 
 # =================================================== #
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -57,9 +57,9 @@
             - 0,0,1,4
             - 0,2,3,4
             - 4,0,5,4
-        #- type: Carriable
-        #  freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand
-        #  pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.
+        - type: Carriable
+          freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand
+          pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.
         - type: BonusMeleeDamage
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -60,12 +60,12 @@
         - type: Carriable
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand. A bit bugged, as picking up with 2 free hands will occupy both hands.
           #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.
-        - type: BonusMeleeDamage
-          conditions:
-          - !type:OneOfSpeciesCondition
-            invert: true
-            species:
-            - Avali
+        conditions:
+        - !type:OneOfSpeciesCondition
+          invert: true
+          species:
+          - Avali
+        - type: BonusMeleeDamage  
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.
               Blunt: 0.9

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -22,6 +22,27 @@
   name: trait-small-name
   description: trait-small-desc
   category: Skills
+  cost: 1
+  conditions:
+  - !type:HasCompCondition
+    invert: true  
+    component: PseudoItem
+  effects:
+    - !type:OverrideCompsEffect
+      components:
+        - type: PseudoItem
+          storedOffset: 0,17
+          shape:
+            - 0,0,1,4
+            - 0,2,3,4
+            - 4,0,5,4
+
+
+- type: trait
+  id: Tiny
+  name: trait-tiny-name
+  description: trait-tiny-desc
+  category: Skills
   cost: 2
   conditions:
   - !type:HasCompCondition
@@ -36,6 +57,14 @@
             - 0,0,1,4
             - 0,2,3,4
             - 4,0,5,4
+        - type: BonusMeleeDamage
+          damageModifierSet:
+            coefficients: #Do less physical damage, because tiny.
+              Blunt: 0.9
+              Slash: 0.9
+              Piercing: 0.9
+    #- !type:ModifyStaminaThresholdEffect Possible additional downside. Would probably need to conflict with stamina traits?
+    #  multiplier: 0.8
 
 # =================================================== #
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -66,8 +66,8 @@
               Blunt: 0.9
               Slash: 0.9
               Piercing: 0.9
-    - !type:ModifyStaminaThresholdEffect #Possible additional downside. Would probably need to conflict with stamina traits?
-      multiplier: 0.7
+    - !type:ModifyStaminaThresholdEffect 
+      multiplier: 0.75
 
 # =================================================== #
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -66,7 +66,7 @@
               Blunt: 0.9
               Slash: 0.9
               Piercing: 0.9
-    - !type:ModifyStaminaThresholdEffect Possible additional downside. Would probably need to conflict with stamina traits?
+    - !type:ModifyStaminaThresholdEffect #Possible additional downside. Would probably need to conflict with stamina traits?
       multiplier: 0.8
 
 # =================================================== #

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -48,10 +48,10 @@
   cost: 2
   conflicts:
   - Small
-  conditions:
-  - !type:HasCompCondition
-    invert: true  
-    component: PseudoItem
+  #conditions:
+  #- !type:HasCompCondition
+  #  invert: true  
+  #  component: PseudoItem
   effects:
     - !type:OverrideCompsEffect
       components:
@@ -59,13 +59,13 @@
           size: Normal #2x2, just like it was on Floof.
         - type: Carriable
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand. A bit bugged, as picking up with 2 free hands will occupy both hands.
-          #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.
-        conditions:
-        - !type:OneOfSpeciesCondition
-          invert: true
-          species:
-          - Avali
+          #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.        
         - type: BonusMeleeDamage  
+        conditions:
+          - !type:OneOfSpeciesCondition
+            invert: true
+            species:
+            - Avali
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.
               Blunt: 0.9

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -61,6 +61,10 @@
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand. A bit bugged, as picking up with 2 free hands will occupy both hands.
           #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.
         - type: BonusMeleeDamage
+          - !type:OneOfSpeciesCondition
+            invert: true
+            species:
+            - Avali
           damageModifierSet:
             coefficients: #Do less physical damage, because tiny.
               Blunt: 0.9

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -61,6 +61,7 @@
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand. A bit bugged, as picking up with 2 free hands will occupy both hands.
           #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.
         - type: BonusMeleeDamage
+          conditions:
           - !type:OneOfSpeciesCondition
             invert: true
             species:

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -67,7 +67,7 @@
               Slash: 0.9
               Piercing: 0.9
     - !type:ModifyStaminaThresholdEffect 
-      multiplier: 0.75
+      multiplier: 0.8
 
 # =================================================== #
 

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -44,6 +44,8 @@
   description: trait-tiny-desc
   category: Skills
   cost: 2
+  conflicts:
+  - Small
   conditions:
   - !type:HasCompCondition
     invert: true  
@@ -52,11 +54,7 @@
     - !type:OverrideCompsEffect
       components:
         - type: PseudoItem
-          storedOffset: 0,17
-          shape:
-            - 0,0,1,4
-            - 0,2,3,4
-            - 4,0,5,4
+          size: Normal
         - type: Carriable
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand
           #pickupDuration: 2 # Default is 3, plus they will already be lighter. Get scooped.

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -61,7 +61,7 @@
           freeHandsRequired: 1 #Default is 2, they are tiny enough to be carried in one hand. A bit bugged, as picking up with 2 free hands will occupy both hands.
           #pickupDuration: 2 # Default is 3, plus they will already be lighter. # Seems like this isn't a variable on the component anymore.        
         - type: BonusMeleeDamage  
-        conditions:
+          conditions:
           - !type:OneOfSpeciesCondition
             invert: true
             species:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Adds the Tiny trait, like we had on Floof. It allows you to fit in 2x2 storage spaces, but also comes with debuffs.

Note: The trait reduces the number of free hands required to be picked up to 1. This works fine if the picker-upper has an item in one hand, and a free hand (the Tiny person getting picked up takes up that free hand, the other hand remains holding the item). But if the picker-upper has both hands free, the carried person takes up both hands. This doesn't break anything, and probably will never be noticed since it only affects those with the Tiny trait. I just wish I could get it so a Tiny person only takes up one hand, even if both hands are free. I may work on that later.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This has been a long requested trait, similar to Small. The Discord threads for Small and Tiny cover this.
Balance:
I've reduced Small to a cost of -1 (was -2, the advantage of being able to fit in only things of duffel size or above is not enough for a -2), and set Tiny to be -2. 
On Floof, Tiny was a cost of 0, but had strict requirements for being able to use it, and it had heavy debuffs. 
Here, I've implemented some of the debuffs, such as dealing less melee damage, and having less stamina. But since I didn't put some of the other debuffs on it, I've given it a point cost. If anything, I worry that the debuffs might be too much for its point cost. 
I did not put size requirements on the trait, for RP reasons. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just trait yml changes. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="431" height="614" alt="image" src="https://github.com/user-attachments/assets/79b8330f-2ffe-4cf2-85c8-4d2078fbc58a" />

<img width="392" height="643" alt="image" src="https://github.com/user-attachments/assets/6c192e2a-c277-4d33-8267-3f1f8f4ca73f" />



</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Added Tiny trait! Go climb into backpacks and satchels, but just beware that you're not as strong as you were.
