### PR TITLE
Buffs Reagent Grinder

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/reagent_grinder.yml
@@ -78,7 +78,7 @@
   - type: SolutionContainerManager
     solutions:
       output:
-        maxVol: 400 #*slaps roof of machine* This baby can fit so much omnizine in it
+        maxVol: 1000 # Euphoria - I scream when botany sends me 400 plants
   - type: MaterialReclaimer
     whitelist:
       components:
@@ -117,3 +117,4 @@
     solution: output
   - type: ExaminableSolution
     solution: output
+    exactVolume: true # Euphoria


### PR DESCRIPTION
## About the PR
This PR Buffs the Industrial Reagent Grinder capacity from 400 to 1000 and allows you view it's exact volume.

## Why / Balance
I don't have a decent reason, Botany just sends me 400 plants via the mail chute and it automatically gets belted into the grinder, flooding the floor. Also 400? shit ate like 9 trumpets and overflowed, it was fucked.

**Changelog**
:cl:
- tweak: Buffed industrial reagent grinder capacity and added exact volume viewing.