### PR TITLE
Un-barotraumad silicon

### DIFF
--- a/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Player/silicon_base.yml
@@ -179,11 +179,11 @@
       damage:
         types:
           Heat: 0 # GoobStation: Replaced fire damage with overheating shutdown
-    - type: Barotrauma # DeltaV - uncommented
-      damage:
-        types:
-          Blunt: 0.5 # DeltaV - was 0.28
-          Heat: 0.25 # DeltaV
+    # - type: Barotrauma # DeltaV - uncommented
+    #   damage:
+    #     types:
+    #       Blunt: 0.5 # DeltaV - was 0.28
+    #       Heat: 0.25 # DeltaV
     - type: Identity
     #  soundHit:
     #    path: /Audio/Effects/metalbreak.ogg


### PR DESCRIPTION
## About the PR
Removes IPC barotrauma component (why was this a DV change?). Pre rebase didnt have it, it was never an issue so lets make it like that again

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Commented out barotrauma for IPCs