### PR TITLE
Make "spawn here" verb load traits and loadouts

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -157,8 +157,15 @@ namespace Content.Server.Administration.Systems
 
                             var stationUid = _stations.GetOwningStation(args.Target);
 
+                            var job = "Passenger"; // Floofstation
                             var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
-                            var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
+                            var mobUid = _spawning.SpawnPlayerMob(coords.Value, job, profile, stationUid);
+
+                            // Floofstation - raise playerspawcomplete so traits and the like can load.
+                            var targetSession = targetActor.PlayerSession; // Note: PlayerSession gets set to null after TransferTo. Mind the side-effects.
+                            RaiseLocalEvent(mobUid,
+                                new PlayerSpawnCompleteEvent(mobUid, targetSession, job, true, true, 0, stationUid ?? EntityUid.Invalid, profile),
+                                true);
 
                             if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
                                 _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);


### PR DESCRIPTION
## About the PR
This sucks. Only loads passenger gear and traits cus there's no reasonable way to prompt the admin for a job when using verbs.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

https://github.com/user-attachments/assets/5ebc24a0-39d9-41c6-a477-ddd0784ad044

</p></details>

**Changelog**
:cl:
- fix: The "spawn here" admin verb now loads the loadouts & traits from the player's profile (while assuming Passenger as the job).