### PR TITLE
Content Warning: Vore Patch 2

### DIFF
--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -30,7 +30,6 @@ public sealed class VoreSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly CarryingSystem _carryingSystem = default!;
-    [Dependency] private readonly ITimerManager _timer = default!;
 
     public static readonly ProtoId<ConsentTogglePrototype> isPred = "PredVore";
     public static readonly ProtoId<ConsentTogglePrototype> isPrey = "PreyVore";
@@ -186,7 +185,7 @@ public sealed class VoreSystem : EntitySystem
             return;
 
         var pred = uid;
-        var container = _containerSystem.EnsureContainer<Container>(args.User, comp.ContainerId);
+        var container = _containerSystem.EnsureContainer<Container>(pred, comp.ContainerId);
         
         var count = 0;
         //only counts entities with bodies meaning no items
@@ -197,7 +196,7 @@ public sealed class VoreSystem : EntitySystem
         }
         //as a way to prevent too many entities to be devoured
         if (count >= args.MaxPrey){
-            _popupSystem.PopupEntity("You are too full to swallow more prey.", args.User, args.User);
+            _popupSystem.PopupEntity("You are too full to swallow more prey.", pred, pred);
             return;
         }
 
@@ -269,8 +268,8 @@ public sealed class VoreSystem : EntitySystem
         var prey = args.Entity;
 
         // Check if this was an intentional release by the pred (not a self-escape)
-        if (comp.IntentionalRelease){
-            comp.IntentionalRelease = false;
+        if (TryComp<VoreComponent>(prey, out var preyComp) && preyComp.IntentionalRelease){
+            preyComp.IntentionalRelease = false;
             return;
         }
 

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -79,9 +79,11 @@ public sealed class VoreSystem : EntitySystem
         /* in case prey is inside a container immediately release them when they turn off prey consent
         works as an emergency leave for the prey*/
         if (!hasPrey &&
-        _containerSystem.TryGetContainingContainer(uid, out var container) &&
-        container.ID == "vore_container")
-                _containerSystem.Remove(uid, container);
+        TryComp<VoreComponent>(uid, out var comp) &&
+        IsInVoreContainer(uid, comp) &&
+        _containerSystem.TryGetContainingContainer(uid, out var container)){
+            _containerSystem.Remove(uid, container);
+        }
 
         //give the mob the needed component to be able to see the verbs
         if (hasPred || hasPrey){
@@ -110,12 +112,12 @@ public sealed class VoreSystem : EntitySystem
         
         // no self activation, only there to remove your own prey and not have other intervene or have others see that you have prey
         if (user == target){
-            var container = _containerSystem.EnsureContainer<Container>(target, "vore_container");
+            var container = _containerSystem.EnsureContainer<Container>(target, comp.ContainerId);
             if (container.ContainedEntities.Count > 0){
                 args.Verbs.Add(new Verb
                 {
                     Text = "Remove Prey",
-                    Act = () =>TryReleasePrey(target)
+                    Act = () =>TryReleasePrey(target, comp)
                 });
             }
             return;
@@ -131,14 +133,8 @@ public sealed class VoreSystem : EntitySystem
 
         /* if the user is a pred inside a pred allows them to have interactions with prey inside
         only if they are in the same container however */ 
-        var userInContainer = _containerSystem.TryGetContainingContainer(user, out var userContainer) &&
-            userContainer.ID == "vore_container";
-        var targetInContainer = _containerSystem.TryGetContainingContainer(target, out var targetContainer) &&
-            targetContainer.ID == "vore_container";
-        if (userInContainer){
-            if (!targetInContainer || userContainer != targetContainer)
-                return;
-        }
+        if (IsInVoreContainer(user, comp) && !IsInVoreContainer(target, comp))
+            return;
 
         // devour (pred → prey)
         if (_consentSystem.HasConsent(user, isPred)
@@ -190,7 +186,7 @@ public sealed class VoreSystem : EntitySystem
             return;
 
         var pred = uid;
-        var container = _containerSystem.EnsureContainer<Container>(args.User, "vore_container");
+        var container = _containerSystem.EnsureContainer<Container>(args.User, comp.ContainerId);
         
         var count = 0;
         //only counts entities with bodies meaning no items
@@ -206,24 +202,24 @@ public sealed class VoreSystem : EntitySystem
         }
 
         //makes sure prey will be dropped from bags and hands
-        EnsureEntityFree(pred, prey);
+        EnsureEntityFree(pred, prey, comp);
 
         //moves prey inside the person
         _containerSystem.Insert(prey, container);
         
         /*make the prey immune to space+temp+breathing to avoid consent concerns from outside influence
         gets removed after escaping or being forcefully ejected by pred*/
-        ApplyStomachImmunities(prey);
+        ApplyStomachImmunities(prey, comp);
     }
 
     /// <summary>
     /// makes sure the prey is not inside any other container such as 
     /// bags or being carried by someone before being inserted into the pred
     /// </summary>
-    private void EnsureEntityFree(EntityUid pred, EntityUid prey){
+    private void EnsureEntityFree(EntityUid pred, EntityUid prey, VoreComponent comp){
          //check if the prey is already inside a container and remove them (for example bags)
         if (_containerSystem.TryGetContainingContainer(prey, out var currentContainer)){
-            if (currentContainer.ID != "vore_container")
+            if (currentContainer.ID != comp.ContainerId)
                 _containerSystem.Remove(prey, currentContainer);
         }
 
@@ -246,8 +242,8 @@ public sealed class VoreSystem : EntitySystem
     /// for when the pred removes the prey from their container
     /// will remove the buffs such as space immunity for the target
     /// </summary>
-    private void TryReleasePrey(EntityUid pred){
-        var container = _containerSystem.EnsureContainer<Container>(pred, "vore_container");
+    private void TryReleasePrey(EntityUid pred, VoreComponent comp){
+        var container = _containerSystem.EnsureContainer<Container>(pred, comp.ContainerId);
         var preyList = new List<EntityUid>(container.ContainedEntities);
         //remove everything from people to items
         foreach (var prey in preyList){
@@ -256,7 +252,7 @@ public sealed class VoreSystem : EntitySystem
                 preyComp.IntentionalRelease = true;
 
             _containerSystem.Remove(prey, container);
-            RemoveStomachImmunities(prey);
+            RemoveStomachImmunities(prey, comp);
             _popupSystem.PopupEntity("You have been released!", prey, prey);
         }
         _popupSystem.PopupEntity("You release your prey.", pred, pred);
@@ -267,18 +263,18 @@ public sealed class VoreSystem : EntitySystem
     /// will remove the buffs such as space immunity for the target
     /// </summary>
     private void OnVoreRemovedFromContainer(EntityUid uid, VoreComponent comp, EntRemovedFromContainerMessage args){
-        if (args.Container.ID != "vore_container")
+        if (args.Container.ID != comp.ContainerId)
             return;
 
         var prey = args.Entity;
 
         // Check if this was an intentional release by the pred (not a self-escape)
-        if (TryComp<VoreComponent>(prey, out var preyComp) && preyComp.IntentionalRelease){
-            preyComp.IntentionalRelease = false;
+        if (comp.IntentionalRelease){
+            comp.IntentionalRelease = false;
             return;
         }
 
-        RemoveStomachImmunities(prey);
+        RemoveStomachImmunities(prey, comp);
         _popupSystem.PopupEntity("You struggle free!", prey, prey);
         _popupSystem.PopupEntity("Your prey escaped!", uid, uid);
     }
@@ -287,32 +283,32 @@ public sealed class VoreSystem : EntitySystem
     /// in case the user gets gibbed need content emptied including prey+items
     /// </summary>
     private void OnGibbedRemoveContent(EntityUid uid, VoreComponent comp, BeingGibbedEvent args){
-        TryReleasePrey(uid);
+        TryReleasePrey(uid, comp);
     }
 
     /// <summary>
     /// in case the user gets destroyed through for example singulo or gibbing
     /// </summary>
     private void OnDestroyedRemoveContent(EntityUid uid, VoreComponent comp, DestructionEventArgs args){
-        TryReleasePrey(uid);
+        TryReleasePrey(uid, comp);
     }
 
     /// <summary>
     /// in case of polymorp scenarios such as kitsune release all the content
     /// </summary>
     private void OnPolymorphedTransferContent(EntityUid uid, VoreComponent comp, PolymorphedEvent args){   
-        TryReleasePrey(uid);
+        TryReleasePrey(uid, comp);
     }
     
     /// <summary>
     /// the prey needs to have certain components such as pressure immunity
     /// for consent purposes -> having others avoid stumbling on scenarios
     /// </summary>
-    private void ApplyStomachImmunities(EntityUid prey){
+    private void ApplyStomachImmunities(EntityUid prey, VoreComponent comp){
         /*double check making sure they are inside the container
         should prevent possible exploitation of the system*/
         if (!_containerSystem.TryGetContainingContainer(prey, out var container) ||
-        container.ID != "vore_container")
+        container.ID != comp.ContainerId)
            return;
 
         var tracker = EnsureComp<VoreImmunityTrackerComponent>(prey);
@@ -345,13 +341,12 @@ public sealed class VoreSystem : EntitySystem
     /// the removal of the components after leaving a container
     /// to avoid intentional and accidental exploitation
     /// </summary>
-    private void RemoveStomachImmunities(EntityUid prey){
+    private void RemoveStomachImmunities(EntityUid prey, VoreComponent comp){
         // necessary to delay the removal incase of multiple containers
         WaitForUpdates(() =>
         {
             // in case the prey still remains inside another vore container (for example multivore) do not remove the immunities
-            if (_containerSystem.TryGetContainingContainer(prey, out var container) &&
-            container.ID == "vore_container")
+            if (IsInVoreContainer(prey, comp))
                 return;
             if (!TryComp<VoreImmunityTrackerComponent>(prey, out var tracker))
                 return;
@@ -373,5 +368,16 @@ public sealed class VoreSystem : EntitySystem
     /// </summary>
     private void WaitForUpdates(Action action){
         Timer.Spawn(0, action);
+    }
+
+    /// <summary>
+    /// checks if an entity is inside a vore container
+    /// </summary>
+    /// <returns>
+    /// true if the entity is inside any vore container, otherwise false
+    /// </returns>
+    private bool IsInVoreContainer(EntityUid uid, VoreComponent comp){
+        return _containerSystem.TryGetContainingContainer(uid, out var container) &&
+           container.ID == comp.ContainerId;
     }
 }

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -18,6 +18,7 @@ using Content.Shared.Polymorph;
 using Content.Shared.Destructible;
 using Robust.Shared.Configuration;
 using Content.Shared._DV.Carrying;
+using Robust.Shared.Timing;
 namespace Content.Server._Floof.Vore;
 
 public sealed class VoreSystem : EntitySystem
@@ -28,13 +29,15 @@ public sealed class VoreSystem : EntitySystem
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly IConfigurationManager _cfg = default!;
     [Dependency] private readonly CarryingSystem _carryingSystem = default!;
+    [Dependency] private readonly ITimerManager _timer = default!;
 
     public static readonly ProtoId<ConsentTogglePrototype> isPred = "PredVore";
     public static readonly ProtoId<ConsentTogglePrototype> isPrey = "PreyVore";
 
     public override void Initialize()
     {
-        SubscribeLocalEvent<MindContainerComponent, ComponentStartup>(OnMindStartup);
+        SubscribeLocalEvent<ConsentComponent, ComponentStartup>(OnConsentStartup);
+        SubscribeLocalEvent<ConsentComponent, EntityConsentToggleUpdatedEvent>(OnConsentUpdated);
 
         SubscribeLocalEvent<VoreComponent, GetVerbsEvent<Verb>>(OnGetVerbs);
         SubscribeLocalEvent<VoreComponent, OnVoreDoAfter>(OnVoreDoAfter);
@@ -45,12 +48,50 @@ public sealed class VoreSystem : EntitySystem
     }
 
     /// <summary>
-    /// gives the vorecomponent to every entity that has the mindcomponent
-    /// in order to avoid giving every mob it one by one
+    /// gives the mob vore component when they updated their consent to be pred or prey
+    /// in order to avoid giving every mob it one by one, timer needed to get the recent change 
     /// </summary>
-    private void OnMindStartup(EntityUid uid, MindContainerComponent comp, ComponentStartup args){
-        if (HasComp<BodyComponent>(uid))
-            EnsureComp<VoreComponent>(uid);
+    private void OnConsentUpdated(EntityUid uid, ConsentComponent comp, EntityConsentToggleUpdatedEvent args){
+        // only for prey and pred consent changes
+        if (args.ConsentToggleProtoId != isPred && args.ConsentToggleProtoId != isPrey)
+            return;
+        Timer.Spawn(0, () => ApplyVoreConsent(uid));
+    }
+
+    /// <summary>
+    /// same principle as OnConsentUpdated but without the need for checking consent change
+    /// </summary>
+    private void OnConsentStartup(EntityUid uid, ConsentComponent comp, ComponentStartup args){
+        Timer.Spawn(0, () => ApplyVoreConsent(uid));
+    }
+
+    /// <summary>
+    /// gives a mob the vore component if they have selected either pred or prey consent and removes it if they have neither
+    /// </summary>
+    private void ApplyVoreConsent(EntityUid uid){
+        var hasPred = _consentSystem.HasConsent(uid, isPred);
+        var hasPrey = _consentSystem.HasConsent(uid, isPrey);
+        //TODO for digest ...
+
+        Console.WriteLine($"Has Pred Consent: {hasPred}, Has Prey Consent: {hasPrey}");
+
+        /* in case prey is inside a container immediately release them when they turn off prey consent
+        works as an emergency button for the prey*/
+        if (!hasPrey &&
+        _containerSystem.TryGetContainingContainer(uid, out var container) &&
+        container.ID == "vore_container")
+                _containerSystem.Remove(uid, container);
+
+        //give the mob the needed component to be able to see the verbs
+        if (hasPred || hasPrey){
+            // to avoid item ghostroles like trays getting vore components
+            if (HasComp<BodyComponent>(uid))
+                EnsureComp<VoreComponent>(uid);
+        }
+        else{
+            RemComp<VoreComponent>(uid);
+        }
+        //TODO for digest ...
     }
 
     /// <summary>

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -73,8 +73,6 @@ public sealed class VoreSystem : EntitySystem
         var hasPrey = _consentSystem.HasConsent(uid, isPrey);
         //TODO var for digest
 
-        //Console.WriteLine($"IsPred{hasPrey}: IsPrey: {hasPred}");
-
         /* in case prey is inside a container immediately release them when they turn off prey consent
         works as an emergency leave for the prey*/
         if (!hasPrey &&
@@ -131,8 +129,8 @@ public sealed class VoreSystem : EntitySystem
             return;
 
         /* if the user is a pred inside a pred allows them to have interactions with prey inside
-        only if they are in the same container however */ 
-        if (IsInVoreContainer(user, comp) && !IsInVoreContainer(target, comp))
+        only if they are in the same container however (not just same type but literally)*/ 
+        if (!IsValidVoreInteraction(user, target, comp))
             return;
 
         // devour (pred → prey)
@@ -154,7 +152,7 @@ public sealed class VoreSystem : EntitySystem
             });
         }
     }
-        
+
     /// <summary>
     /// used for after selecting to insert into someone or devour
     /// will create a slow popup and warning to give both sides time to react on it
@@ -378,5 +376,32 @@ public sealed class VoreSystem : EntitySystem
     private bool IsInVoreContainer(EntityUid uid, VoreComponent comp){
         return _containerSystem.TryGetContainingContainer(uid, out var container) &&
            container.ID == comp.ContainerId;
+    }
+
+    /// <summary>
+    /// checks if prey is inside a vore container to only allow vore in the same container
+    /// </summary>
+    /// <returns>
+    /// false if only one is in a vore container or if both are inside another container
+    /// </returns>
+    private bool IsValidVoreInteraction(EntityUid user, EntityUid target, VoreComponent comp){
+        var userInVore = IsInVoreContainer(user, comp);
+        var targetInVore = IsInVoreContainer(target, comp);
+
+        // one in vore, one not → invalid
+        if (userInVore != targetInVore)
+            return false;
+
+        // both in vore → must be same stomach instance
+        if (userInVore)
+        {
+            _containerSystem.TryGetContainingContainer(user, out var userContainer);
+            _containerSystem.TryGetContainingContainer(target, out var targetContainer);
+
+            if (userContainer!.Owner != targetContainer!.Owner)
+                return false;
+        }
+
+        return true;
     }
 }

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -56,14 +56,14 @@ public sealed class VoreSystem : EntitySystem
         // only if the updated toggle is prey or pred
         if (args.ConsentToggleProtoId != isPred && args.ConsentToggleProtoId != isPrey)
             return;
-        Timer.Spawn(0, () => ApplyVoreConsent(uid));
+        WaitForUpdates(() => ApplyVoreConsent(uid));
     }
 
     /// <summary>
     /// same principle as OnConsentUpdated but without the need for checking consent change
     /// </summary>
     private void OnConsentStartup(EntityUid uid, ConsentComponent comp, ComponentStartup args){
-        Timer.Spawn(0, () => ApplyVoreConsent(uid));
+        WaitForUpdates(() => ApplyVoreConsent(uid));
     }
 
     /// <summary>
@@ -347,7 +347,7 @@ public sealed class VoreSystem : EntitySystem
     /// </summary>
     private void RemoveStomachImmunities(EntityUid prey){
         // necessary to delay the removal incase of multiple containers
-        Timer.Spawn(0, () =>
+        WaitForUpdates(() =>
         {
             // in case the prey still remains inside another vore container (for example multivore) do not remove the immunities
             if (_containerSystem.TryGetContainingContainer(prey, out var container) &&
@@ -365,5 +365,13 @@ public sealed class VoreSystem : EntitySystem
                 RemComp<RadiationProtectionComponent>(prey);
             RemComp<VoreImmunityTrackerComponent>(prey);
         });
+    }
+
+    /// <summary>
+    /// used to delay certain actions by a tick to make sure all the recent changes have been applied 
+    /// for example such as consent changes or container changes, else will often use old values
+    /// </summary>
+    private void WaitForUpdates(Action action){
+        Timer.Spawn(0, action);
     }
 }

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -52,7 +52,7 @@ public sealed class VoreSystem : EntitySystem
     /// in order to avoid giving every mob it one by one, timer needed to get the recent change 
     /// </summary>
     private void OnConsentUpdated(EntityUid uid, ConsentComponent comp, EntityConsentToggleUpdatedEvent args){
-        // only for prey and pred consent changes
+        // only if the updated toggle is prey or pred
         if (args.ConsentToggleProtoId != isPred && args.ConsentToggleProtoId != isPrey)
             return;
         Timer.Spawn(0, () => ApplyVoreConsent(uid));
@@ -71,12 +71,12 @@ public sealed class VoreSystem : EntitySystem
     private void ApplyVoreConsent(EntityUid uid){
         var hasPred = _consentSystem.HasConsent(uid, isPred);
         var hasPrey = _consentSystem.HasConsent(uid, isPrey);
-        //TODO for digest ...
+        //TODO var for digest
 
-        Console.WriteLine($"Has Pred Consent: {hasPred}, Has Prey Consent: {hasPrey}");
+        //Console.WriteLine($"IsPred{hasPrey}: IsPrey: {hasPred}");
 
         /* in case prey is inside a container immediately release them when they turn off prey consent
-        works as an emergency button for the prey*/
+        works as an emergency leave for the prey*/
         if (!hasPrey &&
         _containerSystem.TryGetContainingContainer(uid, out var container) &&
         container.ID == "vore_container")
@@ -91,7 +91,8 @@ public sealed class VoreSystem : EntitySystem
         else{
             RemComp<VoreComponent>(uid);
         }
-        //TODO for digest ...
+        
+        //TODO component for digest
     }
 
     /// <summary>
@@ -127,13 +128,16 @@ public sealed class VoreSystem : EntitySystem
         if (!TryComp<MindContainerComponent>(target, out var mindContainer) || mindContainer.Mind == null)
             return;
 
-        //no verbs for swallowed people
-        /**TODO
-        making multivore possible. As of now its just a prevention method to avoid giving 
-        Components such as space immunity to the pred
-        */
-        if (_containerSystem.TryGetContainingContainer(user, out var userContainer) && userContainer.ID == "vore_container")
-            return;
+        /* if the user is a pred inside a pred allows them to have prey allow interactions
+        only if they are in the same container however */ 
+        var userInContainer = _containerSystem.TryGetContainingContainer(user, out var userContainer) &&
+                 userContainer.ID == "vore_container";
+        var targetInContainer = _containerSystem.TryGetContainingContainer(target, out var targetContainer) &&
+                   targetContainer.ID == "vore_container";
+        if (userInContainer){
+            if (!targetInContainer || userContainer != targetContainer)
+                return;
+        }
 
         // devour (pred → prey)
         if (_consentSystem.HasConsent(user, isPred)
@@ -144,7 +148,6 @@ public sealed class VoreSystem : EntitySystem
                 Act = () => OnTryVore(user, target)
             });
         }
-
         // insert self (prey → pred)
         if (_consentSystem.HasConsent(user, isPrey)
             && _consentSystem.HasConsent(target, isPred)){
@@ -336,14 +339,22 @@ public sealed class VoreSystem : EntitySystem
     /// to avoid intentional and accidental exploitation
     /// </summary>
     private void RemoveStomachImmunities(EntityUid prey){
-        if (!TryComp<VoreImmunityTrackerComponent>(prey, out var tracker))
-            return;
-        if (tracker.AddedPressure)
-            RemComp<PressureImmunityComponent>(prey);
-        if (tracker.AddedBreathing)
-            RemComp<BreathingImmunityComponent>(prey);
-        if (tracker.AddedTemperature)
-            RemComp<TemperatureImmunityComponent>(prey);
-        RemComp<VoreImmunityTrackerComponent>(prey);
+        // necessary to delay the removal incase of multiple containers
+        Timer.Spawn(0, () =>
+        {
+            // in case the prey still remains inside another vore container (for example multivore) do not remove the immunities
+            if (_containerSystem.TryGetContainingContainer(prey, out var container) &&
+            container.ID == "vore_container")
+                return;
+            if (!TryComp<VoreImmunityTrackerComponent>(prey, out var tracker))
+                return;
+            if (tracker.AddedPressure)
+                RemComp<PressureImmunityComponent>(prey);
+            if (tracker.AddedBreathing)
+                RemComp<BreathingImmunityComponent>(prey);
+            if (tracker.AddedTemperature)
+                RemComp<TemperatureImmunityComponent>(prey);
+            RemComp<VoreImmunityTrackerComponent>(prey);
+        });
     }
 }

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -34,6 +34,9 @@ public sealed class VoreSystem : EntitySystem
     public static readonly ProtoId<ConsentTogglePrototype> isPred = "PredVore";
     public static readonly ProtoId<ConsentTogglePrototype> isPrey = "PreyVore";
 
+    private readonly HashSet<EntityUid> _pendingConsentUpdates = new();
+    private readonly HashSet<EntityUid> _pendingImmunityUpdates = new();
+
     public override void Initialize()
     {
         SubscribeLocalEvent<ConsentComponent, ComponentStartup>(OnConsentStartup);
@@ -48,6 +51,25 @@ public sealed class VoreSystem : EntitySystem
     }
 
     /// <summary>
+    /// To get the most recent values for consent and current container
+    /// </summary>
+    public override void Update(float frameTime){
+        base.Update(frameTime);
+
+        // processing of consent updates
+        foreach (var uid in _pendingConsentUpdates){
+            ApplyVoreConsent(uid);
+        }
+        _pendingConsentUpdates.Clear();
+
+        // processing of immunity updates
+        foreach (var uid in _pendingImmunityUpdates){
+            RemoveStomachImmunities(uid);
+        }
+        _pendingImmunityUpdates.Clear();
+    }
+
+    /// <summary>
     /// gives the mob vore component when they updated their consent to be pred or prey
     /// in order to avoid giving every mob it one by one, timer needed to get the recent change 
     /// </summary>
@@ -55,14 +77,14 @@ public sealed class VoreSystem : EntitySystem
         // only if the updated toggle is prey or pred
         if (args.ConsentToggleProtoId != isPred && args.ConsentToggleProtoId != isPrey)
             return;
-        WaitForUpdates(() => ApplyVoreConsent(uid));
+        _pendingConsentUpdates.Add(uid);
     }
 
     /// <summary>
     /// same principle as OnConsentUpdated but without the need for checking consent change
     /// </summary>
     private void OnConsentStartup(EntityUid uid, ConsentComponent comp, ComponentStartup args){
-        WaitForUpdates(() => ApplyVoreConsent(uid));
+        _pendingConsentUpdates.Add(uid);
     }
 
     /// <summary>
@@ -72,7 +94,7 @@ public sealed class VoreSystem : EntitySystem
         var hasPred = _consentSystem.HasConsent(uid, isPred);
         var hasPrey = _consentSystem.HasConsent(uid, isPrey);
         //TODO var for digest
-
+        
         /* in case prey is inside a container immediately release them when they turn off prey consent
         works as an emergency leave for the prey*/
         if (!hasPrey &&
@@ -190,7 +212,6 @@ public sealed class VoreSystem : EntitySystem
         foreach (var e in container.ContainedEntities){
             if (HasComp<BodyComponent>(e))
                 count++;
-            Console.WriteLine($"Contained Entity: {e}, Count: {count}");
         }
         //as a way to prevent too many entities to be devoured
         if (count >= args.MaxPrey){
@@ -249,7 +270,7 @@ public sealed class VoreSystem : EntitySystem
                 preyComp.IntentionalRelease = true;
 
             _containerSystem.Remove(prey, container);
-            RemoveStomachImmunities(prey, comp);
+            _pendingImmunityUpdates.Add(prey);
             _popupSystem.PopupEntity("You have been released!", prey, prey);
         }
         _popupSystem.PopupEntity("You release your prey.", pred, pred);
@@ -271,7 +292,7 @@ public sealed class VoreSystem : EntitySystem
             return;
         }
 
-        RemoveStomachImmunities(prey, comp);
+        _pendingImmunityUpdates.Add(prey);
         _popupSystem.PopupEntity("You struggle free!", prey, prey);
         _popupSystem.PopupEntity("Your prey escaped!", uid, uid);
     }
@@ -338,33 +359,23 @@ public sealed class VoreSystem : EntitySystem
     /// the removal of the components after leaving a container
     /// to avoid intentional and accidental exploitation
     /// </summary>
-    private void RemoveStomachImmunities(EntityUid prey, VoreComponent comp){
-        // necessary to delay the removal incase of multiple containers
-        WaitForUpdates(() =>
-        {
-            // in case the prey still remains inside another vore container (for example multivore) do not remove the immunities
-            if (IsInVoreContainer(prey, comp))
-                return;
-            if (!TryComp<VoreImmunityTrackerComponent>(prey, out var tracker))
-                return;
-            if (tracker.AddedPressure)
-                RemComp<PressureImmunityComponent>(prey);
-            if (tracker.AddedBreathing)
-                RemComp<BreathingImmunityComponent>(prey);
-            if (tracker.AddedTemperature)
-                RemComp<TemperatureImmunityComponent>(prey);
-            if (tracker.AddedRadiation)
-                RemComp<RadiationProtectionComponent>(prey);
-            RemComp<VoreImmunityTrackerComponent>(prey);
-        });
-    }
+    private void RemoveStomachImmunities(EntityUid prey){
+        if (!TryComp<VoreImmunityTrackerComponent>(prey, out var tracker))
+            return;
+        // if still in a container skip alltogether for example release from multi vore
+        if (TryComp<VoreComponent>(prey, out var comp) && IsInVoreContainer(prey, comp))
+            return;
 
-    /// <summary>
-    /// used to delay certain actions by a tick to make sure all the recent changes have been applied 
-    /// for example such as consent changes or container changes, else will often use old values
-    /// </summary>
-    private void WaitForUpdates(Action action){
-        Timer.Spawn(0, action);
+        if (tracker.AddedPressure)
+            RemComp<PressureImmunityComponent>(prey);
+        if (tracker.AddedBreathing)
+            RemComp<BreathingImmunityComponent>(prey);
+        if (tracker.AddedTemperature)
+            RemComp<TemperatureImmunityComponent>(prey);
+        if (tracker.AddedRadiation)
+            RemComp<RadiationProtectionComponent>(prey);
+        
+        RemComp<VoreImmunityTrackerComponent>(prey);
     }
 
     /// <summary>

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.FloofStation;
 using Content.Shared._Floof.Vore;
 using Content.Shared._Shitmed.Body.Components;
 using Content.Shared._DV.CosmicCult.Components;
+using Content.Server.Radiation.Components;
 using Content.Server.Atmos.Components;
 using Content.Shared.Body.Events;
 using Content.Shared._Common.Consent;
@@ -114,7 +115,7 @@ public sealed class VoreSystem : EntitySystem
                 args.Verbs.Add(new Verb
                 {
                     Text = "Remove Prey",
-                    Act = () => OnTryReleasePrey(target)
+                    Act = () =>TryReleasePrey(target)
                 });
             }
             return;
@@ -128,12 +129,12 @@ public sealed class VoreSystem : EntitySystem
         if (!TryComp<MindContainerComponent>(target, out var mindContainer) || mindContainer.Mind == null)
             return;
 
-        /* if the user is a pred inside a pred allows them to have prey allow interactions
+        /* if the user is a pred inside a pred allows them to have interactions with prey inside
         only if they are in the same container however */ 
         var userInContainer = _containerSystem.TryGetContainingContainer(user, out var userContainer) &&
-                 userContainer.ID == "vore_container";
+            userContainer.ID == "vore_container";
         var targetInContainer = _containerSystem.TryGetContainingContainer(target, out var targetContainer) &&
-                   targetContainer.ID == "vore_container";
+            targetContainer.ID == "vore_container";
         if (userInContainer){
             if (!targetInContainer || userContainer != targetContainer)
                 return;
@@ -145,7 +146,7 @@ public sealed class VoreSystem : EntitySystem
             args.Verbs.Add(new Verb
             {
                 Text = "Devour",
-                Act = () => OnTryVore(user, target)
+                Act = () => TryVore(user, target)
             });
         }
         // insert self (prey → pred)
@@ -154,7 +155,7 @@ public sealed class VoreSystem : EntitySystem
             args.Verbs.Add(new Verb
             {
                 Text = "Insert Self",
-                Act = () => OnTryVore(target, user)
+                Act = () => TryVore(target, user)
             });
         }
     }
@@ -163,7 +164,7 @@ public sealed class VoreSystem : EntitySystem
     /// used for after selecting to insert into someone or devour
     /// will create a slow popup and warning to give both sides time to react on it
     /// </summary>
-    private void OnTryVore(EntityUid user, EntityUid target){
+    private void TryVore(EntityUid user, EntityUid target){
 
         //slow loading bar to avoid instant vore with warning pop ups
         var doAfterArgs = new DoAfterArgs(EntityManager, user, 5f, new OnVoreDoAfter(), user, target: target, used: user)
@@ -245,7 +246,7 @@ public sealed class VoreSystem : EntitySystem
     /// for when the pred removes the prey from their container
     /// will remove the buffs such as space immunity for the target
     /// </summary>
-    private void OnTryReleasePrey(EntityUid pred){
+    private void TryReleasePrey(EntityUid pred){
         var container = _containerSystem.EnsureContainer<Container>(pred, "vore_container");
         var preyList = new List<EntityUid>(container.ContainedEntities);
         //remove everything from people to items
@@ -286,21 +287,21 @@ public sealed class VoreSystem : EntitySystem
     /// in case the user gets gibbed need content emptied including prey+items
     /// </summary>
     private void OnGibbedRemoveContent(EntityUid uid, VoreComponent comp, BeingGibbedEvent args){
-        OnTryReleasePrey(uid);
+        TryReleasePrey(uid);
     }
 
     /// <summary>
     /// in case the user gets destroyed through for example singulo or gibbing
     /// </summary>
     private void OnDestroyedRemoveContent(EntityUid uid, VoreComponent comp, DestructionEventArgs args){
-        OnTryReleasePrey(uid);
+        TryReleasePrey(uid);
     }
 
     /// <summary>
     /// in case of polymorp scenarios such as kitsune release all the content
     /// </summary>
     private void OnPolymorphedTransferContent(EntityUid uid, VoreComponent comp, PolymorphedEvent args){   
-        OnTryReleasePrey(uid);
+        TryReleasePrey(uid);
     }
     
     /// <summary>
@@ -332,6 +333,12 @@ public sealed class VoreSystem : EntitySystem
             EnsureComp<TemperatureImmunityComponent>(prey);
             tracker.AddedTemperature = true;
         }
+        //doesnt fully protect from radiation (given its potassium iodine protection) but will give prey more time to react and escape before radiation starts doing damage (90 percent reduction of radiation damage)
+        if (!HasComp<RadiationProtectionComponent>(prey))
+        {
+            EnsureComp<RadiationProtectionComponent>(prey);
+            tracker.AddedRadiation = true;
+        }
     }
 
     /// <summary>
@@ -354,6 +361,8 @@ public sealed class VoreSystem : EntitySystem
                 RemComp<BreathingImmunityComponent>(prey);
             if (tracker.AddedTemperature)
                 RemComp<TemperatureImmunityComponent>(prey);
+            if (tracker.AddedRadiation)
+                RemComp<RadiationProtectionComponent>(prey);
             RemComp<VoreImmunityTrackerComponent>(prey);
         });
     }

--- a/Content.Server/_Floof/Vore/VoreSystem.cs
+++ b/Content.Server/_Floof/Vore/VoreSystem.cs
@@ -307,8 +307,7 @@ public sealed class VoreSystem : EntitySystem
     private void ApplyStomachImmunities(EntityUid prey, VoreComponent comp){
         /*double check making sure they are inside the container
         should prevent possible exploitation of the system*/
-        if (!_containerSystem.TryGetContainingContainer(prey, out var container) ||
-        container.ID != comp.ContainerId)
+        if (!IsInVoreContainer(prey, comp))
            return;
 
         var tracker = EnsureComp<VoreImmunityTrackerComponent>(prey);
@@ -329,7 +328,8 @@ public sealed class VoreSystem : EntitySystem
             EnsureComp<TemperatureImmunityComponent>(prey);
             tracker.AddedTemperature = true;
         }
-        //doesnt fully protect from radiation (given its potassium iodine protection) but will give prey more time to react and escape before radiation starts doing damage (90 percent reduction of radiation damage)
+        /* doesnt fully protect from radiation (given its potassium iodine protection meaning 90 percent reduction of radiation damage) 
+        but will give prey more time to react and escape before radiation starts doing damage */
         if (!HasComp<RadiationProtectionComponent>(prey))
         {
             EnsureComp<RadiationProtectionComponent>(prey);

--- a/Content.Shared/_Floof/Vore/VoreComponent.cs
+++ b/Content.Shared/_Floof/Vore/VoreComponent.cs
@@ -8,9 +8,14 @@ namespace Content.Shared._Floof.Vore;
 public sealed partial class VoreComponent : Component
 {
     /// <summary>
+    /// The ID of the container used for vore mechanics.
+    /// </summary>
+    //TODO later include customizable containers for different vore types
+    [DataField("containerId")]
+    public string ContainerId = "vore_container";
+    /// <summary>
     /// Set to true when the pred intentionally releases this entity to suppress escape popup
     /// </summary>
-    [DataField]
     public bool IntentionalRelease = false;
 }
 [Serializable, NetSerializable]

--- a/Content.Shared/_Floof/Vore/VoreComponent.cs
+++ b/Content.Shared/_Floof/Vore/VoreComponent.cs
@@ -31,4 +31,5 @@ public sealed partial class VoreImmunityTrackerComponent : Component
     public bool AddedPressure;
     public bool AddedBreathing;
     public bool AddedTemperature;
+    public bool AddedRadiation;
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Reworked the voresystem and component plus new feature of handling verbs inside containers

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Massive Reduction of who gets the components, increasing code longevity, better handling of storage

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
1. VoreComponent will now be assigned during both consent changes and startup
-> meaning no more getting that component if you have neither prey or pred on!
-> small timer function needed to get the most recent values
2. Renamed a couple of methods based on if they are subscription (On[...]), or not
-> small change but should now make code slightly easier to read in my opinion
3. Included radiation immunity
-> based on the component function its potassium iodine
-> sadly only gives 90 percent rad immunity cause of dv but should give prey time to react and act
4. RemoveStomach method now checks if someone is still in a vore container
-> in case a prey gets released but still ends up inside another pred such as during multi vore
-> small timer function needed to get the most recent values
5. Vore inside a container is now possible (verbs show up) 
-> only works however if both entities involved are inside the same container
-> else method will just return
-> ensureentitymanager should prevent issues by ejecting them from the initial container
6. Reworked vorecomponents
-> IntentionalRelease doesn't really need a Datafield since its shortlived
-> vore container is now a var inside with all the references patched which will be useful later for multi containers
7. Helper methods added
-> Waitforupdate to create recent values (else for example consent will use old values)
-> IsInVoreContainer (line has been used a lot so now its put there for code readability)
-> IsValidVoreInteraction to check if both preys are in the same vore container
8. During consent check the prey can be ejected of a container if they turned off prey toggle
-> acts as a emergency leave (is inside applyvoreconsent as it handles the change from prey to notprey)

## Media
<details> <summary><h3>Click to show</h3></summary> <p>
<img width="544" height="433" alt="Screenshot 2026-04-29 190728" src="https://github.com/user-attachments/assets/27425be2-afd2-4ce1-b42d-a05aca981df7" />

<!-- This is default collapsed, readers click to expand it and see all your media -->


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Patched handling components with voresystem
