### PR TITLE
Moth Markings Species Compatibility

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Customization/Markings/moth.yml
@@ -3,7 +3,6 @@
   id: MothAntennasDefault
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: default
@@ -12,7 +11,6 @@
   id: MothAntennasCharred
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: charred
@@ -21,7 +19,6 @@
   id: MothAntennasDbushy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: dbushy
@@ -30,7 +27,6 @@
   id: MothAntennasDcurvy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: dcurvy
@@ -39,7 +35,6 @@
   id: MothAntennasDfan
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: dfan
@@ -48,7 +43,6 @@
   id: MothAntennasDpointy
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: dpointy
@@ -57,7 +51,6 @@
   id: MothAntennasFeathery
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: feathery
@@ -66,7 +59,6 @@
   id: MothAntennasFirewatch
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: firewatch
@@ -75,7 +67,6 @@
   id: MothAntennasGray
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: gray
@@ -84,7 +75,6 @@
   id: MothAntennasJungle
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: jungle
@@ -93,7 +83,6 @@
   id: MothAntennasMoffra
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: moffra
@@ -102,7 +91,6 @@
   id: MothAntennasOakworm
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: oakworm
@@ -111,7 +99,6 @@
   id: MothAntennasPlasmafire
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: plasmafire
@@ -120,7 +107,6 @@
   id: MothAntennasMaple
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: maple
@@ -129,7 +115,6 @@
   id: MothAntennasRoyal
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: royal
@@ -138,7 +123,6 @@
   id: MothAntennasStriped
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: striped
@@ -147,7 +131,6 @@
   id: MothAntennasWhitefly
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: whitefly
@@ -156,7 +139,6 @@
   id: MothAntennasWitchwing
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: witchwing
@@ -165,7 +147,6 @@
   id: MothAntennasUnderwing
   bodyPart: HeadTop
   markingCategory: HeadTop
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_antennas.rsi
     state: underwing_primary
@@ -177,7 +158,6 @@
   id: MothWingsDefault
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: default
@@ -186,7 +166,6 @@
   id: MothWingsCharred
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: charred
@@ -195,7 +174,6 @@
   id: MothWingsDbushy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: dbushy_primary
@@ -206,7 +184,6 @@
   id: MothWingsDeathhead
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: deathhead_primary
@@ -217,7 +194,6 @@
   id: MothWingsFan
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: fan
@@ -226,7 +202,6 @@
   id: MothWingsDfan
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: dfan
@@ -235,7 +210,6 @@
   id: MothWingsFeathery
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: feathery
@@ -244,7 +218,6 @@
   id: MothWingsFirewatch
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: firewatch_primary
@@ -255,7 +228,6 @@
   id: MothWingsGothic
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: gothic
@@ -264,7 +236,6 @@
   id: MothWingsJungle
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: jungle
@@ -273,7 +244,6 @@
   id: MothWingsLadybug
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: ladybug
@@ -282,7 +252,6 @@
   id: MothWingsMaple
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: maple_primary
@@ -293,7 +262,6 @@
   id: MothWingsMoffra
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: moffra_primary
@@ -304,7 +272,6 @@
   id: MothWingsOakworm
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: oakworm
@@ -313,7 +280,6 @@
   id: MothWingsPlasmafire
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: plasmafire_primary
@@ -324,7 +290,6 @@
   id: MothWingsPointy
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: pointy
@@ -333,7 +298,6 @@
   id: MothWingsRoyal
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: royal_primary
@@ -344,7 +308,6 @@
   id: MothWingsStellar
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: stellar
@@ -353,7 +316,6 @@
   id: MothWingsStriped
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: striped
@@ -362,7 +324,6 @@
   id: MothWingsSwirly
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: swirly
@@ -371,7 +332,6 @@
   id: MothWingsWhitefly
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: whitefly
@@ -380,7 +340,6 @@
   id: MothWingsWitchwing
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: witchwing
@@ -389,7 +348,6 @@
   id: MothWingsUnderwing
   bodyPart: Tail
   markingCategory: Tail
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_wings.rsi
     state: underwing_primary
@@ -402,7 +360,6 @@
   id: MothChestCharred
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: charred_chest
@@ -411,7 +368,6 @@
   id: MothHeadCharred
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: charred_head
@@ -420,7 +376,6 @@
   id: MothLLegCharred
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: charred_l_leg
@@ -429,7 +384,6 @@
   id: MothRLegCharred
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: charred_r_leg
@@ -438,7 +392,6 @@
   id: MothLArmCharred
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: charred_l_arm
@@ -447,7 +400,6 @@
   id: MothRArmCharred
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: charred_r_arm
@@ -457,7 +409,6 @@
   id: MothChestDeathhead
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: deathhead_chest
@@ -466,7 +417,6 @@
   id: MothHeadDeathhead
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: deathhead_head
@@ -475,7 +425,6 @@
   id: MothLLegDeathhead
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: deathhead_l_leg
@@ -484,7 +433,6 @@
   id: MothRLegDeathhead
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: deathhead_r_leg
@@ -493,7 +441,6 @@
   id: MothLArmDeathhead
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: deathhead_l_arm
@@ -502,7 +449,6 @@
   id: MothRArmDeathhead
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: deathhead_r_arm
@@ -512,7 +458,6 @@
   id: MothChestFan
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: fan_chest
@@ -521,7 +466,6 @@
   id: MothHeadFan
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: fan_head
@@ -530,7 +474,6 @@
   id: MothLLegFan
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: fan_l_leg
@@ -539,7 +482,6 @@
   id: MothRLegFan
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: fan_r_leg
@@ -548,7 +490,6 @@
   id: MothLArmFan
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: fan_l_arm
@@ -557,7 +498,6 @@
   id: MothRArmFan
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: fan_r_arm
@@ -567,7 +507,6 @@
   id: MothChestFirewatch
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: firewatch_chest
@@ -576,7 +515,6 @@
   id: MothHeadFirewatch
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: firewatch_head
@@ -585,7 +523,6 @@
   id: MothLLegFirewatch
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: firewatch_l_leg
@@ -594,7 +531,6 @@
   id: MothRLegFirewatch
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: firewatch_r_leg
@@ -603,7 +539,6 @@
   id: MothLArmFirewatch
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: firewatch_l_arm
@@ -612,7 +547,6 @@
   id: MothRArmFirewatch
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: firewatch_r_arm
@@ -622,7 +556,6 @@
   id: MothChestGothic
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: gothic_chest
@@ -631,7 +564,6 @@
   id: MothHeadGothic
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: gothic_head
@@ -640,7 +572,6 @@
   id: MothLLegGothic
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: gothic_l_leg
@@ -649,7 +580,6 @@
   id: MothRLegGothic
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: gothic_r_leg
@@ -658,7 +588,6 @@
   id: MothLArmGothic
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: gothic_l_arm
@@ -667,7 +596,6 @@
   id: MothRArmGothic
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: gothic_r_arm
@@ -677,7 +605,6 @@
   id: MothChestJungle
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: jungle_chest
@@ -686,7 +613,6 @@
   id: MothHeadJungle
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: jungle_head
@@ -695,7 +621,6 @@
   id: MothLLegJungle
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: jungle_l_leg
@@ -704,7 +629,6 @@
   id: MothRLegJungle
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: jungle_r_leg
@@ -713,7 +637,6 @@
   id: MothLArmJungle
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: jungle_l_arm
@@ -722,7 +645,6 @@
   id: MothRArmJungle
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: jungle_r_arm
@@ -732,7 +654,6 @@
   id: MothChestMoonfly
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: moonfly_chest
@@ -741,7 +662,6 @@
   id: MothHeadMoonfly
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: moonfly_head
@@ -750,7 +670,6 @@
   id: MothLLegMoonfly
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: moonfly_l_leg
@@ -759,7 +678,6 @@
   id: MothRLegMoonfly
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: moonfly_r_leg
@@ -768,7 +686,6 @@
   id: MothLArmMoonfly
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: moonfly_l_arm
@@ -777,7 +694,6 @@
   id: MothRArmMoonfly
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: moonfly_r_arm
@@ -787,7 +703,6 @@
   id: MothChestOakworm
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: oakworm_chest
@@ -796,7 +711,6 @@
   id: MothHeadOakworm
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: oakworm_head
@@ -805,7 +719,6 @@
   id: MothLLegOakworm
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: oakworm_l_leg
@@ -814,7 +727,6 @@
   id: MothRLegOakworm
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: oakworm_r_leg
@@ -823,7 +735,6 @@
   id: MothLArmOakworm
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: oakworm_l_arm
@@ -832,7 +743,6 @@
   id: MothRArmOakworm
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: oakworm_r_arm
@@ -842,7 +752,6 @@
   id: MothChestPointy
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: pointy_chest
@@ -851,7 +760,6 @@
   id: MothHeadPointy
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: pointy_head
@@ -860,7 +768,6 @@
   id: MothLLegPointy
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: pointy_l_leg
@@ -869,7 +776,6 @@
   id: MothRLegPointy
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: pointy_r_leg
@@ -878,7 +784,6 @@
   id: MothLArmPointy
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: pointy_l_arm
@@ -887,7 +792,6 @@
   id: MothRArmPointy
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: pointy_r_arm
@@ -897,7 +801,6 @@
   id: MothChestRagged
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: ragged_chest
@@ -906,7 +809,6 @@
   id: MothHeadRagged
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: ragged_head
@@ -915,7 +817,6 @@
   id: MothLLegRagged
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: ragged_l_leg
@@ -924,7 +825,6 @@
   id: MothRLegRagged
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: ragged_r_leg
@@ -933,7 +833,6 @@
   id: MothLArmRagged
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: ragged_l_arm
@@ -942,7 +841,6 @@
   id: MothRArmRagged
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: ragged_r_arm
@@ -952,7 +850,6 @@
   id: MothChestRoyal
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: royal_chest
@@ -961,7 +858,6 @@
   id: MothHeadRoyal
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: royal_head
@@ -970,7 +866,6 @@
   id: MothLLegRoyal
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: royal_l_leg
@@ -979,7 +874,6 @@
   id: MothRLegRoyal
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: royal_r_leg
@@ -988,7 +882,6 @@
   id: MothLArmRoyal
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: royal_l_arm
@@ -997,7 +890,6 @@
   id: MothRArmRoyal
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: royal_r_arm
@@ -1007,7 +899,6 @@
   id: MothChestWhitefly
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: whitefly_chest
@@ -1016,7 +907,6 @@
   id: MothHeadWhitefly
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: whitefly_head
@@ -1025,7 +915,6 @@
   id: MothLLegWhitefly
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: whitefly_l_leg
@@ -1034,7 +923,6 @@
   id: MothRLegWhitefly
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: whitefly_r_leg
@@ -1043,7 +931,6 @@
   id: MothLArmWhitefly
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: whitefly_l_arm
@@ -1052,7 +939,6 @@
   id: MothRArmWhitefly
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: whitefly_r_arm
@@ -1062,7 +948,6 @@
   id: MothChestWitchwing
   bodyPart: Chest
   markingCategory: Chest
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: witchwing_chest
@@ -1071,7 +956,6 @@
   id: MothHeadWitchwing
   bodyPart: Head
   markingCategory: Head
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: witchwing_head
@@ -1080,7 +964,6 @@
   id: MothLLegWitchwing
   bodyPart: LLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: witchwing_l_leg
@@ -1089,7 +972,6 @@
   id: MothRLegWitchwing
   bodyPart: RLeg
   markingCategory: Legs
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: witchwing_r_leg
@@ -1098,7 +980,6 @@
   id: MothLArmWitchwing
   bodyPart: LArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: witchwing_l_arm
@@ -1107,7 +988,6 @@
   id: MothRArmWitchwing
   bodyPart: RArm
   markingCategory: Arms
-  speciesRestriction: [Moth]
   sprites:
   - sprite: Mobs/Customization/Moth/moth_parts.rsi
     state: witchwing_r_arm


### PR DESCRIPTION

## About the PR
This PR removes the species restriction of the markings in moth.yml, so that they can be used by all species.

## Why / Balance
Currently, all species already have access to the Classic version of these markings, which are uncolorable. This update makes the colorable versions currently limited to moths available to everyone as well.

## Technical details
Fairly straightforward; All lines of "speciesRestriction: [Moth]" in moth.yml are removed.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="1534" height="431" alt="image" src="https://github.com/user-attachments/assets/753879ec-11de-4246-a79d-c4a495a59f1a" />
<img width="156" height="146" alt="image (19)" src="https://github.com/user-attachments/assets/1ce635ec-8d4a-489a-bd84-3182f428c102" />
<img width="132" height="134" alt="image (20)" src="https://github.com/user-attachments/assets/256588de-03ae-458b-83f1-6ad3e78032ea" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
None

**Changelog**
:cl:
- tweak: Changed a number of colorable moth person markings to be available to all species.

