### PR TITLE
Fixes artifact crusher making duplicate sounds

### DIFF
--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);
         crusher.CrushEndTime = _timing.CurTime + crusher.CrushDuration;
-        crusher.CrushingSoundEntity = AudioSystem.PlayPvs(crusher.CrushingSound, ent)?.Entity;
+        crusher.CrushingSoundEntity = AudioSystem.PlayPredicted(crusher.CrushingSound, ent, user)?.Entity ?? crusher.CrushingSoundEntity; //Euphoria - porting sound fix from WizDen commit #42406
         _appearance.SetData(ent, ArtifactCrusherVisuals.Crushing, true);
         Dirty(ent, ent.Comp1);
     }
@@ -136,8 +136,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
 
         if (early)
         {
-            AudioSystem.Stop(ent.Comp.CrushingSoundEntity);
-            ent.Comp.CrushingSoundEntity = null;
+            ent.Comp.CrushingSoundEntity = AudioSystem.Stop(ent.Comp.CrushingSoundEntity); //Euphoria - porting sound fix from WizDen commit #42406
         }
 
         Dirty(ent, ent.Comp);

--- a/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
+++ b/Content.Shared/Xenoarchaeology/Equipment/SharedArtifactCrusherSystem.cs
@@ -121,7 +121,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         crusher.Crushing = true;
         crusher.NextSecond = _timing.CurTime + TimeSpan.FromSeconds(1);
         crusher.CrushEndTime = _timing.CurTime + crusher.CrushDuration;
-        crusher.CrushingSoundEntity = AudioSystem.PlayPredicted(crusher.CrushingSound, ent, user)?.Entity ?? crusher.CrushingSoundEntity; //Euphoria - porting sound fix from WizDen commit #42406
+        crusher.CrushingSoundEntity = AudioSystem.PlayPredicted(crusher.CrushingSound, ent, user)?.Entity ?? crusher.CrushingSoundEntity;
         _appearance.SetData(ent, ArtifactCrusherVisuals.Crushing, true);
         Dirty(ent, ent.Comp1);
     }
@@ -135,9 +135,7 @@ public abstract class SharedArtifactCrusherSystem : EntitySystem
         _appearance.SetData(ent, ArtifactCrusherVisuals.Crushing, false);
 
         if (early)
-        {
-            ent.Comp.CrushingSoundEntity = AudioSystem.Stop(ent.Comp.CrushingSoundEntity); //Euphoria - porting sound fix from WizDen commit #42406
-        }
+            ent.Comp.CrushingSoundEntity = AudioSystem.Stop(ent.Comp.CrushingSoundEntity);
 
         Dirty(ent, ent.Comp);
     }


### PR DESCRIPTION
## About the PR
Fixes the artifact crusher spamming the 'start crushing' sound.

## Technical details
Cherry-pick of upstream commit.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
I assume this doesn't count because I'm porting from upstream?

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Artifact crusher is less noisy; no longer spams the 'hydraulic press' sound.
