### PR TITLE
Hardsuit, Softsuit, and Helmet renames and redescribes. 

### DIFF
--- a/Resources/Locale/en-US/_Floof/prototypes/entities/clothing/head/hardsuit-helmets.ftl
+++ b/Resources/Locale/en-US/_Floof/prototypes/entities/clothing/head/hardsuit-helmets.ftl
@@ -1,2 +1,2 @@
-ent-ClothingHeadHelmetHardsuitSecTech = FPA-41e helmet
+ent-ClothingHeadHelmetHardsuitSecTech = FPA-41SE Helmet
     .desc = A sturdy helmet with specialized lenses to protect the wearer's eyes from arc flashes.

--- a/Resources/Locale/en-US/_Floof/prototypes/entities/clothing/outerClothing/hardsuits.ftl
+++ b/Resources/Locale/en-US/_Floof/prototypes/entities/clothing/outerClothing/hardsuits.ftl
@@ -1,3 +1,2 @@
-ent-ClothingOuterHardsuitSecTech = FPA-41e - "Araa" tacsuit
-    .desc = A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory, used by engineers in the Nanotrasen security force.
-    The tags on the suit indicate that its specially rated for radiation protection. It feels heavy.
+ent-ClothingOuterHardsuitSecTech = FPA-41SE - "Araa" Tacsuit
+    .desc = A sturdy tactical combat engineer hardsuit mass-produced by Five-Points Armory, commonly found on Combat Engineers galaxy-wide. The tags on the suit indicate that its specially rated for radiation protection and mild to moderate amounts of physical trauma and thermal damage. It feels heavy.

--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetEVA
-  name: EVA helmet
-  description: An old-but-gold helmet designed for extravehicular activites. Infamous for making security officers paranoid.
+  name: IP-37 Helmet
+  description: A slightly newer helmet for more typical EVA suits. Manufactured by Interdyne Pharmaceuticals.
   components:
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva.rsi
@@ -19,8 +19,8 @@
 - type: entity
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetEVALarge
-  name: EVA helmet
-  description: An old-but-gold helmet designed for extravehicular activites.
+  name: IP-87 Helmet
+  description: An older model helmet for emergency EVA suits. Manufactured by Interdyne Pharmaceuticals.
   components:
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva_large.rsi
@@ -36,8 +36,8 @@
 - type: entity
   parent: [ ClothingHeadEVAHelmetBase, BaseSyndicateContraband ]
   id: ClothingHeadHelmetSyndicate
-  name: syndicate EVA helmet
-  description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery.
+  name: IP-57 Helmet
+  description: A simple, stylish EVA helmet. Designed for maximum humble space-badassery. Manufactured by Interdyne Pharmaceuticals.
   components:
   - type: Sprite
     sprite: Clothing/Head/Helmets/eva_syndicate.rsi
@@ -50,8 +50,8 @@
 - type: entity
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetCosmonaut
-  name: cosmonaut helmet
-  description: Ancient design, but advanced manufacturing. #Description here originally started with " A deceptively well armored space helmet." Potentially had armor values in SS13 that weren't brought over?
+  name: RI-607 "Cosmonaut" Helmet
+  description: An ancient helmet design made with advanced manufacturing for a Robust Industries promotional campaign for C&Ds. The integrated breath mask actually connects to a tank! #Description here originally started with " A deceptively well armored space helmet." Potentially had armor values in SS13 that weren't brought over?
   components:
   - type: Sprite
     sprite: Clothing/Head/Helmets/cosmonaut.rsi
@@ -74,8 +74,8 @@
 - type: entity
   parent: [ ClothingHeadSuitWithLightBase, ClothingHeadEVAHelmetBase ] #Despite acting like a hardsuit helmet, since it inherits from EVA Helmet, it goes here.
   id: ClothingHeadHelmetVoidParamed
-  name: paramedic void helmet
-  description: A void helmet made for paramedics.
+  name: ZhP-24M Helmet
+  description: A voidsuit helmet for the ZhP-24M. It has wings painted on the sides.
   categories: [ HideSpawnMenu ]
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -9,8 +9,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitAtmos
-  name: atmos hardsuit helmet
-  description: A special hardsuit helmet designed for working in low-pressure, high thermal environments.
+  name: HpI-19A Helmet
+  description: The Fotia's standard helmet. It features the same heat protection as the suit, along with some integrated protective gear for the wearer's head
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/atmospherics.rsi
@@ -90,8 +90,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitEngineering
-  name: engineering hardsuit helmet
-  description: An engineering hardsuit helmet designed for working in low-pressure, high radioactive environments.
+  name: HpI-19E Helmet
+  description: The Lampsi's standard helmet. It features the same radiation protection as the suit, along with some integrated protective gear for the wearer's head.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/engineering.rsi
@@ -170,8 +170,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSpatio
-  name: spationaut hardsuit helmet
-  description: A sturdy helmet designed for complex industrial operations in space.
+  name: HpI-20LS Helmet
+  description: A lightweight helmet designed for the Kriti hardsuit. It allows for better mobility, along with some protection against radiation.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/spatiohelm.rsi
@@ -241,8 +241,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSalvage
-  name: salvage hardsuit helmet
-  description: A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating for wildlife encounters and dual floodlights.
+  name: HpI-20LM Helmet
+  description: A bulky helmet designed for the Lavrion hardsuit. It has reinforced plating to protect the wearer's head in wildlife encounters.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/salvage.rsi
@@ -263,8 +263,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitGoliath
-  name: goliath hardsuit helmet
-  description: A sturdy hardsuit helmet, infused with a goliath's hide and an eerie, unblinking eye cut from its mass.
+  name: HpI-20LS (M) Helmet
+  description: A modified Kriti helmet, infused with a goliath's hide for better protection, and an eerie, unblinking eye cut from a goliath's mass.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/goliathhelm.rsi
@@ -330,8 +330,8 @@
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitMaxim
   categories: [ HideSpawnMenu ]
-  name: salvager maxim helmet
-  description: A predication of decay washes over your mind.
+  name: FPA/HpI-18ELS Helmet
+  description: An old, sturdy helmet for an old, sturdy hardsuit. Designed with the Maxim in mind, it boasts an eccentric design and hefty plating. A predication of decay washes over your mind.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/maxim.rsi
@@ -352,8 +352,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecurity
-  name: security hardsuit helmet
-  description: Armored hardsuit helmet for security needs.
+  name: FPA-83S Helmet
+  description: A bulky helmet deployed with the old Baghatur Mk I tacsuit. Protects its wearer against ballistics and explosive ordnance, at the cost of some mobility.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security.rsi
@@ -380,8 +380,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitBrigmedic
-  name: corpsman hardsuit helmet # DeltaV - rename brigmedic to corpsman
-  description: The lightweight helmet of the corpsman hardsuit. Protects against viruses, and clowns. # Delta V - rename brigmedic to corpsman
+  name: FPA-84SM Helmet # DeltaV - rename brigmedic to corpsman
+  description: A bulky helmet deployed with the old Tsagaan Mk I tacsuit. Protects its wearer against ballistics, explosives, and viruses, at the cost of mobility. # Delta V - rename brigmedic to corpsman
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/brigmedic.rsi
@@ -406,8 +406,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWarden
-  name: warden's hardsuit helmet
-  description: A modified riot helmet. Oddly comfortable.
+  name: FPA-92SW Helmet
+  description: A modified riot-control helmet for use with the older Sulde Mk I tacsuit. Offers better overall protection than standard tacsuits at the expense of mobility.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security-warden.rsi
@@ -430,8 +430,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCap
-  name: captain's hardsuit helmet
-  description: Special hardsuit helmet, made for the captain of the station.
+  name: NT-42C Helmet
+  description: A special helmet for the Tengri tacsuit. Despite its lightweight appearance, it provides good all-around protection to its wearer.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/capspace.rsi
@@ -449,8 +449,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitEngineeringWhite
-  name: chief engineer's hardsuit helmet
-  description: Special hardsuit helmet, made for the chief engineer of the station.
+  name: HpI-24EC Helmet
+  description: A high-grade helmet used with the Daedalus hardsuit. It has a lighter construction than its standard counterparts, along with more radiation protection.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/engineering-white.rsi
@@ -538,8 +538,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitMedical
-  name: chief medical officer's hardsuit helmet
-  description: Lightweight medical hardsuit helmet that doesn't restrict your head movements.
+  name: ZhP-25MC Helmet
+  description: An extraordinarily lightweight helmet designed for use with the Okuninushi hardsuit. It's primarily made from transparent hard plastics, providing complete freedom of vision.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/medical.rsi
@@ -559,8 +559,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitRd
-  name: experimental research hardsuit helmet
-  description: Lightweight hardsuit helmet that doesn't restrict your head movements.
+  name: NT-45EC Helmet
+  description: A heavily-armored helmet worn over the Sophia hardsuit. it boasts the same near-immunity to explosives, heat, and radiation as the suit. Though it heavily restricts the wearer's mobility.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/rd.rsi
@@ -580,8 +580,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecurityRed
-  name: head of security's hardsuit helmet
-  description: Security hardsuit helmet with the latest top secret NT-HUD software. Belongs to the HoS.
+  name: FPA-98SC Helmet
+  description: A high-quality helmet for the outdated Dayicin Mk I tacsuit. It offers better overall protection than it's similarly-aged peers without impacting mobility as much. Implemented with last-gen NT-HUD software.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/security-red.rsi
@@ -604,8 +604,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
-  name: luxury mining hardsuit helmet
-  description: A refurbished mining hardsuit helmet, fitted with satin cushioning and an extra (non-functioning) antenna, because you're that extra.
+  name: HpI-20LC Helmet
+  description: A modified helmet for the Minos hardsuit, fashioned after the Logistics Officer's colors. It's been modified with graphene lining for greater mobility at the expense of physical trauma protection. Additionally it has an extra (non-functioning) antenna, because you're just that extra.
   categories: [ DoNotMap ]
   components:
   - type: Sprite
@@ -624,8 +624,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndie
-  name: blood-red hardsuit helmet
-  description: A heavily armored helmet designed for work in special operations. Property of Gorlex Marauders.
+  name: CSA-51O Helmet
+  description: An armored helmet deployed over a Shanlin tacsuit. This one is painted in a blood red. Designed to enable the survival of Operatives in the most dangerous of environments.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndicate.rsi
@@ -652,8 +652,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieMedic
-  name: blood-red medic hardsuit helmet
-  description: An advanced red hardsuit helmet specifically designed for field medic operations.
+  name: CSA-51OM Helmet
+  description: An armored helmet deployed over a Zhongyao tacsuit. Featuring optic integrations for nearly every medical hud on the market. This one is painted in a blood red. Designed to enable the survival of combat medics in the most dangerous of environments.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndiemedic.rsi
@@ -676,8 +676,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieElite
-  name: syndicate elite helmet
-  description: An elite version of the blood-red hardsuit's helmet, with improved radiation resistance and fireproofing. Property of Gorlex Marauders.
+  name: CSA-54OE Helmet
+  description: An elite version of the Shanlin tacsuit's helmet, featuring improved armor and fireproofing for even greater survivability for the Elite Operatives in the especially dangerous of the most dangerous environments.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndieelite.rsi
@@ -709,8 +709,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSyndieCommander
-  name: syndicate commander helmet
-  description: A bulked up version of the blood-red hardsuit's helmet, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
+  name: CSA-54OC Helmet
+  description: A bulked up version of the Shanlin tacsuit's helmet, purpose-built for the Commander of a Syndicate Operative squad. This one is painted in a blood red. Has significantly improved armor for those deadly front-lines firefights.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/syndiecommander.rsi
@@ -737,8 +737,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ] # DeltaV - added light
   id: ClothingHeadHelmetHardsuitCybersun
-  name: cybersun juggernaut helmet
-  description: Made of compressed red matter, this helmet was designed in the Tau chromosphere facility.
+  name: CSA-80OUA Helmet
+  description: Made of compressed red matter, this helmet was designed in the Tau chromosphere facility for the Guan Yu tacsuit. Bullets will have a tough time getting through this one.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/cybersun.rsi # DeltaV
@@ -765,8 +765,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitWizard
-  name: wizard hardsuit helmet
-  description: A bizarre gem-encrusted helmet that radiates magical energies.
+  name: WZD-84 Helmet
+  description: A bizarre gem-encrusted helmet from unknown origins. It provides some protection to its wearer without restricting their movements.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/wizard.rsi
@@ -876,8 +876,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieCommander ]
   id: ClothingHeadHelmetHardsuitERTLeader
-  name: ERT leader hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-444EL Helmet
+  description: A special hardsuit helmet worn by Leaders of an Emergency Response Team. Designed to keep you alive in the confines of a collapsing Station.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertleader.rsi
@@ -897,8 +897,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTChaplain
-  name: ERT chaplain hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-444EC Helmet
+  description: A special hardsuit helmet worn by Chaplains of an Emergency Response Team. Designed to keep you alive in the confines of a collapsing Station.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertchaplain.rsi
@@ -922,8 +922,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTEngineer
-  name: ERT engineer hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-444EE Helmet
+  description: A special hardsuit helmet worn by Engineers of an Emergency Response Team. Designed to keep you alive in the confines of a collapsing Station.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertengineer.rsi
@@ -945,8 +945,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieElite ]
   id: ClothingHeadHelmetHardsuitERTMedical
-  name: ERT medic hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-444EM Helmet
+  description: A special hardsuit helmet worn by Medics of an Emergency Response Team. Designed to keep you alive in the confines of a collapsing Station.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertmedical.rsi
@@ -959,8 +959,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTSecurity
-  name: ERT security hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-444ES
+  description: A special hardsuit helmet worn by Security Officers of an Emergency Response Team. Designed to keep you alive in the confines of a collapsing Station.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertsecurity.rsi
@@ -980,8 +980,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndie ]
   id: ClothingHeadHelmetHardsuitERTJanitor
-  name: ERT janitor hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-444EJ Helmet
+  description: A special hardsuit helmet worn by Janitors of an emergency response team. Designed to keep you alive in the filthiest of messes.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/ERThelmets/ertjanitor.rsi
@@ -994,8 +994,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetCBURN
-  name: CBURN exosuit helmet
-  description: A pressure resistant and fireproof hood worn by special cleanup units.
+  name: NT-444-CBRN Helmet
+  description: A pressure resistant and fireproof hood worn by special cleanup units. Designed to keep you alive while fighting biological horrors.
   components:
   - type: Sprite
     sprite: Clothing/Head/Hardsuits/cburn.rsi
@@ -1043,8 +1043,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHardsuitBase ]
   id: ClothingHeadHelmetHardsuitDeathsquad
-  name: deathsquad hardsuit helmet
-  description: A robust helmet for special operations.
+  name: NT-662UA Helmet
+  description: A highly-advanced, top-of-the-line, robust helmet for special operations.
   components:
   - type: BreathMask
   - type: Sprite
@@ -1099,7 +1099,7 @@
 - type: entity
   parent: ClothingHeadHardsuitBase
   id: ClothingHeadHelmetHardsuitSanta
-  name: Santa's hardsuit helmet
+  name: DNK-31 Helmet
   description: A festive-looking hardsuit helmet that provides the jolly gift-giver protection from low-pressure environments.
   components:
   - type: BreathMask

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -371,7 +371,7 @@
   parent: [ClothingOuterHardsuitBase, BaseSecurityContraband]
   id: ClothingOuterHardsuitWarden
   name: FPA-92SW - "Sulde" Tacsuit
-  description: A specialized, if outdated, tactical combat hardsuit produced by Five-Points Armory, once commonly used by Wardens on NanoTrasen Stations. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels VERY heavy.
+  description: A specialized, if outdated, tactical combat hardsuit produced by Five-Points Armory, once commonly used by Wardens on NanoTrasen Stations. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels rather heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
@@ -872,7 +872,7 @@
   parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
   id: ClothingOuterHardsuitSyndieCommander
   name: CSA-54OC - "Tianming" Tacsuit
-  description: A bulked up version of the CSA-51O - "Shanlin" Tacsuit, purpose-built for the Commander of a Syndicate Operative squad by the Cybersun Armaments Corporation. It boasts significantly improved armor for those deadly front-lines firefights, the tags indicating that it protects greatly against all forms of damage. This one has been painted in a blood red, and seems to be entirely weightless.
+  description: A bulked up version of the CSA-51O - "Shanlin" Tacsuit, purpose-built for the Commander of a Syndicate Operative squad by the Cybersun Armaments Corporation. It boasts significantly improved armor for those deadly front-lines firefights, the tags indicating that it protects greatly against all forms of damage. This one has been painted in a blood red, and feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndiecommander.rsi

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -5,8 +5,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseEngineeringContraband]
   id: ClothingOuterHardsuitAtmos
-  name: atmos hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has thermal shielding.
+  name: HpI-19A - "Fotia" Hardsuit
+  description: A special hardsuit produced by Hephaestus Industries, used by Atmospheric Technicians in low-pressure environments. The label indicats that it's rated for high thermal exposer. It feels rather heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/atmospherics.rsi
@@ -59,8 +59,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseEngineeringContraband]
   id: ClothingOuterHardsuitEngineering
-  name: engineering hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has radiation shielding.
+  name: HpI-19E - "Lampsi" Hardsuit
+  description: A standard-issue hardsuit produced by Hephaestus Industries, used by Engineers in low-pressure environments. The label indicates that it's rated for moderate radiation exposure. It feels rather heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/engineering.rsi
@@ -109,8 +109,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitSpatio
-  name: spationaut hardsuit
-  description: A lightweight hardsuit designed for industrial EVA in zero gravity.
+  name: HpI-20LS - "Kriti" Hardsuit
+  description: A sturdy hardsuit produced by Hephaestus Industries, designed for salvaging work in low-pressure environments. The label indicates it's rated for moderate amounts of radiation exposure. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/spatio.rsi
@@ -157,8 +157,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitSalvage
-  name: mining hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters.
+  name: HpI-20LM - "Lavrion" Hardsuit
+  description: A sturdy hardsuit produced by Hephaestus Industries, designed for mining operations in low-pressure environments. The suit's labels indicate that it provides moderate protectsions from most damages. It feels heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/salvage.rsi
@@ -207,8 +207,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitGoliath
-  name: goliath hardsuit
-  description: A lightweight hardsuit, adorned with a patchwork of thick, chitinous goliath hide.
+  name: HpI-20LS (M) - "Kriti-Goliath" Hardsuit
+  description: A standard Hephaestus Industries HpI-20LS "Kriti" hardsuit modified with layers of hard, chitinous plates harvested from goliaths, boosting its protection. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/goliath.rsi
@@ -265,8 +265,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitMaxim
-  name: salvager maxim hardsuit
-  description: Fire. Heat. These things forge great weapons, they also forge great salvagers.
+  name: FPA/HpI-18ELS "Maxim" Tacsuit
+  description: An old tactical combat hardsuit produced by Hephaestus Industries in cooperation with Five-Points Armory. It feels very sturdy yet also weightless, and strangely ominous. On one of the breastplates it has "Fire. Heat. These things forge great weapons, they also forge great salvagers." written in what appears to be dried oil and blood.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/maxim.rsi
@@ -303,8 +303,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseSecurityContraband]
   id: ClothingOuterHardsuitSecurity
-  name: security hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
+  name: FPA-83S - "Baghatur" Tacsuit
+  description: A sturdy, if outdated, tactical combat hardsuit mass-produced by Five-Points Armory, once commonly used by the NanoTrasen Security Force. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security.rsi
@@ -341,8 +341,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseSecurityContraband]
   id: ClothingOuterHardsuitBrigmedic
-  name: corpsman hardsuit # DeltaV - rename brigmedic to corpsman
-  description: Special hardsuit of the guardian angel of the brig. It is the medical version of the security hardsuit. # I will fix the rest of this entry later when I resprite sec suits
+  name: FPA-84SM - "Tsagaan" Tacsuit # DeltaV - rename brigmedic to corpsman
+  description: A sturdy, if outdated, tactical hardsuit mass-produced by Five-Points Armory, once commonly used by Corpsmen in the NanoTrasen Security Force. The tags on the suit indicate that it's rated for moderate amounts of physical and explosion damage. It feels heavy. # I will fix the rest of this entry later when I resprite sec suits
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/brigmedic.rsi
@@ -370,8 +370,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseSecurityContraband]
   id: ClothingOuterHardsuitWarden
-  name: warden's hardsuit
-  description: A specialized riot suit geared to combat low pressure environments.
+  name: FPA-92SW - "Sulde" Tacsuit
+  description: A specialized, if outdated, tactical combat hardsuit produced by Five-Points Armory, once commonly used by Wardens on NanoTrasen Stations. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels VERY heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-warden.rsi
@@ -403,8 +403,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitCap
-  name: captain's armored spacesuit
-  description: A formal armored spacesuit, made for the station's captain.
+  name: NT-42C - "Tengri" Tacsuit
+  description: A formal, tactical combat hardsuit, made in collaboration by NanoTrasen's R&D Department with Five-Points Armory for Station Commanders. The labels indicate that it provides protection against most forms of damage. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/capspace.rsi
@@ -460,8 +460,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitEngineeringWhite
-  name: chief engineer's hardsuit
-  description: A special hardsuit that protects against hazardous, low pressure environments, made for the chief engineer of the station.
+  name: HpI-24EC - "Daedalus" Hardsuit
+  description: A specialized hardsuit produced by Hephaestus Industries, often purchased for use by various corporations' Chief Engineers in low-pressure environments. The labels indicate that it's rated for extreme radiation and exotic particle exposure. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/engineering-white.rsi
@@ -512,8 +512,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitMedical
-  name: chief medical officer's hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Built with lightweight materials for easier movement.
+  name: ZhP-25MC - "Okuninushi" Hardsuit
+  description: A hardsuit produced by Zeng-hu Pharmaceuticals, often purchased for use by various corporations' Chief Medical Officers. The labels indicate that it protects against damage from most chemical spills. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/medical.rsi
@@ -557,8 +557,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseGrandTheftContraband]
   id: ClothingOuterHardsuitRd
-  name: experimental research hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
+  name: NT-45EC - "Sophia" Research Hardsuit
+  description: The magnum opus of NanoTrasen's R&D Department. The labels on the hardsuit claim that it's near-immune to explosions, heat, and radiation. It can also somehow shrink to fit inside a duffel bag. It feels heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/rd.rsi
@@ -611,8 +611,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
   id: ClothingOuterHardsuitSecurityRed
-  name: head of security's hardsuit
-  description: A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor.
+  name: FPA-98SC - "Dayicin" Tacsuit
+  description: A top-of-the-line, if outdated, tactical combat hardsuit produced by Five-Points Armory. Once commonly used by NanoTrasen Security Commanders. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/security-red.rsi
@@ -650,8 +650,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
-  name: luxury mining hardsuit
-  description: A refurbished mining hardsuit, fashioned after the Logistics Officer's colors. Graphene lining provides less protection, but is much easier to move. # DeltaV - Logistics Department replacing Cargo
+  name: HpI-20LC - "Minos" Hardsuit
+  description: A modified mining hardsuit from Hephaestus Industries, adorned with purple fabric and gold metal. Made specifically by Hephaestus Industries for their Logistics Officers, with a graphene lining for added flexibility. The labels indicate that it provides slight protection against most forms of damage. It feels incredibly light. # DeltaV - Logistics Department replacing Cargo
   categories: [ DoNotMap ]
   components:
   - type: Sprite
@@ -701,8 +701,8 @@
 - type: entity
   parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband ]
   id: ClothingOuterHardsuitSyndie
-  name: blood-red hardsuit
-  description: A heavily armored hardsuit designed for work in special operations. Property of Gorlex Marauders.
+  name: CSA-51O - "Shanlin" Tacsuit
+  description: A tactical combat hardsuit producted by the Cybersun Armaments Corporation, painted in a blood red. The suit's tags indicate that it provides moderate protection against most forms of damage. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndicate.rsi
@@ -775,8 +775,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitSyndie, BaseSyndicateContraband]
   id: ClothingOuterHardsuitSyndieMedic
-  name: blood-red medic hardsuit
-  description: A heavily armored and agile advanced hardsuit specifically designed for field medic operations.
+  name: CSA-51OM - "Zhongyao" Tacsuit
+  description: A tactical combat hardsuit produced by the Cybersun Armaments Corporation. It's painted in a blood red on one half, the other bearing galactic standard medical markings. The tags on the suit indicate it provides moderate protection against most forms of damage. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndiemedic.rsi
@@ -806,8 +806,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
   id: ClothingOuterHardsuitSyndieElite
-  name: syndicate elite hardsuit
-  description: An elite version of the blood-red hardsuit, with improved radiation resistance and fireproofing. Property of Gorlex Marauders.
+  name: CSA-54OE - "Shiwei" Tacsuit
+  description: An "Elite" tactical combat hardsuit produced by the Cybersun Armaments Corporation. Unlike its siblings, it's painted in a jet black with blood red highlights. The suit's tags indicate it's rated for high radiation and thermal exposure, as well as significant explosive protection and moderate physical trauma protection. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndieelite.rsi
@@ -871,8 +871,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
   id: ClothingOuterHardsuitSyndieCommander
-  name: syndicate commander hardsuit
-  description: A bulked up version of the blood-red hardsuit, purpose-built for the commander of a syndicate operative squad. Has significantly improved armor for those deadly front-lines firefights.
+  name: CSA-54OC - "Tianming" Tacsuit
+  description: A bulked up version of the CSA-51O - "Shanlin" Tacsuit, purpose-built for the Commander of a Syndicate Operative squad by the Cybersun Armaments Corporation. It boasts significantly improved armor for those deadly front-lines firefights, the tags indicating that it protects greatly against all forms of damage. This one has been painted in a blood red, and seems to be entirely weightless.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/syndiecommander.rsi
@@ -933,8 +933,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseSyndicateContraband]
   id: ClothingOuterHardsuitJuggernaut
-  name: cybersun juggernaut suit
-  description: A suit made by the cutting edge R&D department at cybersun to be hyper resilient.
+  name: CSA-80OUA - "Guan Yu" Tacsuit
+  description: The pride and joy of the Cybersun Armaments Corporation, named after an ancient Solarian God of War. Commonly referred to as a "Juggernaut" suit throughout the Galaxy. Matching its bulky appearance, it protects extremely well against all forms of damage. It feels VERY heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/cybersun.rsi
@@ -1002,8 +1002,8 @@
 - type: entity
   parent: [ ClothingOuterHardsuitBase, BaseMagicalContraband ]
   id: ClothingOuterHardsuitWizard
-  name: wizard hardsuit
-  description: A bizarre gem-encrusted suit that radiates magical energies.
+  name: WZD-84 - "Mana" Tacsuit
+  description: A bizarre gem-encrusted suit famously used by members of the Wizard Federation in their operations. Contrary to its appearance, it can protect its wearer from space and moderate amounts of physical trauma. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/wizard.rsi
@@ -1253,8 +1253,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
   id: ClothingOuterHardsuitDeathsquad
-  name: death squad hardsuit
-  description: An advanced hardsuit favored by commandos for use in special operations.
+  name: NT-662UA "Samael" Tacsuit
+  description: A highly-advanced, top-of-the-line tactical combat hardsuit branded with the NanoTrasen logo and a strange-looking series number. You can barely make out the characters "NTIA-DAP" written on it. The armor appears to be lined with an exceptionally sturdy allow, and doesn't seem to have any weight, either.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/deathsquad.rsi
@@ -1309,8 +1309,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingOuterHardsuitBase ]
   id: ClothingOuterHardsuitCBURN
-  name: CBURN exosuit
-  description: A lightweight yet strong exosuit used for special cleanup operations.
+  name: NT-444-CBRN - "Jophiel" Tacsuit
+  description: A tactical combat hardsuit used by the CBURN division of the Emergency Response Team, branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a rather plain but sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/cburn.rsi
@@ -1444,8 +1444,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSanta
-  name: Santa's hardsuit
-  description: A festive, cheerful hardsuit that protects the jolly gift-giver while on sleighrides in space. Offers some resistance against asteroid strikes.
+  name: DNK-31 - "Jolly" Hardsuit
+  description: A festive hardsuit produced by Donk Co. for their limited-time celebratory evides. It provides protection for its jolly gift-giver to sleighride safely in space without worrying about asteroid strikes. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/santahardsuit.rsi

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: ClothingOuterEVASuitBase
   id: ClothingOuterHardsuitEVA
-  name: EVA suit
-  description: A lightweight space suit with the basic ability to protect the wearer from the vacuum of space during emergencies.
+  name: IP-37 - "Huginn" EVA Suit
+  description: A lightweight space suit with the basic ability to protect the wearer from the vacuum of space during emergencies. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/eva.rsi
@@ -35,8 +35,8 @@
 - type: entity
   parent: [ ClothingOuterEVASuitBase, BaseSyndicateContraband ]
   id: ClothingOuterEVASuitSyndicate
-  name: syndicate EVA suit
-  description: "Has a tag on the back that reads: 'Totally not property of an enemy corporation, honest!'"
+  name: IP-57 - "Muninn" EVA Suit
+  description: A red EVA suit produced by Interdyne Pharmaceuticals for maximum style and minimal protection in space. It feels somewhat light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
@@ -69,8 +69,8 @@
 - type: entity
   parent: ClothingOuterEVASuitBase
   id: ClothingOuterSuitEmergency
-  name: emergency EVA suit
-  description: An emergency EVA suit with a built-in helmet. It's horribly slow and lacking in temperature protection, but enough to buy you time from the harsh vacuum of space.
+  name: IP-87 - "Salvator" Emergency EVA Suit
+  description: An emergency EVA suit with a built-in helmet. It's horribly slow and lacking in temperature protection, but enough to buy you time from the harsh vacuum of space. It feels heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/eva_emergency.rsi
@@ -117,8 +117,8 @@
 - type: entity
   parent: ClothingOuterEVASuitBase
   id:  ClothingOuterHardsuitEVAPrisoner
-  name: prisoner EVA suit
-  description: An emergency EVA suit meant for prisoners. It's horribly slow and lacking in temperature protection, but enough to buy you time from the harsh vacuum of space.
+  name: IP-87P - "Jailbird" Prisoner EVA Suit
+  description: An emergency EVA suit meant for prisoners. It's horribly slow and lacking in temperature protection, but enough to buy you time from the harsh vacuum of space. It feels heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Suits/eva_prisoner.rsi
@@ -172,8 +172,8 @@
 - type: entity
   parent: [ClothingOuterEVASuitBase, BaseMedicalContraband] #Despite "Voidsuits are light hardsuits", since it parents of EVA Suits, it goes with the other softsuits
   id: ClothingOuterHardsuitVoidParamed
-  name: paramedic void suit
-  description: A void suit made for paramedics.
+  name: ZhP-24M - "Sukunabikona" Voidsuit
+  description: A minimally-armored, radiation-resistant voidsuit with blue medical markings and little wings painted on the boots. The label also mentions is offers some protection against chemical spills. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/paramed.rsi

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -2,8 +2,8 @@
   parent: ClothingHeadHelmetHardsuitRd
   id: ClothingHeadHelmetHardsuitMystagogue
   categories: [ HideSpawnMenu ]
-  name: mystagogue's hardsuit helmet
-  description: Lightweight hardsuit helmet that has a galaxy-first psionic passthrough system.
+  name: NT-46EC Helmet
+  description: An equally-advanced helmet for an advanced hardsuit. This one has psionic insulation, allowing Mystagogues to go about their duties even with absurd glimmer amounts.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/rd.rsi
@@ -24,7 +24,8 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitERTLeader
   id: ClothingHeadHelmetHardsuitERTCentcomm
-  name: CentComm hardsuit helmet
+  name: NT-444CC Helmet
+  description: A highly-specialized tacsuit helmet adorned in green and gold, worn by Central Command Officers. Designed to keep you safe in your cushy office.
   components:
   - type: Sprite
     sprite: Nyanotrasen/Clothing/Head/Hardsuits/ERThelmets/ertcentcomm.rsi

--- a/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: ClothingOuterHardsuitRd
   id: ClothingOuterHardsuitMystagogue
-  name: mystagogue's hardsuit
-  description: A heavy-duty hardsuit specialized for research that includes a built-in psionic nullification and detection system in the helmet. Modified bluespace embedded into the plating allows it to be folded into a smaller space then one would expect.
+  name: NT-46EC - "Seraphim" Research Hardsuit
+  description: The next tier in NanoTrasen's R&D Department. While this provides the exact same protections as the NT-45EC, it uses experimental bluespace technology to fit into smaller spaces rather than just folding into them, allowing for more stylish armor and even a labcoat to fit on it with a slimmer and sleeker build than the NT-45EC. The labels on the hardsuit claim that it's near-immune to explosions, heat, and radiation. It feels heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/rd.rsi
@@ -14,7 +14,7 @@
 - type: entity
   parent: [ClothingOuterHardsuitMystagogue, ClothingOuterStorageFoldableBaseOpened]
   id: ClothingOuterHardsuitMystagogueLabcoat
-  name: mystagogue's hardsuit
+  name: NT-46EC - "Seraphim" Research Hardsuit
   components:
   - type: ContainerContainer
     containers:
@@ -25,7 +25,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTCentcomm
-  name: CentComm hardsuit
+  name: NT-444CC - "Ophanim" Tacsuit
+  description: A highly advanced tactical combat hardsuit adorned in green and gold used by Central Command Officers. It is branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy, and seems to be incredibly light.
   components:
   - type: Sprite
     sprite: Nyanotrasen/Clothing/OuterClothing/Hardsuits/ERTSuits/ertcentcomm.rsi

--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/eva-helmets.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: ClothingHeadEVAHelmetBase
   id: ClothingHeadHelmetEVAScience
-  name: Epistemics EVA Helmet
-  description: The helmet to an Epistemics EVA suit. The visor is made of highly durable glass. Hopefully you won't get glass shards in your eyes...
+  name: NT-32 Helmet
+  description: A helmet belonging to an NT-32 EVA suit. The visor is made of highly durable, radiation-resistant glass. Hopefully you won't get glass shards in your eyes...
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Helmets/eva_epistemics.rsi

--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCombatStandard
-  name: combat hardsuit helmet
-  description: An armoured helmet with a yellow visor and dual head-mounted lights.
+  name: FPA-85 Helmet
+  description: An armoured helmet with a yellow visor and dual head-mounted lights. Meant to keep your noggin from busting open.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/standard.rsi
@@ -25,7 +25,8 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatStandard
   id: ClothingHeadHelmetHardsuitCombatOfficer
-  name: security combat hardsuit helmet
+  name: FPA-85S Helmet
+  description: An armoured helmet with a yellow visor and dual head-mounted lights. Meant to keep your noggin from busting open. This one is painted in Station Security colors.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/officer.rsi
@@ -36,8 +37,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCombatMedical
-  name: medical combat hardsuit helmet
-  description: A lightweight armoured helmet with full-face blue visor and head-mounted light.
+  name: FPA-86 Helmet
+  description: A lightweight armoured helmet with full-face blue visor and head-mounted light. Meant to keep your noggin from busting open while doing field surgery.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/medical.rsi
@@ -59,7 +60,8 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatMedical
   id: ClothingHeadHelmetHardsuitCombatCorpsman
-  name: corpsman combat hardsuit helmet
+  name: FPA-86SM Helmet
+  description: A lightweight armoured helmet with full-face blue visor and head-mounted light. Meant to keep your noggin from busting open while doing field surgery. This one is painted in Station Security and Medical colors.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/corpsman.rsi
@@ -70,8 +72,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCombatRiot
-  name: riot combat hardsuit helmet
-  description: A heavy armoured helmet with a sealed visor with yellow slits and dual head-mounted lights.
+  name: FPA-93 Helmet
+  description: A heavy armoured helmet with a sealed visor with yellow slits and dual head-mounted lights. Meant to keep your noggin from busting open while dealing with heavy opposition.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/riot.rsi
@@ -93,7 +95,8 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatRiot
   id: ClothingHeadHelmetHardsuitCombatWarden
-  name: warden's riot combat hardsuit helmet
+  name: FPA-93SW Helmet
+  description: A heavy armoured helmet with a sealed visor with yellow slits and dual head-mounted lights. Meant to keep your noggin from busting open while dealing with heavy opposition. This one is painted with the colors of Station Security and Warden's rank markings.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/warden.rsi
@@ -104,8 +107,8 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitCombatAdvanced
-  name: advanced combat hardsuit helmet
-  description: A light but durable helmet with full-face protection and four head-mounted lights.
+  name: FPA-99 Helmet
+  description: A light but durable helmet with full-face protection and four head-mounted lights. Meant to keep your noggin from busting open while leading.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/advanced.rsi
@@ -129,7 +132,8 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitCombatAdvanced
   id: ClothingHeadHelmetHardsuitCombatHoS
-  name: head of security's advanced combat hardsuit helmet
+  name: FPA-99SC Helmet
+  description: A light but durable helmet with full-face protection and four head-mounted lights. Meant to keep your noggin from busting open while leading. This one is painted with the colors of Station Security and Commander's rank markings.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/Combat/hos.rsi
@@ -174,8 +178,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitSyndieElite ]
   id: ClothingHeadHelmetHardsuitERTLeaderElite
-  name: Elite ERT leader hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-555ELE Helmet
+  description: A special tactical combat hardsuit helmet worn by Elite Leaders of an Emergency Response Team. Designed to keep you alive in the confines of a post-collapse Station.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/ERThelmets/eliteertleader.rsi
@@ -195,8 +199,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitERTLeaderElite ]
   id: ClothingHeadHelmetHardsuitERTChaplainElite
-  name: Elite ERT chaplain hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-555ECE Helmet
+  description: A special tactical combat hardsuit helmet worn by Elite Chaplains of an Emergency Response Team. Designed to keep you alive in the confines of a post-collapse Station.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/ERThelmets/eliteertchaplain.rsi
@@ -218,8 +222,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitERTLeaderElite ]
   id: ClothingHeadHelmetHardsuitERTEngineerElite
-  name: Elite ERT engineer hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-555EEE Helmet
+  description: A special tactical combat hardsuit helmet worn by Elite Engineers of an Emergency Response Team. Designed to keep you alive in the confines of a post-collapse Station.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/ERThelmets/eliteertengineer.rsi
@@ -239,8 +243,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitERTLeaderElite ]
   id: ClothingHeadHelmetHardsuitERTMedicalElite
-  name: Elite ERT medic hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-555EME Helmet
+  description: A special tactical combat hardsuit helmet worn by Elite Medics of an Emergency Response Team. Designed to keep you alive in the confines of a post-collapse Station.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/ERThelmets/eliteertmedical.rsi
@@ -253,8 +257,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitERTLeaderElite ]
   id: ClothingHeadHelmetHardsuitERTSecurityElite
-  name: Elite ERT security hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-555ESE Helmet
+  description: A special tactical combat hardsuit helmet worn by Elite Security Officers of an Emergency Response Team. Designed to keep you alive in the confines of a post-collapse Station.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/ERThelmets/eliteertsecurity.rsi
@@ -274,8 +278,8 @@
 - type: entity
   parent: [ BaseCentcommContraband, ClothingHeadHelmetHardsuitERTLeaderElite ]
   id: ClothingHeadHelmetHardsuitERTJanitorElite
-  name: Elite ERT janitor hardsuit helmet
-  description: A special hardsuit helmet worn by members of an emergency response team.
+  name: NT-555EJE Helmet
+  description: A special tactical combat hardsuit helmet worn by Elite Janitors of an Emergency Response Team. Designed to keep you alive in the confines of a post-collapse Station.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/Hardsuits/ERThelmets/eliteertjanitor.rsi
@@ -288,8 +292,8 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitEngineering
   id: ClothingHeadHelmetVoidsuitEngineering
-  name: engineering void suit helmet
-  description: An engineering hardsuit helmet designed for working in low-pressure, high radioactive environments. It's a lot lighter and flimsier than it looks...
+  name: HpI-19EV Helmet
+  description: The helmet to an HpI-19EV. Not as protective as it's harder cousin, but easier to move around in. It feels kind of flimsy.
   components:
   - type: PressureProtection # Using EVA pressure and temperature protections instead of hardsuits.
     highPressureMultiplier: 0.3
@@ -367,8 +371,8 @@
   parent: ClothingHeadHelmetHardsuitSyndie
   id: ClothingHeadHelmetHardsuitSyndieReverseEngineered
   categories: [ HideSpawnMenu ]
-  name: SA-123 combat hardsuit helmet
-  description: An advanced hardsuit helmet designed for work in special operations.
+  name: SA-122 Helmet
+  description: A reverse-engineered "Shanlin" helmet designed for use in special operations.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/ReverseEngineering/syndicate.rsi
@@ -381,8 +385,8 @@
   parent: ClothingHeadHelmetHardsuitCybersun
   id: ClothingHeadHelmetHardsuitJuggernautReverseEngineered
   categories: [ HideSpawnMenu ]
-  name: SA-127 combat hardsuit helmet
-  description: An assault hardsuit helmet featuring nigh-impenetrable armor plating.
+  name: SA-126UA Helmet
+  description: A reverse-engineered "Guan Yu" helmet meant for use with the SA-126UA. Its armor plating is nigh-impenetrable.
   components:
   - type: Sprite
     sprite: _DV/Clothing/Head/ReverseEngineering/juggernaut.rsi

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCombatStandard
-  name: combat hardsuit
-  description: A purpose-built combat suit designed to protect its user against all manner of enemy combatants in low pressure environments.
+  name: FPA-85 "Baghatur Mk II" Tacsuit
+  description: A sturdy tactical combat hardsuit mass-produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/standard.rsi
@@ -42,8 +42,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatOfficer
-  name: security combat hardsuit
-  description: A purpose-built combat suit designed to protect its user against all manner of enemy combatants in low pressure environments. This one has station security markings.
+  name: FPA-85S - "Baghatur Mk II" Tacsuit
+  description: A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory, painted with the colors of Station Security. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/officer.rsi
@@ -56,8 +56,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatMedical
-  name: medical combat hardsuit
-  description: A purpose-built combat suit designed to allow its user greater mobility for superior support of friendly units in active combat zones.
+  name: FPA-86 - "Tsagaan Mk II" Tacsuit
+  description: A sturdy tactical combat medic hardsuit mass-produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/medical.rsi
@@ -88,8 +88,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatMedical
   id: ClothingOuterHardsuitCombatCorpsman
-  name: corpsman combat hardsuit
-  description: A purpose-built combat suit designed to allow its user greater mobility for superior support of friendly units in active combat zones. This one has station security markings.
+  name: FPA-86SM - "Tsagaan Mk II" Tacsuit
+  description: A sturdy tactical combat medic hardsuit mass-produced by Five-Points Armory, painted with the colors of Station Security and Medical staff. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/corpsman.rsi
@@ -102,8 +102,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatRiot
-  name: riot combat hardsuit
-  description: A purpose-built combat suit designed for crowd control against armed combatants in low pressure environments.
+  name: FPA-93 - "Sulde Mk II" Tacsuit
+  description: A specialized tactical combat hardsuit produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels VERY heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/riot.rsi
@@ -136,8 +136,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatRiot
   id: ClothingOuterHardsuitCombatWarden
-  name: warden's riot combat hardsuit
-  description: A purpose-built combat suit designed for crowd control against armed combatants in low pressure environments. This one has station security and warden's rank markings.
+  name: FPA-93SW - "Sulde Mk II" Tacsuit
+  description: A specialized tactical combat hardsuit produced by Five-Points Armory, painted with the colors of Station Security and Warden's rank markings. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels VERY heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/warden.rsi
@@ -150,8 +150,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatAdvanced
-  name: advanced combat hardsuit
-  description: A purpose-built combat suit of second-generation design, providing unparalleled protection against all manner of kinetic forces in low pressure environments.
+  name: FPA-99 - "Dayicin Mk II Tacsuit"
+  description: A top-of-the-line tactical combat hardsuit produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels somewhat light.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/advanced.rsi
@@ -184,8 +184,8 @@
 - type: entity
   parent: ClothingOuterHardsuitCombatAdvanced
   id: ClothingOuterHardsuitCombatHoS
-  name: head of security's advanced combat hardsuit
-  description: A purpose-built combat suit of second-generation design, providing unparalleled protection against all manner of kinetic forces in low pressure environments. This one has station security and commander's rank markings.
+  name: FPA-99SC - "Dayicin Mk II" Tacsuit
+  description: A top-of-the-line tactical combat hardsuit produced by Five-Points Armory, painted witht he colors of Station Security and Commander's rank markings. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels somewhat light.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/hos.rsi
@@ -229,8 +229,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTLeaderBase
-  name: ERT leader's hardsuit
-  description: A protective hardsuit worn by the leader of an emergency response team.
+  name: NT-444EL - "Michael" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by Leaders of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertleader.rsi
@@ -253,8 +253,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTChaplainBase
-  name: ERT chaplain's hardsuit
-  description: A protective hardsuit worn by the chaplains of an Emergency Response Team.
+  name: NT-444EC - "Barachiel" Hardsuit
+  description: A highly-advanced tactical combat hardsuit used by Chaplains of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It feels VERY heavy.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertchaplain.rsi
@@ -275,8 +275,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTEngineerBase
-  name: ERT engineer's hardsuit
-  description: A protective hardsuit worn by the engineers of an emergency response team.
+  name: NT-444EE - "Uriel" Hardsuit
+  description: A highly-advanced hardsuit used by Engineers of an Emergency Response team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a somewhat sturdy alloy that is highly resistant to radiation and thermal exposure. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertengineer.rsi
@@ -302,8 +302,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTMedicalBase
-  name: ERT medic's hardsuit
-  description: A protective hardsuit worn by the medics of an emergency response team.
+  name: NT-444EM - "Raphael" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by medics of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a sturdy alloy. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
@@ -326,8 +326,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTSecurityBase
-  name: ERT security's hardsuit
-  description: A protective hardsuit worn by the security officers of an emergency response team.
+  name: NT-444ES - "Gabriel" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by Security Officers of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a sturdy alloy. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertsecurity.rsi
@@ -350,8 +350,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTJanitorBase
-  name: ERT janitor's hardsuit
-  description: A protective hardsuit worn by the janitors of an emergency response team.
+  name: NT-444EJ - "Sandalphon" Hardsuit
+  description: A highly-advanced hardsuit used by Janitors of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a somewhat sturdy alloy that is highly resistant to radiation and thermal exposure. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertjanitor.rsi
@@ -406,8 +406,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTEliteBase
   id: ClothingOuterHardsuitERTLeaderElite
-  name: Elite ERT Leader Hardsuit
-  description: A protective hardsuit worn by the leader of an emergency response team.
+  name: NT-555ELE - "Michael Mk II" Tacsuit
+  description: A highly-advanced tactical combat suit used by Elite Leaders of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/ERTSuits/eliteertleader.rsi
@@ -420,8 +420,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTEliteBase
   id: ClothingOuterHardsuitERTChaplainElite
-  name: Elite ERT chaplain's hardsuit
-  description: A protective hardsuit worn by the chaplains of an Emergency Response Team.
+  name: NT-555ECE - "Barachiel Mk II" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by Elite Chaplains of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/ERTSuits/eliteertchaplain.rsi #if you change this, please update the humanoid.yml with a better markers sprite.
@@ -434,8 +434,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTEliteBase
   id: ClothingOuterHardsuitERTEngineerElite
-  name: Elite ERT engineer's hardsuit
-  description: A protective hardsuit worn by the engineers of an emergency response team.
+  name: NT-555EEE - "Uriel Mk II" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by Elite Engineers of an Emergency Response team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/ERTSuits/eliteertengineer.rsi
@@ -491,8 +491,8 @@
 - type: entity
   parent: [ClothingOuterHardsuitSalvage, BaseJetpack, BaseCargoContraband]
   id: ClothingOuterHardsuitRhino
-  name: rhino industrial hardsuit
-  description: A hardsuit adorned with purple fabric and gold metal. Made specifically by Nanotrasen for their Logistics Officers, this hardsuit boasts better protection than most salvage suits and has an internal jetpack.
+  name: HpI-20LC - "Minos" Hardsuit
+  description: A modified mining hardsuit from Hephaestus Industries, adorned with purple fabric and gold metal. Made specifically by Hephaestus Industries for their Logistics Officers, this hardsuit boasts better protection than most salvage suits and has an internal jetpack.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/rhinosuit.rsi
@@ -528,8 +528,8 @@
   parent: [ ClothingOuterHardsuitBase, BaseSecurityContraband ]
   id: ClothingOuterHardsuitSyndieReverseEngineered
   suffix: reverse-engineered, Bluekies
-  name: SA-122 combat hardsuit
-  description: A heavily armored hardsuit designed for work in special operations. Made by the special acquisitions department of Nanotrasen.
+  name: SA-122 - "Shanlin" Tacsuit
+  description: A tactical combat hardsuit originally produced by the Cybersun Armaments Corporation, now reverse-engineered by the Special Acquisitions Department. The suit's tags indicate it provides moderate protection against most forms of damage. It feels incredibly light.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/ReverseEngineering/syndicate.rsi
@@ -576,8 +576,8 @@
   parent: [ ClothingOuterHardsuitBase, BaseSecurityContraband ]
   id: ClothingOuterHardsuitJuggernautReverseEngineered
   suffix: reverse-engineered, Bluekies
-  name: SA-126 assault hardsuit
-  description: A suit made by the special acquisitions department of Nanotrasen to be hyper resilient.
+  name: SA-126UA "Guan Yu" Tacsuit
+  description: The former pride and joy of the Cybersun Armaments Corporation, now reverse-engineered by the Special Acquisitions Department. The suit's tags indicate that it protects excellently against all forms of damage. It feels VERY heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/ReverseEngineering/juggernaut.rsi

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitCombatStandard
-  name: FPA-85 "Baghatur Mk II" Tacsuit
+  name: FPA-85 - "Baghatur Mk II" Tacsuit
   description: A sturdy tactical combat hardsuit mass-produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
@@ -43,7 +43,7 @@
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatOfficer
   name: FPA-85S - "Baghatur Mk II" Tacsuit
-  description: A sturdy tactical combat hardsuit mass-produced by Five-Points-Armory, painted with the colors of Station Security. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
+  description: A sturdy tactical combat hardsuit mass-produced by Five-Points Armory, painted with the colors of Station Security. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/officer.rsi
@@ -103,7 +103,7 @@
   parent: ClothingOuterHardsuitCombatStandard
   id: ClothingOuterHardsuitCombatRiot
   name: FPA-93 - "Sulde Mk II" Tacsuit
-  description: A specialized tactical combat hardsuit produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels VERY heavy.
+  description: A specialized tactical combat hardsuit produced by Five-Points Armory. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels EXTREMELY heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/riot.rsi
@@ -137,7 +137,7 @@
   parent: ClothingOuterHardsuitCombatRiot
   id: ClothingOuterHardsuitCombatWarden
   name: FPA-93SW - "Sulde Mk II" Tacsuit
-  description: A specialized tactical combat hardsuit produced by Five-Points Armory, painted with the colors of Station Security and Warden's rank markings. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels VERY heavy.
+  description: A specialized tactical combat hardsuit produced by Five-Points Armory, painted with the colors of Station Security and Warden's rank markings. The tags on the suit indicate that it's rated for moderate amounts of physical and explosive damage. It feels EXTREMELY heavy.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/Combat/warden.rsi
@@ -303,7 +303,7 @@
   parent: ClothingOuterHardsuitERTBase
   id: ClothingOuterHardsuitERTMedicalBase
   name: NT-444EM - "Raphael" Tacsuit
-  description: A highly-advanced tactical combat hardsuit used by medics of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a sturdy alloy. It feels incredibly light.
+  description: A highly-advanced tactical combat hardsuit used by Medics of an Emergency Response Team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a sturdy alloy. It feels incredibly light.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/ERTSuits/ertmedical.rsi
@@ -449,8 +449,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTEliteBase
   id: ClothingOuterHardsuitERTMedicalElite
-  name: Elite ERT medic's hardsuit
-  description: A protective hardsuit worn by the medics of an emergency response team.
+  name: NT-555EME - "Raphael Mk II" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by Elite Medics of an Emergency Response team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/ERTSuits/eliteertmedical.rsi
@@ -463,8 +463,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTEliteBase
   id: ClothingOuterHardsuitERTSecurityElite
-  name: Elite ERT security's hardsuit
-  description: A protective hardsuit worn by the security officers of an emergency response team.
+  name: NT-555ESE - "Gabriel Mk II" Tacsuit
+  description: A highly-advanced tactical combat hardsuit used by Elite Security Officers of an Emergency Response team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/ERTSuits/eliteertsecurity.rsi
@@ -477,8 +477,8 @@
 - type: entity
   parent: ClothingOuterHardsuitERTEliteBase
   id: ClothingOuterHardsuitERTJanitorElite
-  name: Elite ERT janitor's hardsuit
-  description: A protective hardsuit worn by the janitors of an emergency response team.
+  name: NT-555EJE - "Sandalphon Mk II" Hardsuit
+  description: A highly-advanced tactical combat hardsuit used by Elite Janitors of an Emergency Response team. It's branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Hardsuits/ERTSuits/eliteertjanitor.rsi

--- a/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/OuterClothing/softsuits.yml
@@ -28,8 +28,8 @@
 - type: entity
   parent: ClothingOuterEVASuitBase
   id: ClothingOuterHardsuitEVAScience
-  name: Epistemics EVA Suit
-  description: A modified EVA suit padded with shock-absorbant airbags. Looks like it could take a pretty strong blast.
+  name: NT-32 - "Satyr" EVA Suit
+  description: A modified EVA suit produced by NanoTrasen specifically for the Epistemics Department. Its tags indicate that it will protect for from moderate radiation exposure and lightly from chemical spills and explosions. It feels somewhat light.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Suits/eva_epistemics.rsi
@@ -56,8 +56,8 @@
 - type: entity
   parent: [ClothingOuterEVASuitBase, BaseEngineeringContraband]
   id: ClothingOuterVoidsuitEngineering
-  name: engineering void suit
-  description: A lightweight version of the standard engineering hardsuits. Allows for faster response time, at the cost of most of the protective plating.
+  name: HpI-19EV - "Lampsi Lite" Voidsuit
+  description: A lightweight version of the HpI-19E hardsuit. Allows for faster response time, at the cost of most of the protective plating. The tags on the suit indicate it's rated for moderate radiation exposure. It feels light.
   components:
   - type: Sprite
     sprite: _DV/Clothing/OuterClothing/Suits/engineering-light.rsi

--- a/Resources/Prototypes/_Floof/Catalog/Fills/Crates/hardsuits.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Fills/Crates/hardsuits.yml
@@ -2,7 +2,7 @@
   id: CrateSecurityAraaTacsuit
   parent: CrateSecgear
   name: araa tacsuit crate
-  description: Contains a single FPA-41e - "Araa" tacsuit. Requires Security access to open.
+  description: Contains a single FPA-41SE - "Araa" Tacsuit. Requires Security access to open.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_Floof/Entities/Clothing/OuterClothing/hardsuits-helmets.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/OuterClothing/hardsuits-helmets.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitSecTech
-  name: security technician hardsuit helmet
+  name: FPA-41SE Helmet
   description: The sturdy helmet of the security technician's hardsuit. Specialized lenses help prevent eye damage from welding arcs.
   components:
   - type: BreathMask

--- a/Resources/Prototypes/_Floof/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: ClothingOuterHardsuitSyndieMedic
   id: ClothingOuterHardsuitSurgeonGeneral
-  name: Surgeon general hardsuit
-  description: A protective hardsuit worn by the Surgeon Generial, tailor by SESWC.
+  name: NT-444SG - "Jegudiel" Hardsuit
+  description: An advanced medical hardsuit made for the Surgeon General. It is branded with the NanoTrasen logo and a strange-looking series number. The armor appears to be lined with a very sturdy alloy, and it feels incredibly light.
   components:
   - type: Sprite
     sprite: _Floof/Clothing/OuterClothing/Hardsuits/surgengeneralhardsuit.rsi
@@ -10,11 +10,11 @@
     sprite: _Floof/Clothing/OuterClothing/Hardsuits/surgengeneralhardsuit.rsi
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitERTMedical
-    
+
 - type: entity
   parent: [ClothingOuterEVASuitBase, ClothingOuterStorageBase]
   id: ClothingOuterHardsuitFreelancerPilot
-  name: FL-02bt - "Pilot" Freelancer Softsuit
+  name: FL-02BT - "Pilot" Freelancer Softsuit
   description: A armored soft suit. "Maximum speed for minimal protection."
   components:
   - type: Sprite
@@ -35,11 +35,11 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
-    
+
 - type: entity
   parent: [ClothingOuterEVASuitBase, ClothingOuterStorageBase]
   id: ClothingOuterHardsuitFreelancerLegion
-  name: FL-03a - "Legion" Freelancer Softsuit
+  name: FL-03A - "Legion" Freelancer Softsuit
   description: A medium armored soft suit. "You ask if its reliable? We say a ton."
   components:
   - type: Sprite
@@ -60,11 +60,11 @@
   - type: ClothingSpeedModifier
     walkModifier: 0.90
     sprintModifier: 0.90
-    
+
 - type: entity
   parent: [ClothingOuterEVASuitBase, ClothingOuterStorageBase]
   id: ClothingOuterHardsuitFreelancerNorthstar
-  name: FL-04x - "Northstar" Freelancer Softsuit
+  name: FL-04X - "Northstar" Freelancer Softsuit
   description: A medium armored soft suit with build and advanced non functioning cloaking system. "When the clouds clear you will see the light of the Northstar"
   components:
   - type: Sprite
@@ -90,8 +90,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterHardsuitSecTech
-  name: security technician hardsuit
-  description: A security hardsuit specialized for engineering work. Some of the protective lining has been swapped out.
+  name: FPA-41SE - "Aara" Tacsuit
+  description: A sturdy tactical combat engineer hardsuit mass-produced by Five-Points Armory, commonly found on Combat Engineers galaxy-wide. The tags on the suit indicate that its specially rated for radiation protection and mild to moderate amounts of physical trauma and thermal damage. It feels heavy.
   components:
   - type: Sprite
     sprite: _Floof/Clothing/OuterClothing/Hardsuits/sectech.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -2,8 +2,8 @@
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ] # Harmony - Changed parent to upstream convention
   id: ClothingHeadHelmetHardsuitCybersunStealth
   # suffix: stealth - Harmony change
-  name: cybersun stealth hardsuit helmet
-  description: A helmet with plating for stealth operations.
+  name: CSA-48OS Stealth Hardsuit Helmet
+  description: The Ronin's helmet. Lightly armored and required for the stealth capabilities to work.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/Head/Hardsuits/cybersunstealth.rsi

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -2,8 +2,8 @@
   parent: [ ClothingOuterHardsuitBase, BaseSyndicateContraband ]
   id: ClothingOuterHardsuitCybersunStealth
   # suffix: stealth - Harmony change
-  name: cybersun stealth hardsuit
-  description: A hardsuit with stealth plating for operations, the shielding doesn't work while you're moving though! Needs the helmet on to finish the stealth field.
+  name: CSA-48OS "Ronin" Sealth Hardsuit
+  description: A stealth hardsuit reverse-engineered from Spider Clan technology by the Cybersun Armaments Corporation. The armor appears to be lined with a resonating alloy, reducing its effectiveness but allowing it to go invisible while standing still. It doesn't seem to have any weight.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Hardsuits/cybersunstealth.rsi
@@ -21,7 +21,7 @@
       coefficients:
         Blunt: 0.7 # DeltaV - was 0.65
         Slash: 0.7 # DeltaV - was 0.65
-        Piercing: 0.6 
+        Piercing: 0.6
         Heat: 0.8 # DeltaV - was 0.6
         Radiation: 0.8 # DeltaV - was 0.55
         #Caustic: 0.7 # DeltaV

--- a/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -2,9 +2,9 @@
 - type: entity
   parent: [ ClothingHeadHardsuitBase, ClothingHeadSuitWithLightBase ]
   id: ClothingHeadHelmetHardsuitPilot
-  categories: [ HideSpawnMenu ]
-  name: pilot hardsuit helmet
-  description: Light hardsuit helmet for pilots.
+  categories:
+  name: RI-4202 Helmet
+  description: Light hardsuit helmet for 'Robust' pilots. Produced by Robust Industries.
   components:
   - type: BreathMask
   - type: Sprite

--- a/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_NF/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -2,8 +2,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBaseNF
   id: ClothingOuterHardsuitPilot
-  name: pilot hardsuit
-  description: A hardsuit tailored for someone who spends the majority of their time buckled to a chair.
+  name: RI-4202 - "Icarus" Piloting Hardsuit
+  description: A hardsuit tailored for pilots, and also Robust Industries' first and only hardsuit on the market. The tags indicate it protects from high radiation exposure, mild physical trauma, and mild chemical spills. It feels somewhat light.
   components:
   - type: Sprite
     sprite: _NF/Clothing/OuterClothing/Hardsuits/pilot.rsi


### PR DESCRIPTION
## About the PR
Changed a bunch of hard/softsuit names and their helmets to be more in-line with pre-rebase because they were cool and added to lore.

## Why / Balance
Purely looks. It's just pretty having the actual designations, nicknames, and whatnot for the hardsuits. Just adds a little bit of fluff to the world.
## Technical details
12+ hours of pure yamlslopping.

## Media
https://imgur.com/a/U0p0xOg
## Requirements

- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.


## Licensing:

- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
The only broken part is the elite syndicate hardsuit and helmet are still using their DV names instead of the pre-rebase (modified) ones. I cannot find the Thermal Suit and Thermal Helmet names so they're the only pair with code changes but no effect. Everything else works.
**Changelog**
:cl:
- tweak: Renamed and redescribed hardsuits, softsuits, and their helmets to be more in-line with pre-rebase.
