### PR TITLE
Increased Time Between Oracle Yells

### DIFF
--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleComponent.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleComponent.cs
@@ -21,7 +21,7 @@ public sealed partial class OracleComponent : Component
     public float BarkAccumulator;
 
     [DataField("barkTime")]
-    public TimeSpan BarkTime = TimeSpan.FromMinutes(1);
+    public TimeSpan BarkTime = TimeSpan.FromMinutes(3); //Euphoria - 3ish barks per request.
 
     //Euphoria
     [DataField]

--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleComponent.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleComponent.cs
@@ -24,7 +24,7 @@ public sealed partial class OracleComponent : Component
     public TimeSpan BarkTime = TimeSpan.FromMinutes(1);
 
     [DataField]
-    public OracleBarkType BarkType = OracleBarkType.Never;
+    public OracleBarkType BarkType = OracleBarkType.Timed;
 
     [DataField("rejectAccumulator")]
     public float RejectAccumulator;

--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleComponent.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleComponent.cs
@@ -23,6 +23,7 @@ public sealed partial class OracleComponent : Component
     [DataField("barkTime")]
     public TimeSpan BarkTime = TimeSpan.FromMinutes(1);
 
+    //Euphoria
     [DataField]
     public OracleBarkType BarkType = OracleBarkType.Timed;
 


### PR DESCRIPTION
## About the PR
Oracle now yells less frequently; about 3 times per request.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="435" height="133" alt="image" src="https://github.com/user-attachments/assets/43bf7425-0a42-4b50-ad44-dce6bf9f377e" />
This counts the seconds; setting to 180 causes the Oracle to yell.

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Oracle now yells less frequently; about 3 times per request.
