### PR TITLE
Lewd access toggle and lewd system improvements

### DIFF
--- a/Content.Server/_Floof/InteractionVerbs/Actions/Lewd/ToggleLewdAccessibleAction.cs
+++ b/Content.Server/_Floof/InteractionVerbs/Actions/Lewd/ToggleLewdAccessibleAction.cs
@@ -1,0 +1,25 @@
+using Content.Shared._Floof.InteractionVerbs;
+using Content.Shared._Floof.Lewd.Components;
+
+namespace Content.Server._Floof.InteractionVerbs.Actions.Lewd;
+
+/// <summary>
+///     Toggles whether others' and the user can interact with their lewd organs through clothing.
+/// </summary>
+public sealed partial class ToggleLewdAccessBypassAction : InteractionAction
+{
+    public override bool IsAllowed(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps) =>
+        deps.EntMan.HasComponent<LewdMobDataComponent>(args.Target);
+
+    public override bool CanPerform(InteractionArgs args, InteractionVerbPrototype proto, bool beforeDelay, VerbDependencies deps) =>
+        IsAllowed(args, proto, deps);
+
+    public override bool Perform(InteractionArgs args, InteractionVerbPrototype proto, VerbDependencies deps)
+    {
+        if (!deps.TryComp<LewdMobDataComponent>(args.Target, out var lewd))
+            return false;
+
+        lewd.BypassClothingChecks = !lewd.BypassClothingChecks;
+        return true;
+    }
+}

--- a/Content.Server/_Floof/InteractionVerbs/Actions/Lewd/ToggleLewdAccessibleAction.cs
+++ b/Content.Server/_Floof/InteractionVerbs/Actions/Lewd/ToggleLewdAccessibleAction.cs
@@ -20,6 +20,7 @@ public sealed partial class ToggleLewdAccessBypassAction : InteractionAction
             return false;
 
         lewd.BypassClothingChecks = !lewd.BypassClothingChecks;
+        deps.EntMan.Dirty(args.Target, lewd);
         return true;
     }
 }

--- a/Content.Server/_Floof/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/_Floof/InteractionVerbs/InteractionVerbsSystem.cs
@@ -1,10 +1,12 @@
 using System.Linq;
 using Content.Server.Chat.Managers;
+using Content.Server.Examine;
 using Content.Shared._Floof.InteractionVerbs;
 using Content.Shared.Ghost;
 using Content.Shared.Interaction;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
+using NetCord;
 using Robust.Shared.Player;
 
 namespace Content.Server._Floof.InteractionVerbs;
@@ -13,6 +15,7 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
 {
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly SharedInteractionSystem _interactions = default!;
+    [Dependency] private readonly ExamineSystem _examine = default!;
 
     private EntityQuery<OccluderComponent> _occluderQuery;
 
@@ -47,20 +50,28 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
             _chatManager.ChatMessageToManyFiltered(filter, popup.LogChannel, message, wrappedMessage, source, false, false, color);
     }
 
-    private Color InferColor(PopupType popup) => popup switch
+    private Robust.Shared.Maths.Color InferColor(PopupType popup) => popup switch
     {
         // These are all hardcoded on client-side, so we have to improvise
-        PopupType.LargeCaution or PopupType.MediumCaution or PopupType.SmallCaution => Color.Red,
-        PopupType.Medium or PopupType.Small => Color.LightGray,
-        _ => Color.White
+        PopupType.LargeCaution or PopupType.MediumCaution or PopupType.SmallCaution => Robust.Shared.Maths.Color.Red,
+        PopupType.Medium or PopupType.Small => Robust.Shared.Maths.Color.LightGray,
+        _ => Robust.Shared.Maths.Color.White
     };
 
     private bool CanSee(EntityUid source, EntityUid target, float maxRange)
     {
+        // Make sure to call the overload of InRangeUnobstructed that doesn't do an override check
+        // Otherwise the ai eye will see all interacts.
+        var targetXForm = Transform(target);
+
         // TODO: InRangeUnobstructed has a pretty high performance cost and is not intended to be used like that.
         // We should see if we can move this to client side later, aka make the client check if the target is visible for it.
         return _interactions.InRangeUnobstructed(
-            source, target, maxRange,
+            source,
+            (target, targetXForm),
+            targetXForm.Coordinates,
+            targetXForm.LocalRotation,
+            maxRange,
             CollisionGroup.Opaque,
             uid => !_occluderQuery.TryComp(uid, out var occluder) || !occluder.Enabled, // We ignore all entities that do not occlude light
             false);

--- a/Content.Server/_Floof/InteractionVerbs/InteractionVerbsSystem.cs
+++ b/Content.Server/_Floof/InteractionVerbs/InteractionVerbsSystem.cs
@@ -15,7 +15,6 @@ public sealed class InteractionVerbsSystem : SharedInteractionVerbsSystem
 {
     [Dependency] private readonly IChatManager _chatManager = default!;
     [Dependency] private readonly SharedInteractionSystem _interactions = default!;
-    [Dependency] private readonly ExamineSystem _examine = default!;
 
     private EntityQuery<OccluderComponent> _occluderQuery;
 

--- a/Content.Shared/_Floof/Clothing/SlotBlocker/SlotBlockerSystem.cs
+++ b/Content.Shared/_Floof/Clothing/SlotBlocker/SlotBlockerSystem.cs
@@ -3,6 +3,8 @@ using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.Inventory.Events;
 using Content.Shared.Whitelist;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
 
 
 namespace Content.Shared._Floof.Clothing.SlotBlocker;
@@ -17,6 +19,9 @@ public sealed class SlotBlockerSystem : EntitySystem
 
     private EntityQuery<SlotBlockerComponent> _blockerQuery = default!;
     private EntityQuery<ClothingComponent> _clothingQuery = default!;
+
+    // Singleton entities spawned in nullspace for more advanced checks
+    private Dictionary<EntProtoId, EntityUid> Singletons = new();
 
     public override void Initialize()
     {
@@ -104,6 +109,26 @@ public sealed class SlotBlockerSystem : EntitySystem
     }
 
     /// <summary>
+    ///     Variant of IsSlotObstructedOrOccupied that uses a singleton entity to do more advanced checks.
+    ///     Singleton entities are only spawned once.
+    /// </summary>
+    public bool IsSlotObstructedOrOccupied(
+        Entity<InventoryComponent?> ent,
+        EntProtoId equipmentProto,
+        CheckType check,
+        SlotFlags targetSlot,
+        out string? reason)
+    {
+        if (!Singletons.TryGetValue(equipmentProto, out var equipment) || Deleted(equipment))
+        {
+            equipment = Spawn(equipmentProto, MapCoordinates.Nullspace);
+            Singletons[equipmentProto] = equipment;
+        }
+
+        return IsSlotObstructedOrOccupied(ent, equipment, check, targetSlot, out reason);
+    }
+
+    /// <summary>
     ///     Checks whether any slot with the target flags is occupied, returns true if so. Otherwise, checks if it is obstructed and returns that.
     ///     See <see cref="IsSlotObstructed"/>
     /// </summary>
@@ -118,6 +143,14 @@ public sealed class SlotBlockerSystem : EntitySystem
         if (!Resolve(ent, ref ent.Comp))
             return false;
 
+        if (IsSlotOccupied(ent!, equipment, targetSlot))
+            return true;
+
+        return IsSlotObstructed(ent!, equipment, check, targetSlot, out reason);
+    }
+
+    private static bool IsSlotOccupied(Entity<InventoryComponent> ent, EntityUid? equipment, SlotFlags targetSlot)
+    {
         // Code duplication, blegh
         var slots = ent.Comp.Slots;
         for (int i = 0; i < slots.Length; i++)
@@ -127,18 +160,18 @@ public sealed class SlotBlockerSystem : EntitySystem
                 continue;
 
             var container = ent.Comp.Containers[i];
-            if (container.ContainedEntity is not { Valid: true } other || other == equipment?.Owner)
+            if (container.ContainedEntity is not { Valid: true } other || other == equipment)
                 continue;
 
             // The target slot contains an entity, and that entity is not the equipment (if any).
             return true;
         }
 
-        return IsSlotObstructed(ent!, equipment, check, targetSlot, out reason);
+        return false;
     }
 
     /// <summary>
-    ///     Checks whether a slot (or any of the slots) is blocked.
+    ///     Checks whether a slot (or any of the slots) is blocked. This does NOT check if it's blocked (occupied) by something.
     /// </summary>
     /// <param name="ent">Entity to check for blocking clothing.</param>
     /// <param name="equipment">Entity getting equipped/unequipped. Optional. If present, will check "blocked by" and apply blocker whitelists.</param>

--- a/Content.Shared/_Floof/Humanoid/ModifyUndies/ModifyUndiesSystem.cs
+++ b/Content.Shared/_Floof/Humanoid/ModifyUndies/ModifyUndiesSystem.cs
@@ -50,7 +50,7 @@ public sealed class ModifyUndiesSystem : EntitySystem
             return;
 
         if (args.User != args.Target
-            && _slotBlocker.IsSlotObstructedOrOccupied(args.Target, null, IgnoreBlockerPreference, SlotFlags.INNERCLOTHING, out _))
+            && _slotBlocker.IsSlotObstructedOrOccupied(args.Target, "VirtualClothingPanties", IgnoreBlockerPreference, SlotFlags.INNERCLOTHING, out _))
             return; // mainly so people cant just spy on others undies *too* easily
 
         var isMine = args.User == args.Target;

--- a/Content.Shared/_Floof/InteractionVerbs/Requirements/LewdAccessibleRequirement.cs
+++ b/Content.Shared/_Floof/InteractionVerbs/Requirements/LewdAccessibleRequirement.cs
@@ -1,0 +1,64 @@
+using Content.Shared._Floof.Clothing.SlotBlocker;
+using Content.Shared._Floof.Humanoid.ModifyUndies;
+using Content.Shared._Floof.Lewd.Components;
+using Content.Shared.Humanoid;
+using Content.Shared.Inventory;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Floof.InteractionVerbs.Requirements;
+
+/// <summary>
+///     Requires the user and the target to consent to lewd interactions, and also one of the following: <br/>
+///     a. The target's underwear is down and accessible (no inner clothing, outer clothing is not obstructing inner clothing) <br/>
+///     b. The target has toggled the "allow lewd access" toggle. <br/>
+/// </summary>
+public sealed partial class LewdAccessibleRequirement : InteractionRequirement
+{
+    [DataField]
+    public bool CheckUserUnderwear, CheckTargetUnderwear;
+
+    /// <summary>
+    ///     Which humanoid layer to consider for underwear. See UnderwearRequirement.
+    /// </summary>
+    [DataField]
+    public HumanoidVisualLayers LayerUser, LayerTarget;
+
+    /// <summary>
+    ///     Virtual item used to check whether the relevant slots are accessible.
+    /// </summary>
+    [DataField]
+    public EntProtoId VirtItemUser = "VirtualClothingPanties", VirtItemTarget = "VirtualClothingPanties";
+
+    [DataField]
+    public SlotFlags UserSlot = SlotFlags.INNERCLOTHING, TargetSlot = SlotFlags.INNERCLOTHING;
+
+    public override bool IsMet(InteractionArgs args,
+        InteractionVerbPrototype proto,
+        InteractionAction.VerbDependencies deps)
+    {
+        if (CheckUserUnderwear && !UnderwearAccessible(args.User, deps, LayerUser, VirtItemUser, UserSlot))
+            return false;
+
+        if (CheckTargetUnderwear && !UnderwearAccessible(args.Target, deps, LayerTarget, VirtItemTarget, TargetSlot))
+            return false;
+
+        return true;
+    }
+
+    private bool UnderwearAccessible(EntityUid mob, InteractionAction.VerbDependencies deps, HumanoidVisualLayers layer, EntProtoId virtItem, SlotFlags slot)
+    {
+        if (deps.TryComp<LewdMobDataComponent>(mob, out var lewd) && lewd.BypassClothingChecks)
+            return true;
+
+        var underwearSystem = deps.System<ModifyUndiesSystem>();
+        if (!underwearSystem.IsMissingUndergarment(mob, layer))
+            return false;
+
+        // This is the most expensive part
+        var blockerSystem = deps.System<SlotBlockerSystem>();
+        if (blockerSystem.IsSlotObstructedOrOccupied(mob, virtItem, SlotBlockerSystem.CheckType.Equip, slot, out _))
+            return false;
+
+        return true;
+    }
+}

--- a/Content.Shared/_Floof/InteractionVerbs/SharedInteractionVerbsSystem.cs
+++ b/Content.Shared/_Floof/InteractionVerbs/SharedInteractionVerbsSystem.cs
@@ -95,7 +95,7 @@ public abstract partial class SharedInteractionVerbsSystem : EntitySystem
         PerformVerb(proto, ev.VerbArgs!, out var success);
         ev.Handled = true;
 
-        if (success && proto.Repeat && ev.VerbArgs!.AllowRepeat)
+        if (success && proto.Repeat && ev.VerbArgs?.AllowRepeat == true)
             ev.Repeat = true;
     }
 

--- a/Content.Shared/_Floof/Lewd/Components/LewdMobDataComponent.cs
+++ b/Content.Shared/_Floof/Lewd/Components/LewdMobDataComponent.cs
@@ -7,18 +7,25 @@ namespace Content.Shared._Floof.Lewd.Components;
 /// <summary>
 ///     Stores a cached list of all lewd organs the mob has, for use in prediction and to simplify checks.
 /// </summary>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState, Access(typeof(LewdOrganSystem))]
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class LewdMobDataComponent : Component
 {
-    [DataField(serverOnly: true), Access(Other = AccessPermissions.ReadWriteExecute)]
+    [DataField(serverOnly: true)]
     public Ticker UpdateInterval = new(TimeSpan.FromSeconds(5));
 
     /// <summary>
     ///     A set of flags containing all organ kinds this mob has.
     /// </summary>
-    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly), Access(typeof(LewdOrganSystem))]
     public LewdOrganKind OrganKinds;
 
-    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly)]
+    [DataField, AutoNetworkedField, ViewVariables(VVAccess.ReadOnly), Access(typeof(LewdOrganSystem))]
     public Dictionary<LewdOrganKind, LewdOrganData> CachedData = new();
+
+    /// <summary>
+    ///     If set to true, the player has chosen to allow other players to perform lewd interactions on them regardless of clothing.
+    ///     This is mostly used in interaction verbs.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool BypassClothingChecks = false;
 }

--- a/Content.Shared/_Floof/Lewd/Systems/LewdOrganSystem.cs
+++ b/Content.Shared/_Floof/Lewd/Systems/LewdOrganSystem.cs
@@ -98,6 +98,7 @@ public sealed class LewdOrganSystem : EntitySystem
                 var message = FormattedMessage.FromMarkupPermissive(Loc.GetString("lewd-examine-organs-self-header"));
                 foreach (var organDescription in organDescriptions)
                     message.AddMarkupPermissive('\n' + organDescription);
+                message.AddMarkupPermissive('\n' + Loc.GetString("lewd-examine-organs-self-footer", ("bypassClothing", ent.Comp.BypassClothingChecks)));
 
                 _examines.SendExamineTooltip(user, ent, message, getVerbs: false, centerAtCursor: false);
             },

--- a/Resources/Locale/en-US/_Floof/interaction/verbs/lewd/lewd-interactions.ftl
+++ b/Resources/Locale/en-US/_Floof/interaction/verbs/lewd/lewd-interactions.ftl
@@ -87,7 +87,7 @@ interaction-LewdFillPV-delayed-target-popup = {THE($user)} starts pounding your 
 interaction-LewdFillPV-success-target-popup = {THE($user)} cums inside you, coating your pussy white!
 # User
 interaction-LewdFillPV-delayed-self-popup = You start pounding {THE($target)}'s pussy...
-interaction-LewdFillPV-success-self-popup = You cum inside {THE($target)}, coating {POSS-ADJ($target)} ass white!
+interaction-LewdFillPV-success-self-popup = You cum inside {THE($target)}, coating {POSS-ADJ($target)} pussy white!
 # Others
 interaction-LewdFillPV-delayed-others-popup = {THE($user)} seems to be pounding {THE($target)}...
 interaction-LewdFillPV-success-others-popup = {THE($user)} seems to finish inside {THE($target)}.

--- a/Resources/Locale/en-US/_Floof/interaction/verbs/lewd/lewd-meta-interactions.ftl
+++ b/Resources/Locale/en-US/_Floof/interaction/verbs/lewd/lewd-meta-interactions.ftl
@@ -1,0 +1,4 @@
+interaction-LewdToggleAccessBypass-name = Toggle clothing bypass
+interaction-LewdToggleAccessBypass-description = Toggle whether others can interact with your lewd organs while bypassing clothes.
+interaction-LewdToggleAccessBypass-success-self-popup = Lewd access toggled.
+interaction-LewdToggleAccessBypass-fail-self-popup = Failed to toggle, your entity may be lacking the relevant organs.

--- a/Resources/Locale/en-US/_Floof/lewd/lewd-examine.ftl
+++ b/Resources/Locale/en-US/_Floof/lewd/lewd-examine.ftl
@@ -2,6 +2,6 @@ lewd-examine-organs-verb = Lewd organs
 lewd-examine-organs-self-header = Lewd organs status (only you can see this):
 lewd-examine-organs-status = - [color=lightblue]{CAPITALIZE($name)}[/color]: [bold]{$fillFraction}[/bold] full.
 lewd-examine-organs-self-footer = { $bypassClothing ->
-    [true] Clothing is bypassed.
-    *[false] Clothing will obstruct these.
+    [true] Clothing bypass enabled.
+    *[false] Clothing bypass disabled: equipped clothing may prevent lewd interactions.
 }

--- a/Resources/Locale/en-US/_Floof/lewd/lewd-examine.ftl
+++ b/Resources/Locale/en-US/_Floof/lewd/lewd-examine.ftl
@@ -1,3 +1,7 @@
 lewd-examine-organs-verb = Lewd organs
 lewd-examine-organs-self-header = Lewd organs status (only you can see this):
 lewd-examine-organs-status = - [color=lightblue]{CAPITALIZE($name)}[/color]: [bold]{$fillFraction}[/bold] full.
+lewd-examine-organs-self-footer = { $bypassClothing ->
+    [true] Clothing is bypassed.
+    *[false] Clothing will obstruct these.
+}

--- a/Resources/Prototypes/_Floof/Entities/Virtual/slot_blocker.yml
+++ b/Resources/Prototypes/_Floof/Entities/Virtual/slot_blocker.yml
@@ -1,0 +1,8 @@
+# These items are only spawned once when first needed and referenced later when needed
+
+# An "item" that can be used to check if the user has no inner clothing and nothing like a hardsuit restricts access from the bottom
+# This item has an InnerClothing slot so it can be "worn" under coats
+- type: entity
+  id: VirtualClothingPanties
+  parent: ClothingUniformEngiThong
+  categories: [ HideSpawnMenu ]

--- a/Resources/Prototypes/_Floof/Interactions/Lewd/base.yml
+++ b/Resources/Prototypes/_Floof/Interactions/Lewd/base.yml
@@ -83,6 +83,7 @@
   allowSelfInteract: true # A user can only trigger it themselves
   requiresHands: false
   requiresCanInteract: false # Allow doing it while cuffed or w/e
+  checkInteractionBlocker: false # Floof
   hideByRequirement: true
   effectSuccess:
     popup: ObviousWithLimitsForOthers

--- a/Resources/Prototypes/_Floof/Interactions/Lewd/lewd_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/Lewd/lewd_interactions.yml
@@ -14,11 +14,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - !type:SlotObstructionRequirement &accessibleUnderwearTarget
-      checkUser: false
-      slot: INNERCLOTHING # Must have accessible groin/breasts
-    - !type:UnderwearRequirement &noTopUndergarmentTarget
-      layer: UndergarmentTop
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentTop
     - !type:SelfTargetRequirement
   action:
     !type:LewdFillContainerFromTarget
@@ -34,10 +32,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - !type:UnderwearRequirement &noBottomUndergarmentTarget
-      checkUser: false
-      layer: UndergarmentBottom
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - !type:SelfTargetRequirement
   action:
     !type:LewdFillContainerFromTarget
@@ -53,8 +50,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *noBottomUndergarmentTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - !type:SelfTargetRequirement
   action:
     !type:LewdFillContainerFromTarget
@@ -73,8 +71,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *noTopUndergarmentTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentTop
     - !type:ConsentRequirement &filledByOthersConsent
       consent: LewdContainerFillByOthers
       inverted: true
@@ -92,8 +91,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *noBottomUndergarmentTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - *filledByOthersConsent
   action:
     !type:LewdFillContainerFromTarget
@@ -109,8 +109,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *noBottomUndergarmentTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - *filledByOthersConsent
   action:
     !type:LewdFillContainerFromTarget
@@ -129,11 +130,12 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - !type:SlotObstructionRequirement &accessibleMouthUser
       checkUser: true
-      slot: MASK # Must have accessible mouth
-    - *noBottomUndergarmentTarget
+      slot: MASK # Must have accessible mouth - this is a hack because LewdAccessibleRequirement can't sanely handle this
   action:
     !type:LewdDrinkFromOrgan
     organ: Penis
@@ -148,9 +150,10 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentTop
     - *accessibleMouthUser
-    - *noBottomUndergarmentTarget
   action:
     !type:LewdDrinkFromOrgan
     organ: Breasts
@@ -167,14 +170,11 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - !type:SlotObstructionRequirement &accessibleUnderwearUser
-      checkUser: true
-      slot: INNERCLOTHING
-    - *noBottomUndergarmentTarget
-    - !type:UnderwearRequirement &noBottomUndergarmentUser
-      checkUser: false
-      layer: UndergarmentBottom
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      checkUserUnderwear: true
+      layerTarget: UndergarmentBottom
+      layerUser: UndergarmentBottom
   action:
     !type:LewdOrganFluidTransfer
     donorOrgan: Penis
@@ -187,10 +187,11 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *accessibleUnderwearUser
-    - *noBottomUndergarmentTarget
-    - *noBottomUndergarmentUser
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      checkUserUnderwear: true
+      layerTarget: UndergarmentBottom
+      layerUser: UndergarmentBottom
   action:
     !type:LewdOrganFluidTransfer
     donorOrgan: Penis
@@ -208,8 +209,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *noBottomUndergarmentTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - !type:SelfTargetRequirement
   action:
     !type:LewdOrganFluidTransfer
@@ -224,8 +226,9 @@
   requirement:
     !type:ComplexRequirement
     requirements:
-    - *accessibleUnderwearTarget
-    - *noBottomUndergarmentTarget
+    - !type:LewdAccessibleRequirement
+      checkTargetUnderwear: true
+      layerTarget: UndergarmentBottom
     - !type:SelfTargetRequirement
   action:
     !type:LewdOrganFluidTransfer

--- a/Resources/Prototypes/_Floof/Interactions/Lewd/meta_interactions.yml
+++ b/Resources/Prototypes/_Floof/Interactions/Lewd/meta_interactions.yml
@@ -1,0 +1,19 @@
+- type: Interaction
+  id: LewdToggleAccessBypass
+  parent: BaseGlobal
+  category: LewdInteraction
+  priority: -99999 # The bottom
+  delay: 0
+  allowSelfInteract: true
+  contactInteraction: false
+  requiresHands: false
+  requiresCanInteract: false
+  checkInteractionBlocker: false
+  hideByRequirement: true
+  effectDelayed: null
+  effectSuccess:
+    popup: Subtle
+  effectFailure:
+    popup: Subtle
+  requirement: !type:SelfTargetRequirement
+  action: !type:ToggleLewdAccessBypassAction

--- a/Resources/Prototypes/_Floof/consent.yml
+++ b/Resources/Prototypes/_Floof/consent.yml
@@ -21,11 +21,6 @@
   description: Toggle this on to disallow yourself from being cloned via paradox anomalies.
 
 - type: consentToggle
-  id: LewdInteractions
-  name: Lewd interactions
-  description: Enabling this allows you to interact with others' and use your own lewd organs. Most of those will require you to have your outer clothing off.
-
-- type: consentToggle
   id: LewdContainerFillByOthers
   name: "Lewd interactions: milking"
   description: Toggle this on to allow others to "milk" you using beakers and other liquid containers. You will still be able to "milk" yourself with this off.


### PR DESCRIPTION
## About the PR
God damn it, i pushed to the wrong repo.

This adds a new interaction verb - clothing bypass - that lets you toggle whether your lewd organs can be used and interacted with while bypassing (ignoring) clothing.

Also improves the slot blocker system to allow using "virtual" (not really virtual, but spawned in nullspace) clothing to check slot obstruction. This means that if you wear e.g. a non-blocking clothing piece such as a winter coat and nothing underneath, it won't stop you and others from interacting with undies and such. Currently this is only used in the undies system and in the lewd interaction verbs.

Also I realized that the LewdInteractions consent wasn't used at all. I removed the toggle proto for now. It doesn't add much and only leads to confusion.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

Showcase of the new slotblocker behavior

https://github.com/user-attachments/assets/a2d31130-687a-4740-bfda-e3c0a05482c9


Showcase of the bypass toggle and lewd interaction verbs working if the target has just an outer clothing with nothing underneath

https://github.com/user-attachments/assets/59c21a06-2c43-4e5f-89f9-bca39726c073

God fucking damn it, and Spectacle encoded them in vp8 which github doesn't support. Pain.

</p></details>

**Changelog**
:cl:
- add: There is now a "clothing bypass" toggle that you can access by right-clicking yourself. Toggling it on allows others and you to interact with your lewd organs regardless of clothing.
- tweak: Some verbs like "toggle undies" can now be used even if the target has outer clothing, so long as they don't have anything underneath and the outer clothing is not a hardsuit or similar.
- fix: Removed the redundant "lewd interactions" consent toggle as it wasn't used anywhere.
- fix: The ai eye should no longer be able to see interaction verb popups from anywhere near a camera.