### PR TITLE
Trait balance fixes

### DIFF
--- a/Resources/Prototypes/_DV/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DV/Traits/disabilities.yml
@@ -21,7 +21,7 @@
   name: trait-poor-vision-name
   description: trait-poor-vision-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -1 #floof
+  cost: -3 #floof
   conditions:
   - !type:HasCompCondition
     component: Blindable
@@ -71,7 +71,7 @@
   name: trait-impaired-mobility-name
   description: trait-impaired-mobility-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -3 #floof
+  cost: -4 #floof
   effects:
   - !type:AddCompsEffect
     components:
@@ -84,7 +84,7 @@
   name: trait-amputee-left-arm-name
   description: trait-amputee-left-arm-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -3 #floof
+  cost: -5 #floof
   conflicts:
   - ArmAmputeeRight # TODO: AmputeeComponent doesn't stack, should be an effect instead
   effects:
@@ -99,7 +99,7 @@
   name: trait-amputee-right-arm-name
   description: trait-amputee-right-arm-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -3 #floof
+  cost: -5 #floof
   conflicts:
   - ArmAmputeeLeft
   effects:
@@ -125,7 +125,7 @@
   name: trait-painnumbness-name
   description: trait-painnumbness-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -2
+  cost: -3
   effects:
   - !type:AddCompsEffect
     components:
@@ -136,7 +136,7 @@
   name: trait-hemophilia-name
   description: trait-hemophilia-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -2 #floof
+  cost: -3 #floof
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DV/Traits/disabilities.yml
@@ -21,7 +21,7 @@
   name: trait-poor-vision-name
   description: trait-poor-vision-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -3 #floof
+  cost: -1 #floof
   conditions:
   - !type:HasCompCondition
     component: Blindable
@@ -71,7 +71,7 @@
   name: trait-impaired-mobility-name
   description: trait-impaired-mobility-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -4 #floof
+  cost: -3 #floof
   effects:
   - !type:AddCompsEffect
     components:
@@ -125,7 +125,7 @@
   name: trait-painnumbness-name
   description: trait-painnumbness-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -3
+  cost: -2
   effects:
   - !type:AddCompsEffect
     components:
@@ -136,7 +136,7 @@
   name: trait-hemophilia-name
   description: trait-hemophilia-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -3 #floof
+  cost: -2 #floof
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/medical.yml
+++ b/Resources/Prototypes/_DV/Traits/medical.yml
@@ -5,7 +5,7 @@
   name: trait-narcolepsy-name
   description: trait-narcolepsy-desc
   category: DisabilitiesMental # Euphoria
-  cost: -5 #floof
+  cost: -4 #floof
   effects:
   - !type:AddCompsEffect
     components:
@@ -79,7 +79,7 @@
   name: trait-redshirt-name
   description: trait-redshirt-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -10 #floof
+  cost: -8 #floof
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/medical.yml
+++ b/Resources/Prototypes/_DV/Traits/medical.yml
@@ -5,7 +5,7 @@
   name: trait-narcolepsy-name
   description: trait-narcolepsy-desc
   category: DisabilitiesMental # Euphoria
-  cost: -2 #floof
+  cost: -5 #floof
   effects:
   - !type:AddCompsEffect
     components:
@@ -79,7 +79,7 @@
   name: trait-redshirt-name
   description: trait-redshirt-desc
   category: DisabilitiesPhysical # Euphoria
-  cost: -6 #floof
+  cost: -10 #floof
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_Floof/Traits/mental.yml
+++ b/Resources/Prototypes/_Floof/Traits/mental.yml
@@ -19,7 +19,7 @@
   name: trait-precognition-name
   description: trait-precognition-desc
   category: Psionics
-  cost: 4
+  cost: 3
   effects:
   - !type:AddCompsEffect
     components:
@@ -47,7 +47,7 @@
   name: trait-psychokinetic-scream-name
   description: trait-psychokinetic-scream-desc
   category: Psionics
-  cost: 6
+  cost: 3
   effects:
   - !type:AddCompsEffect
     components:
@@ -59,7 +59,11 @@
   name: trait-psionic-regeneration-name
   description: trait-psionic-regeneration-desc
   category: Psionics
-  cost: 6
+  cost: 8
+  conditions:
+  - !type:IsSpeciesCondition
+    species: IPC
+    invert: true
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -42,7 +42,7 @@
   name: trait-name-CyberEyesFlare
   description: trait-description-CyberEyesFlare
   category: Cybernetics
-  cost: 6
+  cost: 8
   conflicts:
   - Blindness
   - PoorVision
@@ -52,13 +52,14 @@
     - type: FlashImmunity
       showInExamine: false
     - type: EyeProtection
+      ProtectionTime: 15
 
 - type: trait
   id: CyberEyesNightVision
   category: Cybernetics
   name: trait-name-CyberEyesNightVision
   description: trait-description-CyberEyesNightVision
-  cost: 6
+  cost: 8
   conflicts:
   - Blindness
   - PoorVision
@@ -83,7 +84,7 @@
   category: Cybernetics
   name: trait-name-CyberEyesSecurity
   description: trait-description-CyberEyesSecurity
-  cost: 3
+  cost: 4
   conflicts:
   - CyberEyesOmni
   conditions:
@@ -117,7 +118,7 @@
   category: Cybernetics
   name: trait-name-CyberEyesMedical
   description: trait-description-CyberEyesMedical
-  cost: 3
+  cost: 4
   conflicts:
     - CyberEyesOmni
   effects:
@@ -139,7 +140,7 @@
   category: Cybernetics
   name: trait-name-CyberEyesOmni
   description: trait-description-CyberEyesOmni
-  cost: 4
+  cost: 6
   conflicts:
   - CyberEyesMedical
   - CyberEyesSecurity

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -52,7 +52,7 @@
     - type: FlashImmunity
       showInExamine: false
     - type: EyeProtection
-      ProtectionTime: 15
+      protectionTime: 15
 
 - type: trait
   id: CyberEyesNightVision

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -4,7 +4,7 @@
   name: trait-name-LeftBionicPryArm
   description: trait-description-BionicPryArm
   category: Cybernetics
-  cost: 2
+  cost: 8
   conflicts:
   - ArmAmputeeRight
   - ArmAmputeeLeft
@@ -23,7 +23,7 @@
   name: trait-name-RightBionicPryArm
   description: trait-description-BionicPryArm
   category: Cybernetics
-  cost: 2
+  cost: 8
   conflicts:
   - ArmAmputeeRight
   - ArmAmputeeLeft
@@ -42,7 +42,7 @@
   name: trait-name-CyberEyesFlare
   description: trait-description-CyberEyesFlare
   category: Cybernetics
-  cost: 8
+  cost: 6
   conflicts:
   - Blindness
   - PoorVision
@@ -58,7 +58,7 @@
   category: Cybernetics
   name: trait-name-CyberEyesNightVision
   description: trait-description-CyberEyesNightVision
-  cost: 8
+  cost: 6
   conflicts:
   - Blindness
   - PoorVision
@@ -83,12 +83,28 @@
   category: Cybernetics
   name: trait-name-CyberEyesSecurity
   description: trait-description-CyberEyesSecurity
-  cost: 4
+  cost: 3
   conflicts:
   - CyberEyesOmni
   conditions:
-  - !type:InDepartmentCondition
-    department: Security
+  - !type:HasJobCondition
+    job: HeadOfSecurity
+  - !type:HasJobCondition
+    job: Warden
+  - !type:HasJobCondition
+    job: Brigmedic
+  - !type:HasJobCondition
+    job: Detective
+  - !type:HasJobCondition
+    job: PrisonGuard
+  - !type:HasJobCondition
+    job: SecurityCadet
+  - !type:HasJobCondition
+    job: SecurityOfficer
+  - !type:HasJobCondition
+    job: SecurityTechnician
+  - !type:HasJobCondition
+    job: SeniorOfficer
   effects:
   - !type:AddCompsEffect
     components:
@@ -101,7 +117,7 @@
   category: Cybernetics
   name: trait-name-CyberEyesMedical
   description: trait-description-CyberEyesMedical
-  cost: 4
+  cost: 3
   conflicts:
     - CyberEyesOmni
   effects:
@@ -116,19 +132,36 @@
       - Biological
       - BiologicalMetaphysical
     - type: ShowTriageIcons # Euphoria - Add triage icons to standard crew-aligned medical HUDs
+    #- type: SolutionScanner
 
 - type: trait
   id: CyberEyesOmni
   category: Cybernetics
   name: trait-name-CyberEyesOmni
   description: trait-description-CyberEyesOmni
-  cost: 6
+  cost: 4
   conflicts:
   - CyberEyesMedical
   - CyberEyesSecurity
   conditions:
-  - !type:InDepartmentCondition
-    department: Command
+  - !type:HasJobCondition
+    job: Captain
+  - !type:HasJobCondition
+    job: ChiefJustice
+  - !type:HasJobCondition
+    job: ChiefEngineer
+  - !type:HasJobCondition
+    job: ChiefMedicalOfficer
+  - !type:HasJobCondition
+    job: HeadOfPersonnel
+  - !type:HasJobCondition
+    job: HeadOfSecurity
+  - !type:HasJobCondition
+    job: Quartermaster
+  - !type:HasJobCondition
+    job: ResearchDirector
+  - !type:HasJobCondition
+    job: Brigmedic
   effects:
   - !type:AddCompsEffect
     components:


### PR DESCRIPTION
## About the PR
Adjusts/Balances Various Trait cost
Fixes Sechud/Omnihud
Increases the Cost of Pryarms and Regeneration which have been an issue partly

## Why / Balance
The LIST

- Amputee - -2 - Missing arm prevents wielding of weapon, even with small arms it prevents carrying a shield in the off-hand.
- Narcolepsy - -2 - Narcolepsy has no warning unlike the previous codebase.
- Redshirt - -2 - Redshirt removes crit state, and in certain scenarios makes your revival impossible.
- Precognition - -1 - Precog is niche and somewhat useful however, it's use increases the glimmer and pisses Epi off.
- Psychokinetic Scream - -3 - Psychokinetic Scream is very niche, annoys janitors and gas lights people into thinking there's a Skia.
- Psionic Regeneration - +2 - Psionic Regeneration has had much discussion, it's downside being "slowed to a crawl" and requires some skill to use wasn't enough, as people simply just hunkered down, so for now, it's being made slightly more expensive instead of being outright removed.
- Bionic PryArm - +6 - It was unnoticed for a while but, it could pry powered doors, so it's cost has been adjusted accordingly.

**Changelog**
:cl:
- tweak: Adjusted various trait point cost.
- fix: Sechud and Omnihuds can now be taken, one of the conditionals (department) wasn't working.
- fix: IPCs can no longer take Psionic Regeneration, not for the lack of trying but the lack of ability to process chemicals.
