### PR TITLE
Sign Language with one hand

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Floofstation.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Floofstation.cs
@@ -123,7 +123,7 @@ public sealed partial class ChatSystem
 
         // TODO harcoded 2 is bad but not like bad bad
         if (language.SpeechOverride.RequireHands &&
-            (!_actionBlocker.CanComplexInteract(entity) || _hands.CountFreeHands(entity) < 2))
+            (!_actionBlocker.CanComplexInteract(entity) || _hands.CountFreeHands(entity) < 1)) //Changed from 2 to 1 to allow one handed signing.
         {
             if (!silent)
                 _popups.PopupEntity(Loc.GetString("chat-manager-language-requires-hands"), entity, entity, PopupType.Medium);

--- a/Resources/Locale/en-US/_Floof/chat/chat-manager.ftl
+++ b/Resources/Locale/en-US/_Floof/chat/chat-manager.ftl
@@ -18,7 +18,7 @@ chat-manager-language-hint = { $language ->
 # Simple ($language) wrapper.
 chat-manager-language-hint-ui = {" "}({$language})
 
-chat-manager-language-requires-hands = You need free hands to speak this language!
+chat-manager-language-requires-hands = You need at least one free hand to speak this language!
 chat-manager-language-requires-speech = You are unable to speak right now!
 
 # todo move this wherever it belongs


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Lowering the amount of free hands from two to one for the sake of signing.

## Why / Balance
Players who are trying to sign have found that if they are working while talking, they can't really communicate because they have a tool in hand. Most sign languages allow for single hand communication, and requiring two hands was prohibitive for work place RP.

## Technical details
I changed the hardcoded 2 to 1, and the text for trying to sign when you can't.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

Please no..

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Signing now only requires one free hand rather than two.
