### PR TITLE
Cats and mice and cats and mice and

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -3507,7 +3507,7 @@
   - type: Speech
     speechSounds: Cat
     speechVerb: SmallMob
-    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'SoftTrill', 'FelineTrill'] #Euphoria | Cat emotes!
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl'] #Euphoria | Cat emotes!
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -3547,6 +3547,7 @@
     tags:
     - VimPilot
     - TajaranEmotes # Euphoria | Cat emotes
+    - DoorBumpOpener # Euphoria | Parity with emotional support cats
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 4
@@ -3678,9 +3679,6 @@
   - type: Temperature
     heatDamageThreshold: 423
     coldDamageThreshold: 0
-  - type: Tag
-    tags:
-      - DoorBumpOpener
   - type: MovementAlwaysTouching
   - type: PressureImmunity
   - type: ProtectedFromStepTriggers

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2173,6 +2173,10 @@
       behaviors:
       - !type:GibBehavior
         recursive: false
+  - type: NightVision # Euphoria | Mice see in the dark
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
 
 - type: entity
   parent: MobMouse
@@ -3503,6 +3507,7 @@
   - type: Speech
     speechSounds: Cat
     speechVerb: SmallMob
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'SoftTrill', 'FelineTrill'] #Euphoria | Cat emotes!
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -3541,6 +3546,7 @@
   - type: Tag
     tags:
     - VimPilot
+    - TajaranEmotes # Euphoria | Cat emotes
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
     baseSprintSpeed: 4
@@ -3554,6 +3560,19 @@
   - type: NpcFactionMember # DeltaV - give cats faction so they fight mice
     factions:
     - Cat
+  - type: NightVision # Euphoria | Cats see in the dark
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
+  - type: Puller # Euphoria | Let cats drag things off
+    needsHands: False
+  - type: Emoting
+  - type: Vocal # Euphoria | Let cats purr
+    wilhelm: "/Audio/Nyanotrasen/Voice/Felinid/cat_wilhelm.ogg"
+    sounds:
+      Male: Cat
+      Female: Cat
+      Unsexed: Cat
 
 - type: entity
   name: calico cat
@@ -3630,6 +3649,13 @@
         Slash: 6
         Piercing: 6
         Structural: 15
+  - type: IntrinsicRadioReceiver # Euphoria | Meows in chat
+  - type: IntrinsicRadioTransmitter # Euphoria | Meows in chat
+    channels:
+    - Syndicate
+  - type: ActiveRadio # Euphoria | Meows in chat
+    channels:
+    - Syndicate
 
 - type: entity
   name: space cat

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -40,7 +40,7 @@
   - type: Speech
     speechSounds: Alto
     speechVerb: Felinid
-    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'SoftTrill', 'FelineTrill']
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl']
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -40,7 +40,7 @@
   - type: Speech
     speechSounds: Alto
     speechVerb: Felinid
-    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl']
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'SoftTrill', 'FelineTrill']
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emote_sounds.yml
@@ -42,6 +42,10 @@
       collection: MaleDeathGasp
     Gulp: # Goob
       path: /Audio/_Goobstation/Voice/Human/gulp.ogg
+    SoftTrill: # Euph
+      collection: SoftTrills
+    FelineTrill: # Euph
+      collection: FelineTrills
 
 - type: emoteSounds
   id: FemaleFelinid
@@ -86,3 +90,7 @@
       collection: FemaleDeathGasp
     Gulp: # Goob
       path: /Audio/_Goobstation/Voice/Human/gulp.ogg
+    SoftTrill: # Euph
+      collection: SoftTrills
+    FelineTrill: # Euph
+      collection: FelineTrills

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/nukiemouse.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/nukiemouse.yml
@@ -95,10 +95,10 @@
           Quantity: 5
   - type: Butcherable
     spawned:
-    - id: FoodMeat
+    - id: FoodMeatRat # Euphoria | Was FoodMeat
       amount: 1
-  - type: ReplacementAccent
-    accent: mouse
+  # - type: ReplacementAccent # Euphoria | Mice Mouse instead
+  #   accent: mouse
   - type: Tag
     tags:
     - VimPilot
@@ -107,6 +107,7 @@
     - Meat
     - FootstepSound
     - Radio
+    - ChefPilot # Euphoria | Nukatouille
   - type: Puller
     needsHands: False
   - type: NoSlip
@@ -160,3 +161,27 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/Animals/mouse_squeak.ogg
+  - type: NightVision # Euphoria | Mice see in the dark
+    color: "#808080"
+    activateSound: null
+    deactivateSound: null
+  - type: Clothing # Euphora | Mice go on your head
+    quickEquip: false
+    sprite: _DV/Mobs/Animals/nukiemouse.rsi
+    slots:
+    - HEAD
+  - type: LanguageKnowledge # Euphoria | Mice can mouse
+    speaks:
+    - Mouse
+    understands:
+    - TauCetiBasic # Euphoria | Trained mouse
+    - Mouse
+  - type: LeashAnchor # Euphoria | Take the nukie for a walk
+    kind: Intrinsic
+  - type: FoodSequenceElement # Euphoria | Mouse food
+    entries:
+      Taco: RatTaco
+      Burger: RatBurger
+      Skewer: RatSkewer
+  - type: Item # Euphoria | Pick up mouse
+    size: Tiny

--- a/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
@@ -54,6 +54,8 @@
         Piercing: 1
   - type: Speech
     speechSounds: Alto
+    speechVerb: Felinid
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'SoftTrill', 'FelineTrill']
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
@@ -55,6 +55,7 @@
   - type: Speech
     speechSounds: Alto
     speechVerb: Felinid
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl']
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
@@ -55,7 +55,6 @@
   - type: Speech
     speechSounds: Alto
     speechVerb: Felinid
-    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl', 'SoftTrill', 'FelineTrill']
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
+++ b/Resources/Prototypes/_EE/Entities/Mobs/Species/tajaran.yml
@@ -54,8 +54,8 @@
         Piercing: 1
   - type: Speech
     speechSounds: Alto
-    speechVerb: Felinid
-    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl']
+    speechVerb: Felinid # Euphoria
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl'] # Euphoria | Emote wheel
   - type: DamageOnHighSpeedImpact # Landing on all fours!
     damage:
       types:

--- a/Resources/Prototypes/_Floof/Voice/Emotes/tajaran.yml
+++ b/Resources/Prototypes/_Floof/Voice/Emotes/tajaran.yml
@@ -1,6 +1,7 @@
 - type: emote
   id: SoftTrill
   name: chat-emote-name-softtrill
+  icon: _DV/Interface/Emotes/purr.png
   category: Vocal
   whitelist:
     tags:
@@ -23,6 +24,7 @@
 - type: emote
   id: FelineTrill
   name: chat-emote-name-felinetrill
+  icon: _DV/Interface/Emotes/purr.png
   category: Vocal
   whitelist:
     tags:

--- a/Resources/Prototypes/_Floof/Voice/SpeechEmoteSounds/tajaran.yml
+++ b/Resources/Prototypes/_Floof/Voice/SpeechEmoteSounds/tajaran.yml
@@ -2,17 +2,7 @@
 - type: emoteSounds
   id: MaleTajaran
   parent: MaleFelinid
-  sounds:
-    SoftTrill:
-      collection: SoftTrills
-    FelineTrill:
-      collection: FelineTrills
 
 - type: emoteSounds
   id: FemaleTajaran
   parent: FemaleFelinid
-  sounds:
-    SoftTrill:
-      collection: SoftTrills
-    FelineTrill:
-      collection: FelineTrills

--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/emotionalsupportanimals.yml
@@ -27,6 +27,7 @@
     - CannotSuicide
     - DoorBumpOpener
     - VimPilot
+    - TajaranEmotes # Euphoria | Trills
   - type: Puller
     needsHands: false
   - type: Inventory

--- a/Resources/Prototypes/_NF/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_NF/Voice/speech_emote_sounds.yml
@@ -4,6 +4,25 @@
     path: /Audio/Animals/cat_meow.ogg
     params:
       variation: 0.125
+  sounds:
+    Scream: # Euph
+      collection: FelinidScreams
+    Snore: # Euph
+      collection: Snores
+    Hiss: # Euph
+      collection: FelinidHisses
+    Meow: # Euph
+      collection: FelinidMeows
+    Mew: # Euph
+      collection: FelinidMews
+    Growl: # Euph
+      collection: FelinidGrowls
+    Purr: # Euph
+      collection: FelinidPurrs
+    SoftTrill: # Euph
+      collection: SoftTrills
+    FelineTrill: # Euph
+      collection: FelineTrills
 
 - type: emoteSounds
   id: NfsdCat


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
**Overview of changes**

NukieMouse:
- Now drops rat meat on butcher
- Can speak Mouse instead of accent replace
- Nightvision
- Can be picked up
- Can be worn as a hat
- Nukatouille
- Can be leashed
- Counts as a rat for tacos, burgers, and skewers

SyndiCats:
- Syndicate radio channel

Cats:
- Nightvision
- Drag things
- Emotes

Mice:
- Nightvision

Felinid:
- Trills

Trill emote:
- Purr icon instead of scream

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Tajaran and Rodentia see in the dark, you'd expect cats and mice to do so as well. Syndicats should speak felidae like other cats and have access to syndie comms like other trained animal operatives. Nukie mice should have more parity with regular mice mobs. Especially in the case where they had sprites to be worn as a hat and couldn't be picked up to be worn!

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
YML stuff

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Trill icon change:
<img width="294" height="199" alt="image" src="https://github.com/user-attachments/assets/f9305656-3fba-4c35-93f3-ca3a84df5745" />
Catvision:
<img width="451" height="478" alt="image" src="https://github.com/user-attachments/assets/218032cd-0025-4aa4-961e-3ecfdccc2146" />
<img width="454" height="452" alt="image" src="https://github.com/user-attachments/assets/637d0bf3-d739-4633-a35a-f4cefc077cb0" />
Nukie mouse hat:
<img width="102" height="94" alt="image" src="https://github.com/user-attachments/assets/0d00b953-5564-4cac-ad20-69ccdd2df359" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- tweak: Various enhancements to Nukie Mice, including the ability to be a hat
- tweak: Various enhancements to SyndiCats, Including access to the radio
- tweak: Various enhancements to cats, including the ability to purr
- tweak: Mice can now see in the dark
- tweak: Felinids can now trill, both ways
- tweak: Trill emotes have slightly more fitting icons on the wheel