### PR TITLE
Grenades are now catchable

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/plastic.yml
@@ -34,6 +34,10 @@
         base:
           Primed: { state: primed }
           Unprimed: { state: icon }
+  - type: Catchable # Euphoria - Think fast chuck nuts
+    catchChance: 0.75
+    catchSuccessSound:
+      path: /Audio/Effects/Footsteps/bounce.ogg
 
 - type: entity
   name: composition C-4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/base_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/base_grenades.yml
@@ -47,6 +47,10 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+  - type: Catchable # Euphoria - Think fast chuckle nuts
+    catchChance: 0.75
+    catchSuccessSound:
+      path: /Audio/Effects/Footsteps/bounce.ogg
 
 - type: entity # Starts fuse after taking 10 damage, instantly detonates/activates after taking 45 damage.
   abstract: true

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -350,6 +350,10 @@
           # Unprimed: <Use state determined by enum.ConstructionVisuals.Layer>
   - type: StaticPrice
     price: 75
+  - type: Catchable # Euphoria - Think fast chuck nuts
+    catchChance: 0.75
+    catchSuccessSound:
+      path: /Audio/Effects/Footsteps/bounce.ogg
 
 - type: entity
   name: EMP grenade


### PR DESCRIPTION
## About the PR
Adds Catchable Component to grenades and plastic explosives.

## Why / Balance
Funny. Anyway, the idea came to me while I was playing fetch with a tennis ball with someone. I was like, this would be pretty fun with a grenade (in LOOC), and everyone was like "do it".

Grenade wise, you'd either, look in your hand and panic, or throw it. Or if you're unlucky, the thrower has cooked it, and you have milliseconds to react.

**Changelog**
:cl:
- add: You can now catch grenades. A test of your reflexes.
