### PR TITLE
Fix resomi having 1u of blood

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
@@ -176,7 +176,7 @@
     bloodReferenceSolution:
       reagents:
       - ReagentId: AmmoniaBlood
-        Quantity: 1
+        Quantity: 200
   - type: MeleeWeapon # Goobstation - aliem raptors probably use their claws
     soundHit:
       collection: AlienClaw


### PR DESCRIPTION
## About the PR
BloodReferenceSolution defines the volume of the bloodstream and what reagents are produced inside, at the same time. I missed this during the upstream merge, makes me wonder if there are more mobs suffering from the same issue. 

this kinda shit:
<img width="407" height="91" alt="image" src="https://github.com/user-attachments/assets/086c5ef3-aa92-43ad-90e3-32d883be5bf4" />


**Changelog**
:cl:
- fix: Resomi should now have more than 1u of blood.
