### PR TITLE
Kitsune and Oni can't understand cats; Freespeak desc. update

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/additional_languages.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/additional_languages.ftl
@@ -10,9 +10,8 @@ trait-Tradeband-desc =
 
 trait-Freespeak-name = Freespeak (Gutter)
 trait-Freespeak-desc =
-    A language of renegades and frontiersmen descending from various languages from Earth like Hindi combined into a multi-rooted jumble that sounds incoherent or even barbarian to non-native speakers.
-    This language is the only common cultural identity for humans in the frontier. Speaking this language in itself boldly declares the speaker a free spirit.
-    Often called 'Gutter' by Alliance citizens.
+    A multi-rooted language used by renegades and frontiersmen that descended from Hindi and various other Earth languages. It sounds rather unique to non-native speakers.
+    It serves as a common cultural identity on the frontier, and speakers of this language boldly declare themselves as free spirits.
 
 trait-Elyran-name = Elyran Standard
 trait-Elyran-desc =

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -51,7 +51,7 @@
     understands:
     - TauCetiBasic
     - Kagebun
-    - Nekomimetic
+    #- Nekomimetic #Euphoria
     naturalLanguage: Kagebun
 
 - type: entity

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/Oni.yml
@@ -51,7 +51,6 @@
     understands:
     - TauCetiBasic
     - Kagebun
-    #- Nekomimetic #Euphoria
     naturalLanguage: Kagebun
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
@@ -36,7 +36,7 @@
     understands:
     - TauCetiBasic
     - Kagebun
-    - Nekomimetic
+    #- Nekomimetic #Euphoria
     naturalLanguage: Kagebun
   - type: TypingIndicator
     proto: kitsune

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/kitsune.yml
@@ -36,7 +36,6 @@
     understands:
     - TauCetiBasic
     - Kagebun
-    #- Nekomimetic #Euphoria
     naturalLanguage: Kagebun
   - type: TypingIndicator
     proto: kitsune


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

## Why / Balance
Lore committee requested that Kitsune and Oni shouldn't understand cats by default, and for Freespeak's description to be updated.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- remove: Kitsune and Oni cannot understand cats by default
- tweak: Freespeak description updated
