### PR TITLE
Loadout - Viper

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -82,9 +82,9 @@
 
 - type: entity
   name: viper
-  parent: [BaseWeaponPistol, BaseSyndicateContraband]
+  parent: [BaseWeaponPistol, BaseSecurityContraband] # Euphoria
   id: WeaponPistolViper
-  description: A common handgun illegally modified by the Syndicate. The Viper sports a selector switch between semi-auto and ‘rock and roll’. The standard sidearm for any soldier who fights under the three serpents. Feeds from .35 pistol magazines.
+  description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -84,7 +84,7 @@
   name: viper
   parent: [BaseWeaponPistol, BaseSecurityContraband] # Euphoria
   id: WeaponPistolViper
-  description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century. Uses .35 auto ammo.
+  description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century. This one has been modified for improved firerate. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -133,9 +133,9 @@
 
 - type: entity
   name: Python
-  parent: [BaseWeaponRevolver, BaseSyndicateContraband]
+  parent: [BaseWeaponRevolver, BaseSecurityContraband] # Euphoria
   id: WeaponRevolverPython
-  description: A powerful double-action revolver manufactured by the Syndicate. Loud and flashy, perfect for any agent looking to make a statement. Loads 6 rounds of .45 magnum.
+  description: An iconic large-framed revolver of ancient Sol' design. It is commonly manufactured by many companies all over the colonies. Uses .45 magnum ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -1,6 +1,6 @@
 - type: entity
   name: viper
-  parent: BaseWeaponPistol
+  parent: WeaponPistolViperSecurity # Euphoria - Added Parent so the code is cleaner
   id: WeaponPistolViperWood
   description: A small, low-power pistol with pleasant lacquered wooden grips. Uses .35 auto ammo.
   suffix: Wood
@@ -9,28 +9,6 @@
     sprite: _DV/Objects/Weapons/Guns/Pistols/viperwood.rsi
   - type: Clothing
     sprite: _DV/Objects/Weapons/Guns/Pistols/viperwood.rsi
-  - type: ItemSlots
-    slots:
-      gun_magazine:
-        name: Magazine
-        startingItem: MagazinePistol
-        insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
-        ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
-        priority: 2
-        whitelist:
-          tags:
-            - MagazinePistol
-      gun_chamber:
-        name: Chamber
-        startingItem: CartridgePistol
-        priority: 1
-        whitelist:
-          tags:
-            - CartridgePistol
-  - type: ContainerContainer
-    containers:
-      gun_magazine: !type:ContainerSlot
-      gun_chamber: !type:ContainerSlot
 
 - type: entity
   name: Pollock

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -1,0 +1,8 @@
+- type: entity # Security Viper
+  name: viper
+  parent: [WeaponPistolViper, BaseSecurityContraband]
+  id: WeaponPistolViperSecurity
+  description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century. Uses .35 auto ammo.
+  components:
+   - type: Gun
+     fireRate: 5

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -3,6 +3,7 @@
   parent: [WeaponPistolViper, BaseSecurityContraband]
   id: WeaponPistolViperSecurity
   description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century. Uses .35 auto ammo.
+  suffix: Security
   components:
    - type: Gun
      fireRate: 5

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/security_weapons.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/security_weapons.yml
@@ -13,6 +13,8 @@
   - FloofPlasteelArmingSword
   - FloofWeaponEnergyGunMini
   - FloofClothingBeltKatanaSheathFilled
+  - FloofWeaponPistolViper
+  - FloofWeaponPistolViperWood
 
 - type: loadoutGroup
   id: FloofSecurityFirearmAmmo

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/security_weapons.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Security/security_weapons.yml
@@ -9,6 +9,16 @@
   equipment:
     pocket1: WeaponLaserSvalinn
 
+- type: loadout
+  id: FloofWeaponPistolViper
+  equipment:
+    pocket1: WeaponPistolViperSecurity
+
+- type: loadout
+  id: FloofWeaponPistolViperWood
+  equipment:
+    pocket1: WeaponPistolViperWood
+
 # Ammo
 - type: loadout
   id: FloofSecurityFirearmMagazinePistolRubber


### PR DESCRIPTION
## About the PR
Frontend - This PR adds Viper and Viper (with the wood grippy) to the security loadout and changes the description of the Viper and Python along with the contraband rating.
Backend - This PR adds a security Viper with a MK58 fire rate (which just makes it a retexture) and parents the wood viper to the security viper.

This is the same as the last Viper PR but I cleaned it better.

## Why / Balance
People want the thematic Viper.

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- add: Added Viper and Viper (w/ wood grippy) to Security Loadout.
- add: Added Security only Viper (it fires slower for regulation/balance purposes).
