### PR TITLE
Fixed Warden having a spare HoS headset

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/security.yml
@@ -53,7 +53,7 @@
     - id: LunchboxSecurityFilledRandom
       prob: 0.3
     - id: ClothingOuterVestPlateCarrierAdv
-    - id: ClothingHeadsetAltSecurity # Restored from upstream merge.
+    - id: ClothingHeadsetSecurity # Restored from upstream merge. # Euphoria - Not sure but Warden ain't command so no command comms.
     #- id: ClothingNeckShockCollar # DeltaV - Moved to dresser I guess?
     #  amount: 2
     # End DeltaV additions


### PR DESCRIPTION
## About the PR
Not sure, if it was just missed, but Warden had a HoS headset in locker. Swaps it for a normal security one.
So they were getting command comms like that despite not starting with it.

**Changelog**
:cl:
- fix: Fixed Warden having a spare HoS headset.
