### PR TITLE
Ore Boxes Store Artifact Frags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Salvage/ore_bag.yml
@@ -26,7 +26,7 @@
     areaInsert: true
     whitelist:
       tags:
-        - ArtifactFragment
+        #- ArtifactFragment #Euphoria - gave ArtifactFragment the 'ore' tag, which is the whitelist for these containers
         - Ore
   - type: Dumpable
   # Begin DeltaV Additions: toggle magnet from White Dream

--- a/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_xenoartifacts.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Xenoarchaeology/item_xenoartifacts.yml
@@ -125,6 +125,7 @@
   - type: Tag
     tags:
     - ArtifactFragment
+    - Ore #Euphoria - ore crate/bag whitelist
   - type: Extractable
     juiceSolution:
       reagents:


### PR DESCRIPTION
## About the PR
Ore boxes now store artifact fragments.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="472" height="189" alt="image" src="https://github.com/user-attachments/assets/5ec4d009-8548-4f27-b9a8-e89e35b75b83" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Ore Boxes can now hold artifact fragments.
