### PR TITLE
Ninja exit condition

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -291,7 +291,7 @@
         - Syndicate
       - type: AutoImplant
         implants:
-        - DeathAcidifierImplant
+        - NinjaEscapeImplant
       - type: RandomMetadata
         nameSegments:
         - NamesNinjaTitle

--- a/Resources/Prototypes/_Euphoria/Actions/types.yml
+++ b/Resources/Prototypes/_Euphoria/Actions/types.yml
@@ -1,0 +1,16 @@
+- type: entity
+  parent: BaseSuicideAction
+  id: ActionActivateNinjaEscape
+  name: Activate Ninja Escape
+  description: Activates your Ninja Escape implant, teleporting you far-far away from this station. You won't be able to come back. Use this when your job is done and you need to return to base.
+  components:
+  - type: Action
+    checkCanInteract: false
+    checkConsciousness: false
+    itemIconStyle: BigAction
+    priority: -20
+    icon:
+      sprite: _Goobstation/Textures/Effects/bluespace_lifeline.rsi
+      state: bluespace_lifeline
+  - type: InstantAction
+    event: !type:ActivateImplantEvent

--- a/Resources/Prototypes/_Euphoria/Entities/Effects/ninja_escape.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Effects/ninja_escape.yml
@@ -1,0 +1,16 @@
+- type: entity
+  parent: Acidifier
+  id: NinjaEscape
+  name: Ninja Escape
+  description: Teleports your body to save your life or leave the region.
+  components:
+  - type: Transform
+    anchored: True
+  - type: Sprite
+    sprite: _Goobstation/Textures/Effects/bluespace_lifeline.rsi
+    noRot: true
+    layers:
+    - state: bluespace_lifeline
+      shader: unshaded
+  - type: SpawnOnDespawn
+    prototype: ClothingMaskNinja # Replace With Ninja Calling Card but a stylish mask will have to do for now

--- a/Resources/Prototypes/_Euphoria/Entities/Misc/implanters.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Misc/implanters.yml
@@ -1,0 +1,7 @@
+- type: entity
+  id: NinjaEscapeImplanter
+  suffix: ninja escape
+  parent: BaseImplantOnlyImplanterCentcomm
+  components:
+  - type: Implanter
+    implant: NinjaEscapeImplant

--- a/Resources/Prototypes/_Euphoria/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Euphoria/Objects/Misc/subdermal_implants.yml
@@ -11,7 +11,9 @@
   - type: TriggerOnMobstateChange
     mobState:
     - Dead
+    keyOut: timer
   - type: TriggerOnActivateImplant
+    keyOut: timer
   - type: SmokeOnTrigger
     keysIn:
     - timer
@@ -22,8 +24,18 @@
     - timer
     sound: /Audio/Items/smoke_grenade_smoke.ogg
     positional: true
+  - type: TimerTrigger
+    keysIn:
+    - timer
+    keyOut:
+    - die
+    delay: 0.5
   - type: DeleteParentOnTrigger
+    keysIn:
+    - die
   - type: SpawnOnTrigger
+    keysIn:
+    - die
     proto: NinjaEscape
   - type: Tag
     tags:

--- a/Resources/Prototypes/_Euphoria/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Euphoria/Objects/Misc/subdermal_implants.yml
@@ -1,0 +1,31 @@
+- type: entity
+  parent: BaseSubdermalImplant
+  id: NinjaEscapeImplant
+  name: ninja escape implant
+  description: This implant teleports the user's body to the Spider Clan dojo, forcing them to leave the current location so they won't be able to come back.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SubdermalImplant
+    permanent: true
+    implantAction: ActionActivateNinjaEscape
+  - type: TriggerOnMobstateChange
+    mobState:
+    - Dead
+  - type: TriggerOnActivateImplant
+  - type: SmokeOnTrigger
+    keysIn:
+    - timer
+    duration: 30
+    spreadAmount: 50
+  - type: EmitSoundOnTrigger
+    keysIn:
+    - timer
+    sound: /Audio/Items/smoke_grenade_smoke.ogg
+    positional: true
+  - type: DeleteParentOnTrigger
+  - type: SpawnOnTrigger
+    proto: NinjaEscape
+  - type: Tag
+    tags:
+    - SubdermalImplant
+    - HideContextMenu

--- a/Resources/Prototypes/_Euphoria/Objects/Misc/subdermal_implants.yml
+++ b/Resources/Prototypes/_Euphoria/Objects/Misc/subdermal_implants.yml
@@ -27,8 +27,7 @@
   - type: TimerTrigger
     keysIn:
     - timer
-    keyOut:
-    - die
+    keyOut: die
     delay: 0.5
   - type: DeleteParentOnTrigger
     keysIn:


### PR DESCRIPTION
## About the PR
Adds a Ninja Escape Implant (Death Acidifier) Implanter exists too but obviously no normal way to get this.
It deploys a smoke cloud and leaves a Ninja Mask (Will change this to a sassy Spider Clan calling card style note if someone ever makes it).

## Why / Balance
Hostile Ninjas typically, do their objectives, greentext and then have no exit condition other then play "ring around the rosie" with a often frustrated security, which leads to a lot of OOC complaining.

This PR adds a "exit condition" which is, leaving the station in a poof of smoke, mission complete, jobs done instead of simply dying or getting captured on purpose. 

## Media

https://github.com/user-attachments/assets/d5aa0826-6fbb-4d18-bf74-54450a2214ae

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added an exit conditions for Ninjas so they don't feel the need to linger around on station.
