### PR TITLE
Biomass Reclaimer Fix

### DIFF
--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -212,12 +212,12 @@ namespace Content.Server.Medical.BiomassReclaimer
             {
                 component.BloodReagents = solution.Clone();
                 /* Floofstation change:
-                 * was component.BloodReagents.Volume, changed to component.BloodReagents.AvailableVolume
-                 * Was changed due to if a mob has 0% blood, ccomponent.BloodReagents.Volume would be 0 this would lead to us dividing by zero and the mob would not be biomassable.
-                 * Chagning to component.BloodReagents.AvailableVolume stops us from dividing by zero and lets the mob with 0% blood be biomassed again
+                 * was component.BloodReagents.Volume, changed to component.BloodReagents.MaxVolume
+                 * Was changed due to if a mob has 0% blood, component.BloodReagents.Volume would be 0 this would lead to us dividing by zero and the mob would not be biomassable.
+                 * Changing to component.BloodReagents.MaxVolume stops us from dividing by zero and lets the mob with 0% blood be biomassed again
                  * I wasted two hours trying to find out why mobs could not be biomassable.
                  */
-                component.BloodReagents.ScaleSolution(50 / component.BloodReagents.AvailableVolume); // Floofstation was component.BloodReagents.Volume
+                component.BloodReagents.ScaleSolution(50 / component.BloodReagents.MaxVolume); // Floofstation was component.BloodReagents.Volume
             }
             if (TryComp<ButcherableComponent>(toProcess, out var butcherableComponent))
             {

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -213,8 +213,8 @@ namespace Content.Server.Medical.BiomassReclaimer
                 component.BloodReagents = solution.Clone();
                 /* Floofstation change:
                  * was component.BloodReagents.Volume, changed to component.BloodReagents.AvailableVolume
-                 * Was changed due to if a mob has 0% blood, ccomponent.BloodReagents.Volume would be 0
-                 * this would to us dividing by zero and the mob would not be biomassable.
+                 * Was changed due to if a mob has 0% blood, ccomponent.BloodReagents.Volume would be 0 this would lead to us dividing by zero and the mob would not be biomassable.
+                 * Chagning to component.BloodReagents.AvailableVolume stops us from dividing by zero and lets the mob with 0% blood be biomassed again
                  * I wasted two hours trying to find out why mobs could not be biomassable.
                  */
                 component.BloodReagents.ScaleSolution(50 / component.BloodReagents.AvailableVolume); // Floofstation was component.BloodReagents.Volume

--- a/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
+++ b/Content.Server/Medical/BiomassReclaimer/BiomassReclaimerSystem.cs
@@ -211,7 +211,13 @@ namespace Content.Server.Medical.BiomassReclaimer
                 _solution.ResolveSolution(toProcess, stream.BloodSolutionName, ref stream.BloodSolution, out var solution))
             {
                 component.BloodReagents = solution.Clone();
-                component.BloodReagents.ScaleSolution(50 / component.BloodReagents.Volume);
+                /* Floofstation change:
+                 * was component.BloodReagents.Volume, changed to component.BloodReagents.AvailableVolume
+                 * Was changed due to if a mob has 0% blood, ccomponent.BloodReagents.Volume would be 0
+                 * this would to us dividing by zero and the mob would not be biomassable.
+                 * I wasted two hours trying to find out why mobs could not be biomassable.
+                 */
+                component.BloodReagents.ScaleSolution(50 / component.BloodReagents.AvailableVolume); // Floofstation was component.BloodReagents.Volume
             }
             if (TryComp<ButcherableComponent>(toProcess, out var butcherableComponent))
             {


### PR DESCRIPTION
## About the PR
Sometimes the biomass reclaimer would not allow the player to biomass a mob. At first i was using pulse weapons because haha funny mob dies quick but every time id kill a mob like this the reclaimer would work with out issue. So then I decided to swap to weapons security would normally use in a round and tabbed out to respond to someone in discord, during that brief tab out time the mobs blood volume reached zero, i attempted to biomass and it failed like we were seeing in rounds. I then gave it some blood and it let me biomass it again.

## Why / Balance
Med needs to be able to biomass mobs.

## Technical details
This hurt my head a lot and i spent more time than i should have on this. Basically when a mob had no blood, component.BloodReagents.Volume would equal zero. component.BloodReagents.ScaleSolution(50 / component.BloodReagents.Volume); would then try to divide by zero, thus preventing the mob from being biomassed. To fix this i just changed component.BloodReagents.Volume to component.BloodReagents.MaxVolume and when the mob has no blood it can still be biomased and arent crashing in debug from dividing by zero anymore. This is probably a really bad solution the problem but its what i came up with so here we are.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
The discovery:
https://github.com/user-attachments/assets/3626ac9c-9926-4417-b23b-357d14e110a1

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: The biomass reclaimer should now be able to biomass mobs again.
