### PR TITLE
Increased Max Prizes in Arcade Machine

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/Computers/arcades.yml
@@ -115,8 +115,8 @@
   suffix: Filled
   components:
   - type: SpaceVillainArcade
-    rewardMinAmount: 3
-    rewardMaxAmount: 15
+    rewardMinAmount: 30 # Euphoria
+    rewardMaxAmount: 150 # Euphoria
 
 - type: entity
   id: BlockGameArcade


### PR DESCRIPTION
## About the PR
This PR increases the minimum and maximum amount of prizes that can come out of a Space Villain Arcade Machine.

## Why / Balance
There's various reasons, 
there's only a limited amount of filled Space Villain machines on any map, 
you can't refill the machine once empty,
it feels bad to win and get nothing,
there's a lot of prizes in the exchange but not enough tickets for more then 1 to 2 players.

**Changelog**
:cl:
- tweak: Increased the max amount of prizes in a Space Villain Arcade Machine.
