### PR TITLE
Svalinn + Speed Boots

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/science.yml
@@ -61,6 +61,7 @@
   # End DeltaV Removals
   - WeaponGauntletGorilla
   - WeaponMicrowaveEmitter # DeltaV - Microwave emitter
+  - WeaponLaserSvalinn # Euphoria
 
 # Only contains parts for making basic modular grenades, no actual explosives
 - type: latheRecipePack

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -150,6 +150,7 @@
   - WeaponLaserCarbine
   - WeaponXrayCannon
   - WeaponTemperatureGun
+  - WeaponLaserSvalinn # Euphoria
 
 - type: latheRecipePack
   id: SecurityDisablers

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -285,7 +285,6 @@
     Plastic: 500
 
 - type: latheRecipe
-  abstract: true # DeltaV - removed svalinn
   parent: BaseWeaponRecipeSidearm
   id: WeaponLaserSvalinn
   result: WeaponLaserSvalinn

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -242,15 +242,3 @@
   - ShuttleGunDusterCircuitboard
   technologyPrerequisites:
   - BasicShuttleArmament
-
-- type: technology # Euphoria - It's Back
-  id: ExperimentalBatteryAmmo
-  name: research-technology-experimental-battery-ammo
-  icon:
-    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
-    state: icon
-  discipline: Arsenal
-  tier: 3
-  cost: 15000
-  recipeUnlocks:
-  - WeaponLaserSvalinn

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -243,7 +243,7 @@
   technologyPrerequisites:
   - BasicShuttleArmament
 
-- type: technology # DeltaV - Removed for only causing issues
+- type: technology # Euphoria - It's Back
   id: ExperimentalBatteryAmmo
   name: research-technology-experimental-battery-ammo
   icon:

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -213,7 +213,6 @@
   - WeaponAdvancedLaser
   - PortableRecharger
   - WeaponEnergyGunAdvanced # DeltaV - Advanced Energy Gun
-  - WeaponLaserSvalinn # Euphoria - Bought Svalinn back
 
 - type: technology
   id: ThermalWeaponry
@@ -243,3 +242,15 @@
   - ShuttleGunDusterCircuitboard
   technologyPrerequisites:
   - BasicShuttleArmament
+
+- type: technology # DeltaV - Removed for only causing issues
+  id: ExperimentalBatteryAmmo
+  name: research-technology-experimental-battery-ammo
+  icon:
+    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - WeaponLaserSvalinn

--- a/Resources/Prototypes/Research/arsenal.yml
+++ b/Resources/Prototypes/Research/arsenal.yml
@@ -213,6 +213,7 @@
   - WeaponAdvancedLaser
   - PortableRecharger
   - WeaponEnergyGunAdvanced # DeltaV - Advanced Energy Gun
+  - WeaponLaserSvalinn # Euphoria - Bought Svalinn back
 
 - type: technology
   id: ThermalWeaponry

--- a/Resources/Prototypes/Research/civilianservices.yml
+++ b/Resources/Prototypes/Research/civilianservices.yml
@@ -224,18 +224,17 @@
 
 # Tier 3
 
-# DeltaV - Kill Speedboots
-# - type: technology
-#   id: QuantumFiberWeaving
-#   name: research-technology-quantum-fiber-weaving
-#   icon:
-#     sprite: Clothing/Shoes/Boots/speedboots.rsi
-#     state: icon
-#   discipline: CivilianServices
-#   tier: 3
-#   cost: 10000
-#   recipeUnlocks:
-#   - ClothingShoesBootsSpeed
+- type: technology # Euphoria Speed Boots Back
+  id: QuantumFiberWeaving
+  name: research-technology-quantum-fiber-weaving
+  icon:
+    sprite: Clothing/Shoes/Boots/speedboots.rsi
+    state: icon
+  discipline: CivilianServices
+  tier: 3
+  cost: 10000
+  recipeUnlocks:
+  - ClothingShoesBootsSpeed
 
 - type: technology
   id: BluespaceChemistry

--- a/Resources/Prototypes/_Floof/Research/research.yml
+++ b/Resources/Prototypes/_Floof/Research/research.yml
@@ -1,0 +1,14 @@
+# File for Euphoria Research
+
+# Arsenal
+- type: technology # DV removed this
+  id: ExperimentalBatteryAmmo
+  name: research-technology-experimental-battery-ammo
+  icon:
+    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 3
+  cost: 15000
+  recipeUnlocks:
+  - WeaponLaserSvalinn


### PR DESCRIPTION
## About the PR
This PR brings the Svalinn laser pistol back after DV disabled it.

I wanted to nerf the laser (using a microreactor), but unlike the old codebase, the laser damage isn't tied to the cell anymore.

Post - Speed Boots are also back.

## Why / Balance
According to this changelog, DV changed it in Feb 3rd, and disabling the Svalinn due to unspecified problems.

**Changelog**
:cl:
- add: Brings back the Svalinn Laser Pistol that DV disabled.
- add: Brings back the Speed Boots.
