### PR TITLE
Make paper and mail fit under doors

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -95,6 +95,19 @@
     materialComposition:
       SheetPrinter: 100
   # Corvax-Printer-End
+  # Euphoria | Slip paper under doors.
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        #- ItemMask # Euphoria | Disabled for slipping papers under doors
+        - SmallMobMask # Euphoria | Slip papers under doors
+        restitution: 0.3  # fite me
+        friction: 0.2
 
 - type: entity
   name: paper scrap

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Mail/base_mail.yml
@@ -113,6 +113,19 @@
     - TauCetiBasic
     understands:
     - TauCetiBasic
+  # Euphoria | Slip paper under doors.
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        #- ItemMask # Euphoria | Disabled for slipping papers under doors
+        - SmallMobMask # Euphoria | Slip papers under doors
+        restitution: 0.3  # fite me
+        friction: 0.2
 
 # This empty parcel is allowed to exist and evade the tests for the admin
 # mailto command.

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/Mail/base_mail_large.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/Mail/base_mail_large.yml
@@ -74,6 +74,18 @@
   - type: Tag
     tags:
     - PackageDelivery
+  # Euphoria | Prevent large packages from going under doors.
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.25,-0.25,0.25,0.25"
+        density: 20
+        mask:
+        - ItemMask
+        restitution: 0.3  # fite me
+        friction: 0.2
 
 - type: entity
   categories: [ HideSpawnMenu ]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Made it so paper and mail can be slid under doors.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was a feature we used to have.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Makes BasePaper and BaseMail use a different collision mask that ignores doors. Forces BaseMailLarge to use the original mask so big parcels don't go under doors.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="268" height="357" alt="image" src="https://github.com/user-attachments/assets/6ae8cf79-eadb-4868-bca7-5632f1d7f11f" />
<img width="170" height="339" alt="image" src="https://github.com/user-attachments/assets/24e274ef-90d3-4cda-a883-3473ad42b38b" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- tweak: Paper and mail can now be slid under airlock doors.
