### PR TITLE
fixes cost on synth trait

### DIFF
--- a/Resources/Prototypes/_DV/Traits/medical.yml
+++ b/Resources/Prototypes/_DV/Traits/medical.yml
@@ -97,6 +97,7 @@
   name: trait-synth-name
   description: trait-synth-desc
   category: Cybernetics # Euphoria
+  cost: 0 # Euphoria - Missing Cost meant it costed 1
   conditions:
   - !type:HasCompCondition
     component: Silicon


### PR DESCRIPTION
## About the PR
Fixes the cost on the synth trait to cost 0, as its additions are flavor.

**Changelog**
:cl:
- fix: Fixed Synth Trait costing a point when it should have been neutral.
