### PR TITLE
Cybernetics Fix: Prybar Arms

### DIFF
--- a/Resources/Prototypes/_Floof/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Floof/Body/Parts/cybernetic.yml
@@ -1,0 +1,23 @@
+- type: entity
+  parent: LeftArmCyberneticBase
+  id: PrybarLeftArm
+  name: prybar left arm
+  description: A cybernetic left arm with the ability to pry doors open.
+  components:
+  - type: BodyPart
+    onAdd:
+    - type: Prying
+      speedModifier: 1.2
+      pryPowered: false
+
+- type: entity
+  parent: RightArmCyberneticBase
+  id: PrybarRightArm
+  name: prybar right arm
+  description: A cybernetic right arm with the ability to pry doors open.
+  components:
+  - type: BodyPart
+    onAdd:
+    - type: Prying
+      speedModifier: 1.2 # DeltaV - change from 1.5
+      pryPowered: false

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/robotics.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/robotics.yml
@@ -1,0 +1,25 @@
+- type: latheRecipe
+  id: PrybarLeftArm
+  result: PrybarLeftArm
+  categories:
+  - Robotics
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 250
+    Plastic: 250
+    Gold: 150
+    Silver: 150
+
+- type: latheRecipe
+  id: PrybarRightArm
+  result: PrybarRightArm
+  categories:
+  - Robotics
+  completetime: 5
+  materials:
+    Steel: 500
+    Glass: 250
+    Plastic: 250
+    Gold: 150
+    Silver: 150

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -15,7 +15,7 @@
     - type: Amputee
       removeBodyPart: Arm
       partSymmetry: Left
-      protoId: JawsOfLifeLeftArm
+      protoId: PrybarLeftArm
       slotId: "left arm"
 
 - type: trait
@@ -34,7 +34,7 @@
     - type: Amputee
       removeBodyPart: Arm
       partSymmetry: Right
-      protoId: JawsOfLifeRightArm
+      protoId: PrybarRightArm
       slotId: "right arm"
 
 - type: trait

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -115,7 +115,7 @@
   parent: RightArmCyberneticBase
   id: JawsOfLifeRightArm
   name: J.W.L right arm
-  description: A cybernetic right arm with the ability to powered doors open. # Euphoria | Description to differentiate from prybar arm
+  description: A cybernetic right arm with the ability to pry powered doors open. # Euphoria | Description to differentiate from prybar arm
   components:
   - type: BodyPart
     onAdd:

--- a/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Parts/cybernetic.yml
@@ -103,7 +103,7 @@
   parent: LeftArmCyberneticBase
   id: JawsOfLifeLeftArm
   name: J.W.L left arm
-  description: A cybernetic left arm with the ability to pry doors open.
+  description: A cybernetic left arm with the ability to pry powered doors open. # Euphoria | Description to differentiate from prybar arm
   components:
   - type: BodyPart
     onAdd:
@@ -115,7 +115,7 @@
   parent: RightArmCyberneticBase
   id: JawsOfLifeRightArm
   name: J.W.L right arm
-  description: A cybernetic right arm with the ability to pry doors open.
+  description: A cybernetic right arm with the ability to powered doors open. # Euphoria | Description to differentiate from prybar arm
   components:
   - type: BodyPart
     onAdd:

--- a/Resources/Prototypes/_Shitmed/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/_Shitmed/Recipes/Lathes/Packs/robotics.yml
@@ -42,6 +42,8 @@
   recipes:
   - JawsOfLifeLeftArm
   - JawsOfLifeRightArm
+  - PrybarLeftArm # Euphoria
+  - PrybarRightArm # Euphoria
   - SpeedLeftLeg
   - SpeedRightLeg
   # - BasicCyberneticEyes # DeltaV - Moved to CyberneticsRobotics

--- a/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Shitmed/Research/civilianservices.yml
@@ -46,6 +46,8 @@
   recipeUnlocks:
   - JawsOfLifeLeftArm
   - JawsOfLifeRightArm
+  - PrybarLeftArm # Euphoria
+  - PrybarRightArm # Euphoria
   - SpeedLeftLeg
   - SpeedRightLeg
   - BasicCyberneticEyes


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Makes the prybar arm traits give actual prybar arms.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Previously allowed 2 point round start Jaws for anyone that took the trait.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
N/A

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="564" height="382" alt="image" src="https://github.com/user-attachments/assets/159c3808-4b3f-4bf3-b759-6a9aa66d0684" />
<img width="554" height="334" alt="image" src="https://github.com/user-attachments/assets/7c4d66f5-b7f5-4a6d-a0f6-511f0209fa01" />
<img width="470" height="249" alt="image" src="https://github.com/user-attachments/assets/8eaf9ceb-3caa-48fa-ba3e-a67e05d498c1" />
<img width="218" height="177" alt="image" src="https://github.com/user-attachments/assets/258fc88e-a59a-4860-8b92-cb180021693c" />
<img width="166" height="119" alt="image" src="https://github.com/user-attachments/assets/df88c563-633c-4289-acd2-eb34b7b6b5dd" />
<img width="251" height="142" alt="image" src="https://github.com/user-attachments/assets/608bee67-080a-475d-92b1-49b640f5599d" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- fix: Fixed the cybernetic prybar arm traits.
