### PR TITLE
Elite suit unshittening

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1789,7 +1789,7 @@
 # Begin DeltaV additions
   discountCategory: RareDiscounts # Euphoria
   discountDownTo:
-    Telecrystal: 4 # Euphoria
+    Telecrystal: 4 # Euphoria - was 8
 # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1778,7 +1778,7 @@
   icon: { sprite: /Textures/Clothing/OuterClothing/Hardsuits/syndieelite.rsi, state: icon }
   productEntity: ClothingBackpackDuffelSyndicateEliteHardsuitBundle
   cost:
-    Telecrystal: 14 # DeltaV - was 12
+    Telecrystal: 10 # Euphoria - was 14
   categories:
   - UplinkWearables
 #  conditions: # DeltaV - Traitors can now buy Elite suit!
@@ -1787,9 +1787,9 @@
 #      tags:
 #      - NukeOpsUplink
 # Begin DeltaV additions
-  discountCategory: veryRareDiscounts
+  discountCategory: RareDiscounts # Euphoria
   discountDownTo:
-    Telecrystal: 8
+    Telecrystal: 4 # Euphoria
 # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1787,7 +1787,7 @@
 #      tags:
 #      - NukeOpsUplink
 # Begin DeltaV additions
-  discountCategory: RareDiscounts # Euphoria
+  discountCategory: rareDiscounts # Euphoria
   discountDownTo:
     Telecrystal: 4 # Euphoria - was 8
 # End DeltaV additions

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -842,8 +842,8 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6 # Euphoria - was 0.2
-        Slash: 0.6 # Euphoria - was 0.2
+        Blunt: 0.6 # Euphoria - was 0.8
+        Slash: 0.6 # Euphoria - was 0.8
         Piercing: 0.6
         Heat: 0.2
         Radiation: 0.01

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -848,7 +848,7 @@
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
-        Cold: 0.2 # Euphoria - was 0.3 // In the unlikely event that syndies end up fighting coscult
+        Cold: 0.2 # Euphoria - was 0.4 // In the unlikely event that syndies end up fighting coscult
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -826,7 +826,7 @@
       outerClothing-dog:
       - state: equipped-OUTERCLOTHING-dog
   - type: PressureProtection
-    highPressureMultiplier: 0.02
+    highPressureMultiplier: 0.001 # Euphoria - was 0.02
     lowPressureMultiplier: 1000
   - type: TemperatureProtection
     heatingCoefficient: 0.001
@@ -834,19 +834,21 @@
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: FireProtection
-    reduction: 0.8
+    reduction: 0.95
   - type: StaminaResistance # DeltaV - uncommented
-    damageCoefficient: 0.3 # DeltaV - was 0.6
+    damageCoefficient: 0.5 # Euphoria - was 0.3
+  - type: ZombificationResistance
+    zombificationResistanceCoefficient: 0.1 # Euphoria - Added 90% Zombie Resistance // This effect will only ever show up in planned events on Euphoria
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.8 # DeltaV - was 0.6
-        Slash: 0.8 # DeltaV - was 0.6
+        Blunt: 0.6 # Euphoria - was 0.2
+        Slash: 0.6 # Euphoria - was 0.2
         Piercing: 0.6
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5
-        Cold: 0.4 # DeltaV - Cold res
+        Cold: 0.2 # Euphoria - was 0.3 // In the unlikely event that syndies end up fighting coscult
   - type: DamageOnShootProtection # imp
     slots: OUTERCLOTHING
     damageProtection:
@@ -854,9 +856,9 @@
         Blunt: 10
   - type: Item
     size: Huge
-  - type: ClothingSpeedModifier
-    walkModifier: 0.9
-    sprintModifier: 0.9
+  - type: ClothingSpeedModifier # Euphoria
+    walkModifier: 1
+    sprintModifier: 1
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSyndieElite


### PR DESCRIPTION
## About the PR
Reverts DV's "Side-grade" to the Elite suit and slightly improves it in a non-major way.

## Why / Balance
So, just to explain, DV says it's a "Side-grade", it was a downgrade, in both doubling the cost and armor.
This reverts the change so it's a "Side-upgrade" so it's the Atmos Suit of Syndies.
Reduced the price back to EE's 10 down from 14... which was insane.
Also minor DV related buffs is just improvements to cold damage.

## Requirements
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Made the Elite/Thermal Suit good again, it was too expensive for "a side DOWN-grade".
