### PR TITLE
Free Chitinids From Door Stuck By Reducing Fixture Radius

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -84,7 +84,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.35 #Was 0.42. Base radius is 0.35
+          radius: 0.40 #Was 0.42. Base radius is 0.35
         density: 220 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
         restitution: 0.0
         mask:

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -84,8 +84,8 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.42 #Base radius is 0.35
-        density: 200 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
+          radius: 0.35 #Was 0.42. Base radius is 0.35
+        density: 220 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -84,7 +84,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.38 #Was 0.42. Base radius is 0.35
+          radius: 0.39 #Euphoria change. Was 0.42. Base radius is 0.35
         density: 220 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
         restitution: 0.0
         mask:

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -84,8 +84,8 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.42
-        density: 220
+          radius: 0.42 #Base radius is 0.35
+        density: 200 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
         restitution: 0.0
         mask:
         - MobMask

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -84,7 +84,7 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.40 #Was 0.42. Base radius is 0.35
+          radius: 0.38 #Was 0.42. Base radius is 0.35
         density: 220 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
         restitution: 0.0
         mask:

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -84,8 +84,8 @@
       fix1:
         shape:
           !type:PhysShapeCircle
-          radius: 0.39 #Euphoria change. Was 0.42. Base radius is 0.35
-        density: 220 #Euphoria change. Was 220. Max height Chitinids get stuck in doors. Base species density is 185. Base density with Heavyweight trait should be 259. 
+          radius: 0.39 #Euphoria change. Was 0.42. Base radius is 0.35. Any higher, and max-size Chitinid cannot fit through doors. 
+        density: 220 #Base species density is 185. Base density with Heavyweight trait should be 259. 
         restitution: 0.0
         mask:
         - MobMask


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Changed fixture radius for Chitinids from 0.42 to 0.39. (The base species radius is 0.35)

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously, max-height Chitinids were getting stuck on doors. Now, they're just barely able to get through doors with no wiggle room. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just a change to the Chitinid species yml. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="391" height="347" alt="image" src="https://github.com/user-attachments/assets/39ce0fd3-e052-426d-8d6c-b1f644527682" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Changed fixture radius of Chitinids to no longer get stuck in doors. 
