### PR TITLE
Adjusted Meteors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -68,7 +68,7 @@
         - Impassable
         - BulletImpassable
   - type: Explosive
-    totalIntensity: 25
+    totalIntensity: 12.5 # Euphoria - Halved
   - type: Destructible
     thresholds:
     - trigger:
@@ -103,7 +103,7 @@
         - Impassable
         - BulletImpassable
   - type: Explosive
-    totalIntensity: 100
+    totalIntensity: 50 # Euphoria - Halved
   - type: Destructible
     thresholds:
     - trigger:
@@ -143,7 +143,7 @@
         - Impassable
         - BulletImpassable
   - type: Explosive
-    totalIntensity: 200
+    totalIntensity: 100 # Euphoria - Halved
   - type: Destructible
     thresholds:
     - trigger:
@@ -171,7 +171,7 @@
   - type: Sprite
     state: big
   - type: Explosive
-    totalIntensity: 300
+    totalIntensity: 150 # Euphoria - Halved
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/meteors.yml
@@ -68,7 +68,7 @@
         - Impassable
         - BulletImpassable
   - type: Explosive
-    totalIntensity: 12.5 # Euphoria - Halved
+    totalIntensity: 1 # Euphoria - down from 25
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -133,9 +133,9 @@
     waves:
       min: 2
       max: 3
-    meteorsPerWave:
-      min: 3
-      max: 5
+    meteorsPerWave: # Euphoria - Tripled Amount
+      min: 9
+      max: 15
 
 - type: entity
   parent: GameRuleMeteorSwarm
@@ -153,9 +153,9 @@
     waves:
       min: 2
       max: 3
-    meteorsPerWave:
-      min: 8
-      max: 12
+    meteorsPerWave: # Euphoria - Tripled Amount
+      min: 24
+      max: 36
 
 - type: entity
   parent: GameRuleMeteorSwarm

--- a/Resources/Prototypes/_Floof/Gamerules/meteorswarms.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/meteorswarms.yml
@@ -3,9 +3,9 @@
   id: MeteorSwarmCalmScheduler
   components:
   - type: BasicStationEventScheduler
-    minimumTimeUntilFirstEvent: 1200 # 20 min
+    minimumTimeUntilFirstEvent: 1800 # 30 min
     minMaxEventTiming:
-      min: 900 # 15 min
+      min: 1800 # 30 min
       max: 4500 # 75 min
     scheduledGameRules: !type:EntSelector # DeltaV: use old event
       id: MeteorSwarm

--- a/Resources/Prototypes/_Floof/Gamerules/meteorswarms.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/meteorswarms.yml
@@ -7,5 +7,5 @@
     minMaxEventTiming:
       min: 1800 # 30 min
       max: 4500 # 75 min
-    scheduledGameRules: !type:EntSelector # DeltaV: use old event
-      id: MeteorSwarm
+    scheduledGameRules: !type:NestedSelector # This should make it so only dust swarms spawn
+      tableId: MeteorSwarmDustEventsTable


### PR DESCRIPTION
## About the PR
Halves the explosive strength of meteors

ALRIGHT I'VE DONE IT.
I've nerfed space dust to a point where it won't break walls but will still blow reinforced windows.
To compensate I've increased the amount of dust per storm.

## Why / Balance
Meteors have been causing way too much damage too often, and Reinforced Walls still crumple to space dust.

**Changelog**
:cl:
- tweak: Changed Meteors less frequent on greenshifts.
- tweak: Changed Greenshift meteors to only be dust storms.
- tweak: Changed Meteors to be less destructive.

[Classic Video too big to attach](https://cdn.discordapp.com/attachments/1255992182880473269/1499938973928390787/2026-05-02_10-41-01.mp4?ex=69f69e86&is=69f54d06&hm=e1453175adb892c7575b374dd85428b23acbd85539fde89843ffca0e9e88582a&)
