### PR TITLE
Rhino pill fix

### DIFF
--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -78,7 +78,7 @@
   - type: SolutionContainerManager
     solutions:
       stomach:
-        maxVol: 40
+        maxVol: 50 # Euphoria
       food:
         maxVol: 5
         reagents:

--- a/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Body/Organs/shadowkin.yml
@@ -70,7 +70,7 @@
   - type: SolutionContainerManager
     solutions:
       stomach:
-        maxVol: 40
+        maxVol: 50
       food:
         maxVol: 5
         reagents:


### PR DESCRIPTION
## About the PR
Increases the consumption cap of Animal and Shadowkin stomachs to 50.

## Why / Balance
Turns out, Harpies and Shadowkin can't eat the Gas Station Rhino Pill.

**Changelog**
:cl:
- fix: Fixed Harpies and Shadekin being unable to eat Space Station Rhino Pills. (for better or worse)