### PR TITLE
Make greenshift non-votable

### DIFF
--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -100,7 +100,7 @@
   - greenshift
   - shittersafarideluxeedition
   name: greenshift-title
-  showInVote: true #4boring4vote # DeltaV - Enable greenshift in gamemode vote
+  showInVote: false #4boring4vote # DeltaV - Enable greenshift in gamemode vote # Floof - disable
   description: greenshift-description
   rules:
   - SpaceTrafficControlFriendlyEventScheduler


### PR DESCRIPTION
## Why / Balance
It's way more harmful than extended to everyone except passengers and prevents extended from ever getting votes.

**Changelog**
:cl:
- tweak: Greenshift has been removed from the gamemode vote - extended is the better option if you want a calm shift.