### PR TITLE
Increase alcohol vomiting threshold

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -207,7 +207,7 @@
           type: [ Dwarf ]
           inverted: true
       - !type:Drunk
-        boozePower: 2
+        boozePower: 1 # Euphoria - People getting drunk too fast
 
 - type: reagent
   id: Gin

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -201,13 +201,13 @@
         conditions:
         - !type:ReagentCondition
           reagent: Ethanol
-          min: 12
+          min: 25
         # dwarves immune to vomiting from alcohol
         - !type:MetabolizerTypeCondition
           type: [ Dwarf ]
           inverted: true
       - !type:Drunk
-        boozePower: 1 # Euphoria - People getting drunk too fast
+        boozePower: 2
 
 - type: reagent
   id: Gin


### PR DESCRIPTION
## About the PR
~~Reduces the "BoozePower" of Ethanol from 2 to 1, allowing people to drink more before their vision is blurred.
This does not change the damage threshold.~~

Edit 2026-08-13: now this PR only doubles the vomiting threshold.

## Why / Balance
~~So, I heard some complains about slimes being able to drink an Op's Shine before the rebase without getting drunk, but it makes em drunk in 1 glass now. But nothing's really changed other then some sort of DV calculation which is impossible to find in the C# code. So, instead of fucking with C#, I've halved the "Drunkness" buildup so people are less lightweights, foreseen consequences will probably be more alcohol poisoning tho. ~~

**Changelog**
:cl:
- tweak: Doubled the vomiting threshold from alcohol, so no more getting sloshed in 1 glass, now it's 2 glasses.
