### PR TITLE
Make Honkbots more annoying

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -236,6 +236,14 @@
       path: /Audio/Items/bikehorn.ogg
       params:
         variation: 0.125
+  - type: TriggerOnMobstateChange # Euphoria Start
+      mobState:
+      - Dead
+  - type: ScatteringGrenade
+    fillPrototype: HoloPeel
+    capacity: 10
+    randomDistance: true
+    randomThrowDistanceMax: 5
 
 - type: entity
   parent: MobHonkBot

--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -237,8 +237,8 @@
       params:
         variation: 0.125
   - type: TriggerOnMobstateChange # Euphoria Start
-      mobState:
-      - Dead
+    mobState:
+    - Dead
   - type: ScatteringGrenade
     fillPrototype: HoloPeel
     capacity: 10


### PR DESCRIPTION
## About the PR
Makes Honkbots explode into Holopeels on death.

## Why / Balance
:)

## Requirements

- [ ] I have tested all added content and changes.
Awaiting a tester. (Content was tested on previous codebase as a part of a xenos buff)
- [ ] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Made Honkbots have the last laugh.
