### PR TITLE
Baton Knuckle Duster

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -68,6 +68,7 @@
   - Stunbaton
   - CombatKnife
   - RiotShield
+  - ClothingHandsKnuckleDustersStun # Euphoria
 
 ## Dynamic recipes
 

--- a/Resources/Prototypes/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/security.yml
@@ -197,6 +197,14 @@
     Steel: 250
     Plastic: 100
 
+- type: latheRecipe # Euphoria
+  parent: BaseWeaponRecipeMelee
+  id: ClothingHandsKnuckleDustersStun
+  result: ClothingHandsKnuckleDustersStun
+  materials:
+    Steel: 300
+    Plastic: 300
+
 # Practice weapons
 - type: latheRecipe
   parent: BaseWeaponRecipePractice

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -459,6 +459,7 @@
   loadouts:
   - SecurityClothingHandsGlovesColorBlack
   - SecurityClothingHandsGlovesFingerless
+  - ClothingHandsKnuckleDustersStun # Euphoria
 
 ## Security Glasses
 - type: loadoutGroup

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/common.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/common.yml
@@ -12,3 +12,8 @@
   id: UniformSecCatsuit
   equipment:
     jumpsuit: ClothingUniformSecCatsuit
+
+- type: loadout
+  id: ClothingHandsKnuckleDustersStun
+  equipment:
+    jumpsuit: ClothingHandsKnuckleDustersStun


### PR DESCRIPTION
## About the PR
Adds the stun knuckle dusters (which is just a stun baton in knuckle duster form) to the security gloves loadout and secfab.

## Why / Balance
I saw an admin use it for a bit, and I thought to myself, wow that's really mid to use because it's a fist weapon. 
Security players probably would have fun with this, so here it is, another slightly worse way to stun people.

**Changelog**
:cl:
- add: Made stun knuckle dusters available for security loadout and printing.
