### PR TITLE
Add Measurements to the Height Slider

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -80,6 +80,7 @@
                                     <Control HorizontalExpand="True" />
                                     <Slider Name="CDHeightSlider" HorizontalAlignment="Right" SetWidth="300" MinValue="0.0" MaxValue="1.0"/>
                                     <LineEdit HorizontalAlignment="Right" Name="CDHeight" MinSize="60 0" Text="1.0" />
+                                    <Label Name="EuphHeightDisplay" HorizontalAlignment="Right" MinSize="60 0"/>
                                     <Button Name="CDHeightReset" Text="{Loc 'humanoid-profile-editor-reset-height-button'}" HorizontalAlignment="Right"/>
                                 </BoxContainer>
                                 <!-- End CD - Character Records -->

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -44,7 +44,9 @@ using Content.Shared._CD.Records;
 using Content.Shared.Chemistry.Reagent;
 using Content.Shared.FixedPoint;
 // End CD - Character Records
-using Content.Shared._DV.Traits; // DV - Traits
+using Content.Shared._DV.Traits;
+using System.Runtime.InteropServices;
+using Robust.Shared.Toolshed.Commands.Values; // DV - Traits
 
 namespace Content.Client.Lobby.UI
 {
@@ -297,6 +299,7 @@ namespace Content.Client.Lobby.UI
                 var prototype = _prototypeManager.Index<SpeciesPrototype>(Profile.Species);
                 var newHeight = MathF.Round(MathHelper.Lerp(prototype.MinHeight, prototype.MaxHeight, CDHeightSlider.Value), 2);
                 CDHeight.Text = newHeight.ToString(CultureInfo.InvariantCulture);
+                EuphHeightDisplay.Text = ConvertHeightDisplay(newHeight); //Euphoria | Height display
                 SetProfileHeight(newHeight);
             };
 
@@ -1629,7 +1632,21 @@ namespace Content.Client.Lobby.UI
                                 (prototype.MaxHeight - prototype.MinHeight);
             CDHeightSlider.Value = sliderPercent;
             CDHeight.Text = Profile.Height.ToString(CultureInfo.InvariantCulture);
+            EuphHeightDisplay.Text = ConvertHeightDisplay(Profile.Height); //Euphoria | Height display
         }
+
+        // Euphoria | Height display - START
+        private static string ConvertHeightDisplay(float inputHeight)
+        {
+            var inInches = Math.Truncate(inputHeight * 100 - 31);
+            var outFeet = Math.Truncate(inInches / 12).ToString();
+            var outInchesTens = Math.Round(inInches % 12 / 10, 0, MidpointRounding.ToZero).ToString();
+            var outInchesOnes = (inInches % 12 % 10).ToString();
+            var outCM = Math.Round(inInches * 2.54, 0).ToString();
+            var result = $"{outCM}cm | {outFeet}'{outInchesTens}{outInchesOnes}\"";
+            return result;
+        }
+        // Euphoria | Height display - END
 
         private void UpdateCDAllergies()
         {


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Adds measurements to the height slider in CM and feet/inches. Measurement conversions are from a chart shared in the community.

This does not tie in to the records screen on purpose. This allows a little extra wiggle room at the max and min values for people to input their own canon height. Say, someone plays a 242cm character. That's out of the slider range, but they can just make their official record show that height.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Standardizes the height slider so everyone is on the same page on what 0.81 means compared to 0.95. Minimizes situations where someone who plays a five foot character towers over someone playing a five foot two character.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Adds a label to the UI that displays the measurements. Adds a code block to do some math processing. It is a little more complicated than it should be, but apparently Robust implemented its own toString formatting that doesn't recognize "D2" or ":D2" so I did a work around with my more math inclined partner.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="886" height="301" alt="image" src="https://github.com/user-attachments/assets/a44d10d4-d6d0-4fc7-8d3e-f8a272226f30" />
<img width="911" height="298" alt="image" src="https://github.com/user-attachments/assets/bf9759b2-bb9b-439b-9861-8ecc8e237296" />
<img width="907" height="294" alt="image" src="https://github.com/user-attachments/assets/47517e76-f09b-4ee0-b957-83d6511fee94" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- add: Height measurements now display by the height slider.
