### PR TITLE
Banana cream Pie

### DIFF
--- a/Resources/Locale/en-US/_Floof/reagents/meta/consumable/drink/drinks.ftl
+++ b/Resources/Locale/en-US/_Floof/reagents/meta/consumable/drink/drinks.ftl
@@ -9,4 +9,8 @@ reagent-desc-boykisser-energy = Bubbly, bright magenta, and smells suspiciously 
 
 reagent-name-VB-beer = Viktoria Bitter
 reagent-desc-VB-beer = Bubbly, hazy light golden, with a distinct bitterness that reminds you of Australia.
-flavor-complex-vbbeer = like you've finally sat down after a long hot days work at your blue collar 9 to 5 job
+flavor-complex-vbbeer = like you've finally sat down after a long hot days work at your blue collar 9 to 5 job.
+
+reagent-name-bananacreampie = Banana Cream
+reagent-desc-bananacreampie = A rich and thick pale golden cream, with a strong Gros Michel banana flavor.
+flavor-complex-bananacreampie = like dreams of a banana republic, with a hint of harmbatoning clowns.

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -211,6 +211,13 @@
       reagents:
       - ReagentId: LiquidPie
         Quantity: 2
+  - type: SolutionContainerManager # Euphoria - Changed what's inside a banana cream pie to be cream
+    solutions:
+      food:
+        maxVol: 15
+        reagents: 
+        - ReagentId: BananaCreamPie
+          Quantity: 12.5
 # Tastes like pie, cream, banana.
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/Baked/pie.yml
@@ -178,6 +178,13 @@
     - Pie
   - type: SliceableFood
     slice: FoodPieBananaCreamSlice
+  - type: SolutionContainerManager # Euphoria - Changed what's inside a banana cream pie to be cream
+    solutions:
+      food:
+        maxVol: 60
+        reagents: 
+        - ReagentId: BananaCreamPie
+          Quantity: 50
 
 - type: entity
   name: slice of banana cream pie

--- a/Resources/Prototypes/_Floof/Flavors/flavors.yml
+++ b/Resources/Prototypes/_Floof/Flavors/flavors.yml
@@ -382,4 +382,8 @@
   id: harpysnowfall
   flavorType: Complex
   description: flavor-complex-harpysnowfall
-  
+
+- type: flavor
+  id: bananacreampie
+  flavorType: Complex
+  description: flavor-complex-bananacreampie

--- a/Resources/Prototypes/_Floof/Reagents/Drinks/drinks.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Drinks/drinks.yml
@@ -101,8 +101,8 @@
 
 - type: reagent # You may ask me why, but I got sick of seeing green come of cream pies.
   id: BananaCreamPie
+  parent: Nutriment
   name: reagent-name-bananacreampie
-  group: Foods
   desc: reagent-desc-bananacreampie
   physicalDesc: reagent-physical-desc-creamy
   flavor: bananacreampie

--- a/Resources/Prototypes/_Floof/Reagents/Drinks/drinks.yml
+++ b/Resources/Prototypes/_Floof/Reagents/Drinks/drinks.yml
@@ -98,3 +98,27 @@
       - !type:AdjustReagent # Will find a way to make it so only someone with the Australian Accent component heals later
         reagent: Ichor
         amount: 0.2
+
+- type: reagent # You may ask me why, but I got sick of seeing green come of cream pies.
+  id: BananaCreamPie
+  name: reagent-name-bananacreampie
+  group: Foods
+  desc: reagent-desc-bananacreampie
+  physicalDesc: reagent-physical-desc-creamy
+  flavor: bananacreampie
+  color: "#fffdd0"
+  recognizable: true
+  metabolisms:
+    Food:
+      effects:
+      - !type:SatiateHunger
+      - !type:SatiateThirst
+        factor: 0.5
+      - !type:HealthChange # I folded vitamins into it
+        probability: 0.5
+        damage:
+          groups:
+            Brute: -0.1 # For reference vitamins are -0.5
+            Burn: -0.1
+      - !type:ModifyBleed
+        amount: -0.1 # 0.25


### PR DESCRIPTION
## About the PR
Adds Reagent Banana Cream
Replaces Banana Cream Pie's Reagents with Banana Cream

## Why / Balance
So, when someone gets hit by a banana cream pie currently.
They leave a pile of green nutriment, and that doesn't feel very pie like.
So I've created a new chemical that goes into the banana cream pie (the only pie that can be thrown) that is the color of banana cream.

No more green flood from pies, it will now be banana cream.

<img width="540" height="467" alt="image" src="https://github.com/user-attachments/assets/0c767fd5-a873-40cf-afd4-c91481632ea1" />


## Technical details
First I copy Nutriment, place it in our namespace so there will be no issues later.
Then I create a replacement to nutriment with a tiny bit of vitamins folded in.
Write flavor (banana) text for the pie.
Then I add SolutionContainerManager to the pie itself, to overwrite the original solution. As well as the pie slice.

**Changelog**
:cl:
- tweak: Changed the chemicals inside a Banana Cream Pie, it will now look tasty instead of green.
