### PR TITLE
Reduced Minimum Players Required for Devil

### DIFF
--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -4,7 +4,7 @@
   components:
   - type: DevilRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 3 # Euphoria - Was 15
   - type: AntagObjectives
     objectives:
     - DevilContractObjective
@@ -15,7 +15,7 @@
     definitions:
     - prefRoles: [ Devil ]
       max: 1
-      playerRatio: 40
+      playerRatio: 15 # Euphoria - Was 40
       mindRoles:
       - DevilMindRole
       startingGear: DevilStartingGear

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -15,7 +15,7 @@
     definitions:
     - prefRoles: [ Devil ]
       max: 1
-      playerRatio: 15 # Euphoria - Was 40
+      playerRatio: 40
       mindRoles:
       - DevilMindRole
       startingGear: DevilStartingGear


### PR DESCRIPTION
## About the PR
Reduced Minimum Players Required for Devil.

## Why / Balance
Mostly just people not readying up.

**Changelog**
:cl:
- tweak: Adjusted Devil to require less players to be readied up.
