### PR TITLE
Unrandomizes Shuttle Spawns

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -39,13 +39,6 @@
       roleLoadout:
       - RoleSurvivalStandard
       components:
-      - type: RandomMetadata
-        nameSegments:
-        - NamesFakeHumanFirst
-        - NamesFakeHumanLast
-        nameFormat: name-format-standard
-      - type: RandomHumanoidAppearance
-        randomizeName: false
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -83,13 +76,6 @@
       roleLoadout:
       - RoleSurvivalStandard
       components:
-      - type: RandomMetadata
-        nameSegments:
-        - NamesFakeHumanFirst
-        - NamesFakeHumanLast
-        nameFormat: name-format-standard
-      - type: RandomHumanoidAppearance
-        randomizeName: false
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -126,13 +112,6 @@
       roleLoadout:
       - RoleSurvivalStandard
       components:
-      - type: RandomMetadata
-        nameSegments:
-        - NamesFakeHumanFirst
-        - NamesFakeHumanLast
-        nameFormat: name-format-standard
-      - type: RandomHumanoidAppearance
-        randomizeName: false
       - type: NpcFactionMember
         factions:
         - Syndicate

--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -39,6 +39,13 @@
       roleLoadout:
       - RoleSurvivalStandard
       components:
+      #- type: RandomMetadata # Euphoria - Unrandomized
+      #  nameSegments:
+      #  - NamesFakeHumanFirst
+      #  - NamesFakeHumanLast
+      #  nameFormat: name-format-standard
+      #- type: RandomHumanoidAppearance
+      #  randomizeName: false
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -76,6 +83,13 @@
       roleLoadout:
       - RoleSurvivalStandard
       components:
+      #- type: RandomMetadata # Euphoria - Unrandomized
+      #  nameSegments:
+      #  - NamesFakeHumanFirst
+      #  - NamesFakeHumanLast
+      #  nameFormat: name-format-standard
+      #- type: RandomHumanoidAppearance
+      #  randomizeName: false
       - type: NpcFactionMember
         factions:
         - Syndicate
@@ -112,6 +126,13 @@
       roleLoadout:
       - RoleSurvivalStandard
       components:
+      #- type: RandomMetadata # Euphoria - Unrandomized
+      #  nameSegments:
+      #  - NamesFakeHumanFirst
+      #  - NamesFakeHumanLast
+      #  nameFormat: name-format-standard
+      #- type: RandomHumanoidAppearance
+      #  randomizeName: false
       - type: NpcFactionMember
         factions:
         - Syndicate


### PR DESCRIPTION
## About the PR
Makes it so random shuttle spawns for Arms Dealer, Chemist and Recruiter is no longer random
(praying i've done the right thing)

## Why / Balance
👍 

**Changelog**
:cl:
- tweak: Shuttle Spawns will look more familiar.

