### PR TITLE
SimpleStation Dragon Wings Reenabled

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/wings.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Customization/Markings/wings.yml
@@ -45,3 +45,23 @@
     - sprite: _Floof/Mobs/Customization/wings64-32.rsi
       state: bionic_wings_tone_2
       shader: unshaded
+
+- type: marking
+  id: WingsDragon
+  bodyPart: Wings
+  markingCategory: Wings
+  invertedRestrictions: true
+  sprites:
+  - sprite: _SimpleStation/Mobs/Customization/wings64x34.rsi
+    state: dragon
+
+- type: marking
+  id: WingsDragonTwotone
+  bodyPart: Wings
+  markingCategory: Wings
+  invertedRestrictions: true
+  sprites:
+  - sprite: _SimpleStation/Mobs/Customization/wings64x34.rsi
+    state: dragon
+  - sprite: _SimpleStation/Mobs/Customization/wings64x34.rsi
+    state: dragon-inner


### PR DESCRIPTION
## About the PR
Reenabled the dragon wings from SimpleStation 14 in Resources\Prototypes\_Floof\Entities\Mobs\Customization\Markings\wings.yml

## Why / Balance
We had them pre-rebase and I wanted to port them over before discovering we still had them and they were just (probably mistakenly) omitted from the wings.yml so I put the code in for them to be reenabled

## Technical details
Adds 18 lines of code in the above mentioned .yml to make the wings able to be used as markings. Usable by any species.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="422" height="411" alt="image_2026-05-21_172928910" src="https://github.com/user-attachments/assets/c3072155-ea88-4479-9f69-702fdcd7a2cd" />
<img width="413" height="395" alt="image_2026-05-21_172944184" src="https://github.com/user-attachments/assets/3d0c8116-5307-4d44-b52f-728f92086067" />
<img width="319" height="374" alt="image_2026-05-21_172959041" src="https://github.com/user-attachments/assets/19894d29-28a2-4da3-9dd8-fd969a53edaa" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
N/A

**Changelog**
:cl:
- add: Reenabled the dragon wing markings. Dragon enjoyers rejoice!
