### PR TITLE
Fix Nudity Permit Link

### DIFF
--- a/Resources/Textures/_Floof/Clothing/Uniforms/nuditypermit.rsi/meta.json
+++ b/Resources/Textures/_Floof/Clothing/Uniforms/nuditypermit.rsi/meta.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "license": "CC-BY-SA-3.0",
-  "copyright": "Taken from https://github.com/VOREStation/VOREStation",
+  "copyright": "Taken from VOREStation PR: https://github.com/VOREStation/VOREStation/pull/126",
   "size": {
     "x": 32,
     "y": 32


### PR DESCRIPTION
## About the PR
While looking for fishnet sprite commit history i noticed that the nudity permit also from vorestation did not have proper commit or pr linked so im correcting that since i found it

## Why / Balance
We should fix these when we can

## Technical details
json edit

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
No media.

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->