### PR TITLE
Remove hydraulic sound from HarpyPurrs soundCollection

### DIFF
--- a/Resources/Prototypes/_DV/SoundCollections/harpy.yml
+++ b/Resources/Prototypes/_DV/SoundCollections/harpy.yml
@@ -175,7 +175,7 @@
   id: HarpyPurrs
   files:
   - /Audio/Nyanotrasen/Voice/Felinid/cat_purr1.ogg
-  - /Audio/Mecha/sound_mecha_hydraulic.ogg
+  #- /Audio/Mecha/sound_mecha_hydraulic.ogg # Euphoria - Removed so that harpies can purr normally, with no chance of loud hydraulic jumpscares.
 
 - type: soundCollection
   id: HarpyRings


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
I removed sound_mecha_hydraulic.ogg from the HarpyPurrs soundCollection because, well... I can't imagine it's supposed to be there. Now when harpies purr it is always a purring noise, instead of a 50/50 chance of sounding like an APLU. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
In addition to being generally out of place, as someone who likes to play a felinid/harpy hybrid that likes to purr a lot, I have had multiple experiences where it was disruptive. Occasionally characters decide not to ignore it and I have to explain why my character just made that noise. In multiple instances I've been in relaxing, intimate scenes, decided to risk purring, and startled people with the sound of sudden activation of large industrial machinery coming from the catbird in their arms. One person spilled their drink on their keyboard. It was hilarious the first time, not so much the 308th. 

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Harpy purrs no longer have a chance to sound like an APLU.
