### PR TITLE
Adds Rat Servants to Trash Bag Whitelist

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -314,6 +314,7 @@
     tags:
       - CannotSuicide
       - FootstepSound
+      - Trash # Euphoria - QoL
   - type: NoSlip
   - type: MobPrice
     price: 500 # rat wealth


### PR DESCRIPTION
## About the PR
Adds Rat Servants to Trash Bag Whitelist so you can suck em all up after a rat massacre.

**Changelog**
:cl:
- add: Added Rat Servants to Trash Bag whitelist
