### PR TITLE
Add Medipen Recipe

### DIFF
--- a/Resources/Prototypes/_Floof/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Cooking/medical_recipes.yml
@@ -112,3 +112,40 @@
     Saline: 50
     Bleach: 5
   recipeType: MedicalAssembler # Frontier
+
+- type: microwaveMealRecipe
+  id: RecipeWehMedipen
+  name: weh auto-injector
+  result: WehMedipen
+  time: 5
+  group: Medicinal
+  solids:
+    BlankMediPen: 1
+  reagents:
+    JuiceThatMakesYouWeh: 60
+  recipeType: MedicalAssembler
+
+- type: microwaveMealRecipe
+  id: RecipeCombatMedipen
+  name: combat medipen
+  result: CombatMedipen
+  time: 5
+  group: Medicinal
+  solids:
+    BlankMediPen: 1
+  reagents:
+    Omnizine: 20
+    TranexamicAcid: 10
+  recipeType: MedicalAssembler
+
+- type: microwaveMealRecipe
+  id: RecipeStimpack
+  name: hyperzine injector
+  result: Stimpack
+  time: 5
+  group: Medicinal
+  solids:
+    BlankMediPen: 1
+  reagents:
+    Stimulants: 30
+  recipeType: MedicalAssembler

--- a/Resources/Prototypes/_NF/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/_NF/Recipes/Cooking/medical_recipes.yml
@@ -101,7 +101,7 @@
   solids:
     BlankMediPen: 1
   reagents:
-    Saline: 15
+    Saline: 15 # Euphoria - DV adding funkychem which changed the amount in the pens but the recipe still needed the old amount
     Salbutamol: 15 # Delta-v renamed DexPlus
   recipeType: MedicalAssembler
 
@@ -207,43 +207,4 @@
   reagents:
     Ethylredoxrazine: 15
     Dylovene: 5
-  recipeType: MedicalAssembler
-
-# Euphoria
-
-- type: microwaveMealRecipe
-  id: RecipeWehMedipen
-  name: weh auto-injector
-  result: WehMedipen
-  time: 5
-  group: Medicinal
-  solids:
-    BlankMediPen: 1
-  reagents:
-    JuiceThatMakesYouWeh: 60
-  recipeType: MedicalAssembler
-
-- type: microwaveMealRecipe
-  id: RecipeCombatMedipen
-  name: combat medipen
-  result: CombatMedipen
-  time: 5
-  group: Medicinal
-  solids:
-    BlankMediPen: 1
-  reagents:
-    Omnizine: 20
-    TranexamicAcid: 10
-  recipeType: MedicalAssembler
-
-- type: microwaveMealRecipe
-  id: RecipeStimpack
-  name: hyperzine injector
-  result: Stimpack
-  time: 5
-  group: Medicinal
-  solids:
-    BlankMediPen: 1
-  reagents:
-    Stimulants: 30
   recipeType: MedicalAssembler

--- a/Resources/Prototypes/_NF/Recipes/Cooking/medical_recipes.yml
+++ b/Resources/Prototypes/_NF/Recipes/Cooking/medical_recipes.yml
@@ -101,8 +101,8 @@
   solids:
     BlankMediPen: 1
   reagents:
-    Saline: 20
-    Salbutamol: 20 # Delta-v renamed DexPlus
+    Saline: 15
+    Salbutamol: 15 # Delta-v renamed DexPlus
   recipeType: MedicalAssembler
 
 #Frontier pen recipes
@@ -207,4 +207,43 @@
   reagents:
     Ethylredoxrazine: 15
     Dylovene: 5
+  recipeType: MedicalAssembler
+
+# Euphoria
+
+- type: microwaveMealRecipe
+  id: RecipeWehMedipen
+  name: weh auto-injector
+  result: WehMedipen
+  time: 5
+  group: Medicinal
+  solids:
+    BlankMediPen: 1
+  reagents:
+    JuiceThatMakesYouWeh: 60
+  recipeType: MedicalAssembler
+
+- type: microwaveMealRecipe
+  id: RecipeCombatMedipen
+  name: combat medipen
+  result: CombatMedipen
+  time: 5
+  group: Medicinal
+  solids:
+    BlankMediPen: 1
+  reagents:
+    Omnizine: 20
+    TranexamicAcid: 10
+  recipeType: MedicalAssembler
+
+- type: microwaveMealRecipe
+  id: RecipeStimpack
+  name: hyperzine injector
+  result: Stimpack
+  time: 5
+  group: Medicinal
+  solids:
+    BlankMediPen: 1
+  reagents:
+    Stimulants: 30
   recipeType: MedicalAssembler


### PR DESCRIPTION
## About the PR
This PR adds Medical Assembler recipes for Hyperzine, Combat and Weh Juice Pens.
This PR also fixes airloss auto-injector recipe using the wrong amount of chemicals.

## Why / Balance
The Weh Juice one is jokes, the Airloss one is a fix.
Combat Pens are fine post DV nerf.

**Changelog**
:cl:
- add: Added Medical Assembler Recipes for Hyperzine, Combat and Weh Pens.
- fix: Fixed Airloss Auto-Injector using the wrong amount of chemicals.
