### PR TITLE
Implement 1/4 of "unreadied" players in lobby as "readied"

### DIFF
--- a/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/SecretRuleSystem.cs
@@ -14,6 +14,8 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Configuration;
 using Robust.Shared.Utility;
+using Content.Shared.GameTicking; // imp
+using Robust.Server.Player; // imp
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -93,6 +95,28 @@ public sealed class SecretRuleSystem : GameRuleSystem<SecretRuleComponent>
         var options = _prototypeManager.Index(weights).Weights.ShallowClone();
         var players = GameTicker.ReadyPlayerCount();
         var totalPlayers = _player.PlayerCount; //DeltaV
+
+        // imp edit start
+        var unreadied = 0;
+
+        // get every UNREADIED player
+        foreach (var (userId, status) in GameTicker.PlayerGameStatuses)
+        {
+            if (status != PlayerGameStatus.NotReadyToPlay)
+                continue;
+
+            if (!_player.TryGetSessionById(userId, out _))
+                continue;
+
+            unreadied++;
+        }
+
+        // divide it by four because not all unreadied players will actually join the round
+        unreadied /= 4;
+
+        // add it to players. a quarter of the unreadied amount will count for game preset rolling
+        players += unreadied;
+        // imp edit end
 
         GamePresetPrototype? selectedPreset = null;
         var sum = options.Values.Sum();


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Port of https://github.com/impstation/imp-station-14/pull/4261
Title

## Why / Balance
We have been having issues with rolling antags/gamemodes. When secret is chosen, often there is barely enough players to try the round, and then when it comes time to roll antags, there isn't anyone able to be the antag due to the selected preset. This allows for more presets to be choose able. 

## Technical details
it takes a count of unreadied players, divides it by four, and adds it to the readied player count

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
Due to the nature of these changes, its difficult to test in a dev environment. While this will allow for more presets to be available, it also means there is a higher likelihood of round start failure. I suspect that with this change we would see more antag rounds, but also more rounds not starting correctly due to no antags being available.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: 1/4 of unreadied players count as readied for secret round calculation.
