### PR TITLE
Double Barrel Shotgun - Both Barrels

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -124,6 +124,12 @@
   - type: GunRequiresWield #remove when inaccuracy on spreads is fixed
   - type: Gun
     fireRate: 3
+    selectedMode: SemiAuto # Euphoria - Both Barrels
+    shotsPerBurst: 2
+    burstFireRate: 30
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: GunSpreadModifier
     spread: 0.6
   - type: BallisticAmmoProvider
@@ -206,6 +212,12 @@
     sprite: _DV/Objects/Weapons/Guns/Shotguns/sawn.rsi # Delta-V
   - type: Gun
     fireRate: 3
+    selectedMode: SemiAuto # Euphoria - Both Barrels
+    shotsPerBurst: 2
+    burstFireRate: 30
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: GunSpreadModifier
     spread: 1.4
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/_Starlight/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -11,6 +11,12 @@
     - 0,0,4,0
   - type: Gun
     fireRate: 3
+    selectedMode: SemiAuto # Euphoria - Both Barrels
+    shotsPerBurst: 2
+    burstFireRate: 30
+    availableModes:
+    - SemiAuto
+    - Burst
   - type: Sprite
     sprite: _Starlight/Objects/Weapons/Guns/Shotguns/forged_shotgun.rsi
   - type: Clothing


### PR DESCRIPTION
## About the PR
Adds a burst fire option to fire both barrels of shotguns with 2 barrels.
Ported from Foxtrot where it was tested, some people also asked for it.

## Why / Balance
Because shotguns with 2 barrels are designed to be able to fire both at once.

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Allows Shotguns with 2 Barrels to unload both in a single click.

