### PR TITLE
Make hellspawn not die to a single dispel

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/artifact.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/artifact.yml
@@ -27,11 +27,10 @@
       types:
         Blunt: 35
         Structural: 70
-  - type: Dispellable
   - type: DamageOnDispel
     damage:
       types:
-        Heat: 100
+        Holy: 100
   - type: Body
     prototype: Goliath
   - type: LanguageSpeaker


### PR DESCRIPTION
## About the PR
Yeah. 100 holy/hit. DispellableComponent just deletes the hellspawn on hit. Very descriptive component name.

**Changelog**
:cl:
- fix: Dispel should no longer kill the lesser hellspawn.