### PR TITLE
fixes telepads

### DIFF
--- a/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
@@ -65,7 +65,7 @@ public sealed partial class CargoSystem
         }
     }
 
-    //euphora edit start
+    //euphoria edit start
     private IEnumerable<Entity<CargoOrderConsoleComponent>> GetLinkedConsoles(Entity<CargoTelepadComponent> telepad)
     {
         if (!TryComp<DeviceLinkSinkComponent>(telepad, out var sinkComponent))
@@ -171,11 +171,7 @@ public sealed partial class CargoSystem
 
         foreach (var order in ent.Comp.CurrentOrders)
         {
-            // We use the first console for the account info if multiple are linked when the telepad shuts down.
-            // todo: this causes the order slip to use the wrong account... but nothing else.
-            //       and at this point i'd rather leave in this cosmetic bug than spend another day working on this.
-            //       let the future sort it out.
-            TryFulfillOrder((station, data), consoles[0].Comp.Account, order, db); //euphoria
+            TryFulfillOrder((station, data), order.Account, order, db); //euphoria; why didn't the order use its own account???
         }
     }
 

--- a/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
@@ -40,9 +40,18 @@ public sealed partial class CargoSystem
             if (_station.GetOwningStation(uid, xform) != args.Station)
                 continue;
 
-            // todo cannot be fucking asked to figure out device linking rn but this shouldn't just default to the first port.
-            if (!TryGetLinkedConsole((uid, tele), out var console) ||
-                console.Value.Owner != args.OrderConsole.Owner)
+            // Check if any linked console matches the order console
+            var isLinked = false;
+            foreach (var console in GetLinkedConsoles(uid))
+            {
+                if (console.Owner == args.OrderConsole.Owner)
+                {
+                    isLinked = true;
+                    break;
+                }
+            }
+
+            if (!isLinked)
                 continue;
 
             for (var i = 0; i < args.Order.OrderQuantity; i++)
@@ -56,19 +65,16 @@ public sealed partial class CargoSystem
         }
     }
 
-    private bool TryGetLinkedConsole(Entity<CargoTelepadComponent> ent,
-        [NotNullWhen(true)] out Entity<CargoOrderConsoleComponent>? console)
+    private IEnumerable<Entity<CargoOrderConsoleComponent>> GetLinkedConsoles(EntityUid uid)
     {
-        console = null;
-        if (!TryComp<DeviceLinkSinkComponent>(ent, out var sinkComponent) ||
-            sinkComponent.LinkedSources.FirstOrNull() is not { } linked)
-            return false;
+        if (!TryComp<DeviceLinkSinkComponent>(uid, out var sinkComponent))
+            yield break;
 
-        if (!TryComp<CargoOrderConsoleComponent>(linked, out var consoleComp))
-            return false;
-
-        console = (linked, consoleComp);
-        return true;
+        foreach (var linked in sinkComponent.LinkedSources)
+        {
+            if (TryComp<CargoOrderConsoleComponent>(linked, out var consoleComp))
+                yield return (linked, consoleComp);
+        }
     }
 
 
@@ -98,7 +104,7 @@ public sealed partial class CargoSystem
                 continue;
             }
 
-            if (comp.CurrentOrders.Count == 0 || !TryGetLinkedConsole((uid, comp), out var console))
+            if (comp.CurrentOrders.Count == 0 || !GetLinkedConsoles(uid).Any())
             {
                 comp.Accumulator += comp.Delay;
                 continue;
@@ -143,12 +149,15 @@ public sealed partial class CargoSystem
             !TryComp<StationDataComponent>(station, out var data))
             return;
 
-        if (!TryGetLinkedConsole(ent, out var console))
+        var consoles = GetLinkedConsoles(ent).ToList();
+        if (consoles.Count == 0)
             return;
 
         foreach (var order in ent.Comp.CurrentOrders)
         {
-            TryFulfillOrder((station, data), console.Value.Comp.Account, order, db);
+            // We use the first console for the account info if multiple are linked during shutdown.
+            // This is a fallback; so just picking one is fine.
+            TryFulfillOrder((station, data), consoles[0].Comp.Account, order, db);
         }
     }
 

--- a/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
@@ -42,7 +42,7 @@ public sealed partial class CargoSystem
 
             // Check if any linked console matches the order console
             var isLinked = false;
-            foreach (var console in GetLinkedConsoles(uid))
+            foreach (var console in GetLinkedConsoles((uid, tele)))
             {
                 if (console.Owner == args.OrderConsole.Owner)
                 {
@@ -65,15 +65,30 @@ public sealed partial class CargoSystem
         }
     }
 
-    private IEnumerable<Entity<CargoOrderConsoleComponent>> GetLinkedConsoles(EntityUid uid)
+    private IEnumerable<Entity<CargoOrderConsoleComponent>> GetLinkedConsoles(Entity<CargoTelepadComponent> telepad)
     {
-        if (!TryComp<DeviceLinkSinkComponent>(uid, out var sinkComponent))
+        //Get a 'DeviceLinkSinkComponent', or end the function early if we can't.
+        if (!TryComp<DeviceLinkSinkComponent>(telepad, out var sinkComponent))
             yield break;
 
         foreach (var linked in sinkComponent.LinkedSources)
         {
-            if (TryComp<CargoOrderConsoleComponent>(linked, out var consoleComp))
-                yield return (linked, consoleComp);
+            if (!TryComp<CargoOrderConsoleComponent>(linked, out var consoleComp) ||
+                !TryComp<DeviceLinkSourceComponent>(linked, out var sourceComponent))
+            {
+                continue;
+            }
+
+            var links = _linker.GetLinks(linked, telepad.Owner, sourceComponent);
+
+            foreach (var (_, sinkPort) in links)
+            {
+                if (sinkPort == telepad.Comp.ReceiverPort)
+                {
+                    yield return (linked, consoleComp);
+                    break;
+                }
+            }
         }
     }
 
@@ -104,7 +119,7 @@ public sealed partial class CargoSystem
                 continue;
             }
 
-            if (comp.CurrentOrders.Count == 0 || !GetLinkedConsoles(uid).Any())
+            if (comp.CurrentOrders.Count == 0 || !GetLinkedConsoles((uid, comp)).Any())
             {
                 comp.Accumulator += comp.Delay;
                 continue;

--- a/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
+++ b/Content.Server/Cargo/Systems/CargoSystem.Telepad.cs
@@ -40,7 +40,7 @@ public sealed partial class CargoSystem
             if (_station.GetOwningStation(uid, xform) != args.Station)
                 continue;
 
-            // Check if any linked console matches the order console
+            // euphoria edit start
             var isLinked = false;
             foreach (var console in GetLinkedConsoles((uid, tele)))
             {
@@ -51,7 +51,7 @@ public sealed partial class CargoSystem
                 }
             }
 
-            if (!isLinked)
+            if (!isLinked) //euphoria edit end
                 continue;
 
             for (var i = 0; i < args.Order.OrderQuantity; i++)
@@ -65,9 +65,9 @@ public sealed partial class CargoSystem
         }
     }
 
+    //euphora edit start
     private IEnumerable<Entity<CargoOrderConsoleComponent>> GetLinkedConsoles(Entity<CargoTelepadComponent> telepad)
     {
-        //Get a 'DeviceLinkSinkComponent', or end the function early if we can't.
         if (!TryComp<DeviceLinkSinkComponent>(telepad, out var sinkComponent))
             yield break;
 
@@ -91,6 +91,7 @@ public sealed partial class CargoSystem
             }
         }
     }
+    //euphoria edit end
 
 
     private void UpdateTelepad(float frameTime)
@@ -119,7 +120,7 @@ public sealed partial class CargoSystem
                 continue;
             }
 
-            if (comp.CurrentOrders.Count == 0 || !GetLinkedConsoles((uid, comp)).Any())
+            if (comp.CurrentOrders.Count == 0 || !GetLinkedConsoles((uid, comp)).Any()) //euphoria
             {
                 comp.Accumulator += comp.Delay;
                 continue;
@@ -164,15 +165,17 @@ public sealed partial class CargoSystem
             !TryComp<StationDataComponent>(station, out var data))
             return;
 
-        var consoles = GetLinkedConsoles(ent).ToList();
-        if (consoles.Count == 0)
+        var consoles = GetLinkedConsoles(ent).ToList(); //euphoria
+        if (consoles.Count == 0) //euphoria
             return;
 
         foreach (var order in ent.Comp.CurrentOrders)
         {
-            // We use the first console for the account info if multiple are linked during shutdown.
-            // This is a fallback; so just picking one is fine.
-            TryFulfillOrder((station, data), consoles[0].Comp.Account, order, db);
+            // We use the first console for the account info if multiple are linked when the telepad shuts down.
+            // todo: this causes the order slip to use the wrong account... but nothing else.
+            //       and at this point i'd rather leave in this cosmetic bug than spend another day working on this.
+            //       let the future sort it out.
+            TryFulfillOrder((station, data), consoles[0].Comp.Account, order, db); //euphoria
         }
     }
 


### PR DESCRIPTION
## About the PR
Telepads now accept orders from ALL linked devices, instead of just the last linked device.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->

https://github.com/user-attachments/assets/37569a53-c449-43f9-afc9-14d915102954
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Telepads now receive orders from all multitool-linked devices!
