### PR TITLE
Extend lobby duration

### DIFF
--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -21,7 +21,7 @@ public sealed partial class CCVars
     ///     Controls the duration of the lobby timer in seconds. Defaults to 2 minutes and 30 seconds.
     /// </summary>
     public static readonly CVarDef<int>
-        GameLobbyDuration = CVarDef.Create("game.lobbyduration", 150, CVar.ARCHIVE);
+        GameLobbyDuration = CVarDef.Create("game.lobbyduration", 300, CVar.ARCHIVE); // euphoria - let people wind down between the 2-3+ hour rounds we tend to have
 
     /// <summary>
     ///     Controls if players can latejoin at all.

--- a/Content.Shared/CCVar/CCVars.Vote.cs
+++ b/Content.Shared/CCVar/CCVars.Vote.cs
@@ -62,7 +62,7 @@ public sealed partial class CCVars
     ///     Sets the duration of the map vote timer.
     /// </summary>
     public static readonly CVarDef<int>
-        VoteTimerMap = CVarDef.Create("vote.timermap", 90, CVar.SERVERONLY);
+        VoteTimerMap = CVarDef.Create("vote.timermap", 180, CVar.SERVERONLY); // euphoria - compensate for lobby duration
 
     /// <summary>
     ///     Sets the duration of the restart vote timer.
@@ -74,7 +74,7 @@ public sealed partial class CCVars
     ///     Sets the duration of the gamemode/preset vote timer.
     /// </summary>
     public static readonly CVarDef<int>
-        VoteTimerPreset = CVarDef.Create("vote.timerpreset", 60, CVar.SERVERONLY);
+        VoteTimerPreset = CVarDef.Create("vote.timerpreset", 180, CVar.SERVERONLY); // euphoria - compensate for lobby duration
 
     /// <summary>
     ///     Sets the duration of the map vote timer when ALONE.


### PR DESCRIPTION
## About the PR
Extends the lobby's duration to 5 minutes up from 2 minutes and 30 seconds. Also extends the automated lobby/gamemode votes to compensate.
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A byproduct of the discussion in our discord feature request thread "Make half of the current unreadied players count towards secret gamemode rolls" made a few people bring up that the lobby timer seems to be too short for them for one reason or another. This lets people wind down for a little bit longer in-between rounds without making them wait too long and hopefully allow a few more people to ready up at the start of the round.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
First of my many victories on the YAML battlegrounds

<!-- This is default collapsed, readers click to expand it and see all your media -->

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: The lobby duration has been extended to 5 minutes, up from 2 minutes and 30 seconds
