### PR TITLE
Purifying Salts to Medkit Whitelist

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/job.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/job.yml
@@ -185,6 +185,7 @@
       - SurgeryTool
       - Dropper
       - Vial # DeltaV
+      - MedicalMisc # Euphoria
       components:
       - Injector
       - Pill

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -17,6 +17,7 @@
         - Ointment
         - PillCanister
         - Syringe
+        - MedicalMisc # Euphoria
       components:
         - GasTank # DeltaV
         - BreathMask

--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Medical/healing.yml
@@ -311,6 +311,9 @@
     count: 5
   - type: StackPrice
     price: 10
+  - type: Tag # Euphoria - I'm pretty sure this is purely the DV April fools thing.
+    tags:
+    - MedicalMisc
 
 - type: entity
   parent: Oilpack
@@ -344,6 +347,9 @@
   - type: Stack
     stackType: OmniPatch
     count: 10
+  - type: Tag # Euphoria
+    tags:
+    - MedicalMisc
 
 - type: entity
   id: Omnipatch1
@@ -395,3 +401,6 @@
     count: 10
   - type: StackPrice
     price: 5
+  - type: Tag # Euphoria
+    tags:
+    - MedicalMisc

--- a/Resources/Prototypes/_Floof/Tags/assorted.yml
+++ b/Resources/Prototypes/_Floof/Tags/assorted.yml
@@ -49,3 +49,6 @@
 
 - type: Tag
   id: WeldbotFixableStructure # Euphoria - Used by Weldbot
+
+- type: Tag
+  id: MedicalMisc # Storage whitelist: Medical Belt and Medkits

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -930,9 +930,6 @@
 - type: Tag
   id: Medkit # CargoBounty: BountyMedkitBox. ConstructionGraph: MediBot
 
-- type: Tag # Euphoria
-  id: MedicalMisc # Storage whitelist: Medical Belt and Medkits
-
 - type: Tag
   id: MessyDrinkerImmune # Default value in MessyDrinkerComponent. Tagged entity is immune to spills.
 

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -930,6 +930,9 @@
 - type: Tag
   id: Medkit # CargoBounty: BountyMedkitBox. ConstructionGraph: MediBot
 
+- type: Tag # Euphoria
+  id: MedicalMisc # Storage whitelist: Medical Belt and Medkits
+
 - type: Tag
   id: MessyDrinkerImmune # Default value in MessyDrinkerComponent. Tagged entity is immune to spills.
 


### PR DESCRIPTION
## About the PR
Adds a tag to Purifying Salts (honestly the most important one), Omnipatches and Oilpacks? (I assume it was the DV Aprils Fools car thing) which allows them to be put into Medical Belts and Medkits.

## Why / Balance
Was bothering me Purifying Salts wasn't going into medkits.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Purifying Salts (and various adjacent healing packs) can now fit in Med Belts and Medkits.
