### PR TITLE
Add Harnesses to Loadout

### DIFF
--- a/Resources/Prototypes/_Floof/Loadouts/Groups/collars.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/collars.yml
@@ -10,6 +10,9 @@
   - ClothingNeckCollarSyndi
   - ClothingNeckCollarBell
   - ClothingNeckShockCollarCivilian
+  - ClothingUncategorizedHarnessBlue
+  - ClothingUncategorizedHarnessPink
+  - ClothingUncategorizedHarnessGray
   - NeckNeckerchief
   - MothCloak
   - CloakWitchCloak

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Civilian/common.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Civilian/common.yml
@@ -28,3 +28,19 @@
   id: ClothingNeckCollarBell
   equipment:
     neck: ClothingNeckCollarBell
+
+# neck - harness
+- type: loadout
+  id: ClothingUncategorizedHarnessBlue
+  equipment:
+    neck: ClothingUncategorizedHarnessBlue
+
+- type: loadout
+  id: ClothingUncategorizedHarnessPink
+  equipment:
+    neck: ClothingUncategorizedHarnessPink
+
+- type: loadout
+  id: ClothingUncategorizedHarnessGray
+  equipment:
+    neck: ClothingUncategorizedHarnessGray


### PR DESCRIPTION
## About the PR
Someone requested harnesses be added to loadouts, so i added them to the neck category.

## Why / Balance
They can go into three slots but i figured the neck slot would be the most unused maybe I'm wrong.

## Technical details
The harnesses colors don't display right in loadouts, but when you load into the round it will give you the proper color, im guessing because of being paintable? but im not to sure

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="788" height="791" alt="image" src="https://github.com/user-attachments/assets/d3aff49f-a5ce-460e-b4a4-6eefb2f1f4fb" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Harnesses have been added to the neck section of loadouts. Note: they will display white in loadouts but will have their proper color in round.
