### PR TITLE
Add saltern to rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -29,3 +29,4 @@
   - Train # Floof - Maintainer Dunrab
   - Amber # Floof
   - Getaway # Floof - Maintainer Dunrab
+  - Saltern # Floof


### PR DESCRIPTION
## About the PR
It was missed. 

**Changelog**
:cl:
- fix: Saltern should appear in rotation again.