### PR TITLE
Make ModifyLewdOrgansEffect increase solution volume to accomodate for production

### DIFF
--- a/Content.Shared/_Floof/Traits/Effects/ModifyLewdOrgansEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyLewdOrgansEffect.cs
@@ -38,9 +38,12 @@ public sealed partial class ModifyLewdOrgansEffect : BaseTraitEffect
             data.ProductionSpeed *= ProductionMultiplier;
 
             // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (ProductionCapMultiplier != 1 && data.ProducedReagents is not null)
-                for (var i = 0; i < data.ProducedReagents.Length; i++)
+            if (ProductionCapMultiplier != 1 && data.ProducedReagents is not null) {
+                for (var i = 0; i < data.ProducedReagents.Length; i++) {
+                    data.SolutionVolume += data.ProducedReagents[i].Quantity * (ProductionCapMultiplier - 1); // Add volume to accomodate
                     data.ProducedReagents[i] = new(data.ProducedReagents[i].Reagent, data.ProducedReagents[i].Quantity * ProductionCapMultiplier);
+                }
+            }
 
             if (DepositionCapacityBonus != 0)
                 data.SolutionVolume += DepositionCapacityBonus;

--- a/Resources/Locale/en-US/_Floof/traits/lewd.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/lewd.ftl
@@ -12,10 +12,10 @@ trait-basic-Rectum-desc = Your anal tunnel is accessible for deposition of up to
 
 
 # Bonuses
-trait-double-production-name = Double fluid production
+trait-double-production-name = Double fluid production speed
 trait-double-production-desc = All lewd organs you choose produce fluids twice as fast as specified in the description.
 
-trait-quadruple-production-name = Quadruple fluid production
+trait-quadruple-production-name = Quadruple fluid production speed
 trait-quadruple-production-desc = All lewd organs you choose produce fluids four times as fast as specified in the description.
 
 # Factorio flashbacks...


### PR DESCRIPTION
## About the PR
It used not to do that, which caused "quadruple production" and similar traits to have no effect on organs that had no extra volume on top of what's needed for production.

## Technical details
Web-edited, but it should be fine.

## Media
<details>
Before:

<img width="575" height="377" alt="image" src="https://github.com/user-attachments/assets/2327ba7e-dcc3-423a-ad11-fb701e3fa093" />
<img width="575" height="377" alt="image" src="https://github.com/user-attachments/assets/6d13e96c-4096-4b10-83c9-63d4a6425274" />

After:
<img width="730" height="162" alt="image" src="https://github.com/user-attachments/assets/bca32dd9-7ecf-4b65-b827-fb2c5269ab4f" />
<img width="560" height="88" alt="image" src="https://github.com/user-attachments/assets/8bc95331-6551-47f6-95ab-d2f098f44614" />


</details>

**Changelog**
:cl:
- fix: Lewd traits that increase the maximum amount of fluid production should now correctly increase the organ fluid capacity to accommodate for additional fluids.
