### PR TITLE
Crit And Dead Threshold Traits

### DIFF
--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -2,6 +2,7 @@ using Content.Shared._DV.Traits.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
 using System.Linq;
 
 namespace Content.Shared._Floof.Traits.Effects;
@@ -11,6 +12,8 @@ namespace Content.Shared._Floof.Traits.Effects;
 /// </summary>
 public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
 {
+    [Dependency] private readonly MobThresholdSystem _thresholds = default!;
+    
     /// <summary>
     /// How much to multiply the Critical threshold by.
     /// </summary>
@@ -36,47 +39,47 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Critical).Key;
         var newDead = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Dead).Key;
 
-        // Make some temporary values to capture the existing Crit and Dead values. 
-        //var newCrit = 0f;
-        //var newDead = 0f;
-
-        if (newDead != null) {
+        if (newDead != null){
             //Make changes only if something is passed in via the trait.
-            if (DeadModifier != 0) {
+            if (DeadModifier != 0){
                 newDead = newDead * DeadModifier;
             }
             
             //Grab the existing Crit value. There shouldn't be a case in which we send in a Dict that doesn't have Crit, but let's account for that anyway.
-            if (newCrit != null) {
+            if (newCrit != null){
                 //Make changes only if something is passed in via the trait.
-                if (CritModifier != 0) {
+                if (CritModifier != 0){
                   newCrit = newCrit * CritModifier;
 
                   //Safeguard to make sure this value will not be too low, though this shouldn't happen.
-                  if (newCrit <= 5) {
+                  if (newCrit <= 5){
                     newCrit = 5;
                   }
                 }
                 //Safeguard to make sure Dead is not less than or equal to Crit.
-                if (newDead <= newCrit) {
+                if (newDead <= newCrit){
                     newDead = newCrit + 0.1;
                 }
                 
-                newDict.Add(newCrit, MobState.Critical);
-                newDict.Add(newDead, MobState.Dead);
+                //newDict.Add(newCrit, MobState.Critical);
+                //newDict.Add(newDead, MobState.Dead);
+                _thresholds.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
+                _thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
             }
             else { //I don't think there's a scenario in which a player will not have a Critical threshold, but just in case...
                 //There is no reason the Dead value should ever be 0 or lower, but just in case...
                 if (newDead <= 0) {
                     newDead = 5;
                 }
-                newDict.Add(newDead, MobState.Dead);
+                //newDict.Add(newDead, MobState.Dead);
+                _thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
             }
         }
         else { //If the Dead threshold doesn't exist, something went horribly wrong. This should never happen, but just in case...
-            newDict.Add(1, MobState.Dead); //A value greater than 0.
+            //newDict.Add(1, MobState.Dead); //A value greater than 0.
+            _thresholds.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
         }
 
-        threshDict.Thresholds = newDict; //This isn't working, says I only have Read access to Thresholds in MobThresholdComponent
+        //threshDict.Thresholds = newDict; //This isn't working, says I only have Read access to Thresholds in MobThresholdComponent
     }
 }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -1,0 +1,59 @@
+using Content.Shared._DV.Traits.Effects;
+using Content.Shared.Mobs.Components;
+
+namespace Content.Shared._Floof.Traits.Effects;
+
+/// <summary>
+/// Effect that modifies the Critical and/or Dead threshold of an entity.
+/// </summary>
+public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
+{
+    /// <summary>
+    /// How much to multiply the Critical threshold by.
+    /// </summary>
+    [DataField]
+    public float CritModifier = 0f;
+
+    /// <summary>
+    /// How much to multiply the Dead threshold by.
+    /// </summary>
+    [DataField]
+    public float DeadModifier = 0f;
+
+    public override void Apply(TraitEffectContext ctx)
+    {
+        if (!ctx.EntMan.TryGetComponent<MobThresholdsComponent>(ctx.Player, out var threshDict))
+            return;
+
+        // Make some temporary values to capture the existing Crit and Dead values. 
+        var newCrit = threshDict.FirstOrDefault(x => x.Value == "Critical").Key;
+        var newDead = threshDict.FirstOrDefault(x => x.Value == "Dead").Key;
+
+        //Make changes only if something is passed in via the trait.
+        if (CritModifier != 0} {
+          newCrit = newCrit * CritModifier;
+
+          //Safeguard to make sure this value will not be too low, though this shouldn't happen.
+          if (newCrit <= 5) {
+            newCrit = 5;
+          }
+        }
+
+        //Make changes only if something is passed in via the trait.
+        if (DeadModifier != 0} {
+          newDead = newDead * DeadModifier;
+
+          //Safeguard to make sure Dead is not less than or equal to Crit.
+          if (newDead <= newCrit) {
+            newDead = newCrit + 0.1;
+          }
+        }
+        
+        SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
+        newDict.Add(0, "Alive");
+        newDict.Add(newCrit, "Critical");
+        newDict.Add(newDead, "Dead");
+
+        threshDict = newDict;
+    }
+}

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -1,4 +1,6 @@
 using Content.Shared._DV.Traits.Effects;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
 
 namespace Content.Shared._Floof.Traits.Effects;
@@ -38,15 +40,15 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         var newDead = 0f;
 
         //Grab the existing Dead value
-        if (threshDict.TryGetValue("Dead", out newDead)) {
+        if (threshDict.Thresholds.TryGetValue("Dead", out newDead)) {
             //Make changes only if something is passed in via the trait.
-            if (DeadModifier != 0} {
+            if (DeadModifier != 0) {
                 newDead = newDead * DeadModifier;
             }
             //Grab the existing Crit value. There shouldn't be a case in which we send in a Dict that doesn't have Crit, but let's account for that anyway.
-            if (threshDict.TryGetValue("Critical", out newCrit)) {
+            if (threshDict.Thresholds.TryGetValue("Critical", out newCrit)) {
                 //Make changes only if something is passed in via the trait.
-                if (CritModifier != 0} {
+                if (CritModifier != 0) {
                   newCrit = newCrit * CritModifier;
 
                   //Safeguard to make sure this value will not be too low, though this shouldn't happen.

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -2,6 +2,7 @@ using Content.Shared._DV.Traits.Effects;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Components;
+using System.Linq;
 
 namespace Content.Shared._Floof.Traits.Effects;
 
@@ -32,8 +33,8 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         newDict.Add(0, MobState.Alive);
 
         // Make some temporary values to capture the existing Crit and Dead values. 
-        var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == "Critical").Key;
-        var newDead = threshDict.Thresholds.FirstOrDefault(x => x.Value == "Dead").Key;
+        var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Critical).Key;
+        var newDead = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Dead).Key;
 
         // Make some temporary values to capture the existing Crit and Dead values. 
         //var newCrit = 0f;
@@ -115,33 +116,7 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
             newDict.Add(1, "Dead");
         }
 */
-/*
-        //Make changes only if something is passed in via the trait.
-        if (CritModifier != 0} {
-          newCrit = newCrit * CritModifier;
 
-          //Safeguard to make sure this value will not be too low, though this shouldn't happen.
-          if (newCrit <= 5) {
-            newCrit = 5;
-          }
-        }
-
-        //Make changes only if something is passed in via the trait.
-        if (DeadModifier != 0} {
-          newDead = newDead * DeadModifier;
-
-          //Safeguard to make sure Dead is not less than or equal to Crit.
-          if (newDead <= newCrit) {
-            newDead = newCrit + 0.1;
-          }
-        }
-        
-        SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
-        newDict.Add(0, "Alive");
-        newDict.Add(newCrit, "Critical");
-        newDict.Add(newDead, "Dead");
-*/
-
-        threshDict = newDict;
+        threshDict.Thresholds = newDict;
     }
 }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -25,10 +25,57 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         if (!ctx.EntMan.TryGetComponent<MobThresholdsComponent>(ctx.Player, out var threshDict))
             return;
 
-        // Make some temporary values to capture the existing Crit and Dead values. 
-        var newCrit = threshDict.FirstOrDefault(x => x.Value == "Critical").Key;
-        var newDead = threshDict.FirstOrDefault(x => x.Value == "Dead").Key;
+        //The new Dictionary we'll be playing with.
+        SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
+        newDict.Add(0, "Alive");
 
+        // Make some temporary values to capture the existing Crit and Dead values. 
+        //var newCrit = threshDict.FirstOrDefault(x => x.Value == "Critical").Key;
+        //var newDead = threshDict.FirstOrDefault(x => x.Value == "Dead").Key;
+
+        // Make some temporary values to capture the existing Crit and Dead values. 
+        var newCrit = 0f;
+        var newDead = 0f;
+
+        //Grab the existing Dead value
+        if (threshDict.TryGetValue("Dead", out newDead)) {
+            //Make changes only if something is passed in via the trait.
+            if (DeadModifier != 0} {
+                newDead = newDead * DeadModifier;
+            }
+            //Grab the existing Crit value. There shouldn't be a case in which we send in a Dict that doesn't have Crit, but let's account for that anyway.
+            if (threshDict.TryGetValue("Critical", out newCrit)) {
+                //Make changes only if something is passed in via the trait.
+                if (CritModifier != 0} {
+                  newCrit = newCrit * CritModifier;
+
+                  //Safeguard to make sure this value will not be too low, though this shouldn't happen.
+                  if (newCrit <= 5) {
+                    newCrit = 5;
+                  }
+                }
+                //Safeguard to make sure Dead is not less than or equal to Crit.
+                if (newDead <= newCrit) {
+                    newDead = newCrit + 0.1;
+                }
+                
+                newDict.Add(newCrit, "Critical");
+                newDict.Add(newDead, "Dead");
+            }
+            else { //In the unlikely event that there is no Critical at all.
+                //There is no reason the Dead value should ever be 0 or lower, but just in case...
+                if (newDead <= 0) {
+                    newDead = 5;
+                }
+                newDict.Add(newDead, "Dead");
+            }
+        }
+        else {
+            //This should never happen, but if there's no Dead value, there's a problem. Throw a value into it.
+            newDict.Add(1, "Dead");
+        }
+
+/*
         //Make changes only if something is passed in via the trait.
         if (CritModifier != 0} {
           newCrit = newCrit * CritModifier;
@@ -53,6 +100,7 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         newDict.Add(0, "Alive");
         newDict.Add(newCrit, "Critical");
         newDict.Add(newDead, "Dead");
+*/
 
         threshDict = newDict;
     }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -77,46 +77,6 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
             newDict.Add(1, MobState.Dead); //A value greater than 0.
         }
 
-/*
-        //Grab the existing Dead value
-        if (threshDict.Thresholds.TryGetValue("Dead", out newDead)) {
-            //Make changes only if something is passed in via the trait.
-            if (DeadModifier != 0) {
-                newDead = newDead * DeadModifier;
-            }
-            //Grab the existing Crit value. There shouldn't be a case in which we send in a Dict that doesn't have Crit, but let's account for that anyway.
-            if (threshDict.Thresholds.TryGetValue("Critical", out newCrit)) {
-                //Make changes only if something is passed in via the trait.
-                if (CritModifier != 0) {
-                  newCrit = newCrit * CritModifier;
-
-                  //Safeguard to make sure this value will not be too low, though this shouldn't happen.
-                  if (newCrit <= 5) {
-                    newCrit = 5;
-                  }
-                }
-                //Safeguard to make sure Dead is not less than or equal to Crit.
-                if (newDead <= newCrit) {
-                    newDead = newCrit + 0.1;
-                }
-                
-                newDict.Add(newCrit, "Critical");
-                newDict.Add(newDead, "Dead");
-            }
-            else { //In the unlikely event that there is no Critical at all.
-                //There is no reason the Dead value should ever be 0 or lower, but just in case...
-                if (newDead <= 0) {
-                    newDead = 5;
-                }
-                newDict.Add(newDead, "Dead");
-            }
-        }
-        else {
-            //This should never happen, but if there's no Dead value, there's a problem. Throw a value into it.
-            newDict.Add(1, "Dead");
-        }
-*/
-
-        threshDict.Thresholds = newDict;
+        threshDict.Thresholds = newDict; //This isn't working, says I only have Read access to Thresholds in MobThresholdComponent
     }
 }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -29,16 +29,54 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
 
         //The new Dictionary we'll be playing with.
         SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
-        newDict.Add(0, "Alive");
+        newDict.Add(0, MobState.Alive);
 
         // Make some temporary values to capture the existing Crit and Dead values. 
-        //var newCrit = threshDict.FirstOrDefault(x => x.Value == "Critical").Key;
-        //var newDead = threshDict.FirstOrDefault(x => x.Value == "Dead").Key;
+        var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == "Critical").Key;
+        var newDead = threshDict.Thresholds.FirstOrDefault(x => x.Value == "Dead").Key;
 
         // Make some temporary values to capture the existing Crit and Dead values. 
-        var newCrit = 0f;
-        var newDead = 0f;
+        //var newCrit = 0f;
+        //var newDead = 0f;
 
+        if (newDead != null) {
+            //Make changes only if something is passed in via the trait.
+            if (DeadModifier != 0) {
+                newDead = newDead * DeadModifier;
+            }
+            
+            //Grab the existing Crit value. There shouldn't be a case in which we send in a Dict that doesn't have Crit, but let's account for that anyway.
+            if (newCrit != null) {
+                //Make changes only if something is passed in via the trait.
+                if (CritModifier != 0) {
+                  newCrit = newCrit * CritModifier;
+
+                  //Safeguard to make sure this value will not be too low, though this shouldn't happen.
+                  if (newCrit <= 5) {
+                    newCrit = 5;
+                  }
+                }
+                //Safeguard to make sure Dead is not less than or equal to Crit.
+                if (newDead <= newCrit) {
+                    newDead = newCrit + 0.1;
+                }
+                
+                newDict.Add(newCrit, MobState.Critical);
+                newDict.Add(newDead, MobState.Dead);
+            }
+            else { //I don't think there's a scenario in which a player will not have a Critical threshold, but just in case...
+                //There is no reason the Dead value should ever be 0 or lower, but just in case...
+                if (newDead <= 0) {
+                    newDead = 5;
+                }
+                newDict.Add(newDead, MobState.Dead);
+            }
+        }
+        else { //If the Dead threshold doesn't exist, something went horribly wrong. This should never happen, but just in case...
+            newDict.Add(1, MobState.Dead); //A value greater than 0.
+        }
+
+/*
         //Grab the existing Dead value
         if (threshDict.Thresholds.TryGetValue("Dead", out newDead)) {
             //Make changes only if something is passed in via the trait.
@@ -76,7 +114,7 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
             //This should never happen, but if there's no Dead value, there's a problem. Throw a value into it.
             newDict.Add(1, "Dead");
         }
-
+*/
 /*
         //Make changes only if something is passed in via the trait.
         if (CritModifier != 0} {

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -12,8 +12,6 @@ namespace Content.Shared._Floof.Traits.Effects;
 /// </summary>
 public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
 {
-    //[Dependency] private readonly MobThresholdSystem _thresholds = default!;
-    
     /// <summary>
     /// How much to multiply the Critical threshold by.
     /// </summary>
@@ -32,10 +30,6 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
             return;
 
         var threshy = ctx.EntMan.EntitySysManager.GetEntitySystem<MobThresholdSystem>();
-
-        //The new Dictionary we'll be playing with.
-        //SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
-        //newDict.Add(0, MobState.Alive);
 
         // Make some temporary values to capture the existing Crit and Dead values. 
         var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Critical).Key;
@@ -63,10 +57,6 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
                     newDead = newCrit + 0.1;
                 }
                 
-                //newDict.Add(newCrit, MobState.Critical);
-                //newDict.Add(newDead, MobState.Dead);
-                //_thresholds.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
-                //_thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
                 threshy.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
                 threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
             }
@@ -75,14 +65,10 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
                 if (newDead <= 0) {
                     newDead = 5;
                 }
-                //newDict.Add(newDead, MobState.Dead);
-                //_thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
                 threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
             }
         }
         else { //If the Dead threshold doesn't exist, something went horribly wrong. This should never happen, but just in case...
-            //newDict.Add(1, MobState.Dead); //A value greater than 0.
-            //_thresholds.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
             threshy.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
         }
     }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -35,41 +35,25 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Critical).Key;
         var newDead = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Dead).Key;
 
-        if (newDead != null){
-            //Make changes only if something is passed in via the trait.
-            if (DeadModifier != 0){
-                newDead = newDead * DeadModifier;
-            }
-            
-            //Grab the existing Crit value. There shouldn't be a case in which we send in a Dict that doesn't have Crit, but let's account for that anyway.
-            if (newCrit != null){
-                //Make changes only if something is passed in via the trait.
-                if (CritModifier != 0){
-                  newCrit = newCrit * CritModifier;
+        //Make changes only if something is passed in via the trait.
+        if (DeadModifier != 0){
+            newDead = newDead * DeadModifier;
+        }
+        //Make changes only if something is passed in via the trait.
+        if (CritModifier != 0){
+            newCrit = newCrit * CritModifier;
 
-                  //Safeguard to make sure this value will not be too low, though this shouldn't happen.
-                  if (newCrit <= 5){
-                    newCrit = 5;
-                  }
-                }
-                //Safeguard to make sure Dead is not less than or equal to Crit.
-                if (newDead <= newCrit){
-                    newDead = newCrit + 0.1;
-                }
+            //Safeguard to make sure this value will not be too low, though this shouldn't happen.
+            if (newCrit <= 5){
+                newCrit = 5;
+            }
+        }
+        //Safeguard to make sure Dead is not less than or equal to Crit.
+        if (newDead <= newCrit){
+            newDead = newCrit + 0.1;
+        }
                 
-                threshy.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
-                threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
-            }
-            else { //I don't think there's a scenario in which a player will not have a Critical threshold, but just in case...
-                //There is no reason the Dead value should ever be 0 or lower, but just in case...
-                if (newDead <= 0) {
-                    newDead = 5;
-                }
-                threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
-            }
-        }
-        else { //If the Dead threshold doesn't exist, something went horribly wrong. This should never happen, but just in case...
-            threshy.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
-        }
+        threshy.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
+        threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
     }
 }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyCritDeadThresholdEffect.cs
@@ -12,7 +12,7 @@ namespace Content.Shared._Floof.Traits.Effects;
 /// </summary>
 public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
 {
-    [Dependency] private readonly MobThresholdSystem _thresholds = default!;
+    //[Dependency] private readonly MobThresholdSystem _thresholds = default!;
     
     /// <summary>
     /// How much to multiply the Critical threshold by.
@@ -31,9 +31,11 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
         if (!ctx.EntMan.TryGetComponent<MobThresholdsComponent>(ctx.Player, out var threshDict))
             return;
 
+        var threshy = ctx.EntMan.EntitySysManager.GetEntitySystem<MobThresholdSystem>();
+
         //The new Dictionary we'll be playing with.
-        SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
-        newDict.Add(0, MobState.Alive);
+        //SortedDictionary<FixedPoint2, MobState> newDict = new SortedDictionary<FixedPoint2, MobState>();
+        //newDict.Add(0, MobState.Alive);
 
         // Make some temporary values to capture the existing Crit and Dead values. 
         var newCrit = threshDict.Thresholds.FirstOrDefault(x => x.Value == MobState.Critical).Key;
@@ -63,8 +65,10 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
                 
                 //newDict.Add(newCrit, MobState.Critical);
                 //newDict.Add(newDead, MobState.Dead);
-                _thresholds.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
-                _thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
+                //_thresholds.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
+                //_thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
+                threshy.SetMobStateThreshold(ctx.Player, newCrit, MobState.Critical, threshDict);
+                threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
             }
             else { //I don't think there's a scenario in which a player will not have a Critical threshold, but just in case...
                 //There is no reason the Dead value should ever be 0 or lower, but just in case...
@@ -72,14 +76,14 @@ public sealed partial class ModifyCritDeadThresholdEffect : BaseTraitEffect
                     newDead = 5;
                 }
                 //newDict.Add(newDead, MobState.Dead);
-                _thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
+                //_thresholds.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
+                threshy.SetMobStateThreshold(ctx.Player, newDead, MobState.Dead, threshDict);
             }
         }
         else { //If the Dead threshold doesn't exist, something went horribly wrong. This should never happen, but just in case...
             //newDict.Add(1, MobState.Dead); //A value greater than 0.
-            _thresholds.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
+            //_thresholds.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
+            threshy.SetMobStateThreshold(ctx.Player, 1, MobState.Dead, threshDict); //A value greater than 0.
         }
-
-        //threshDict.Thresholds = newDict; //This isn't working, says I only have Read access to Thresholds in MobThresholdComponent
     }
 }

--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -54,7 +54,7 @@ trait-amputee-right-arm-desc =
 
 trait-redshirt-name = Redshirt
 trait-redshirt-desc =
-    Sets your death threshold to 100 damage. You no longer have a critical state.
+    Halves your death threshold (to 100 damage for most). You no longer have a critical state.
 
     "They said this air would be breathable.
     Get in, get out again, and no one gets hurt.

--- a/Resources/Locale/en-US/_DV/traits/traits.ftl
+++ b/Resources/Locale/en-US/_DV/traits/traits.ftl
@@ -54,7 +54,7 @@ trait-amputee-right-arm-desc =
 
 trait-redshirt-name = Redshirt
 trait-redshirt-desc =
-    Halves your death threshold (to 100 damage for most). You no longer have a critical state.
+    Halves your death threshold (to 100 damage for most). You likely no longer have a critical state.
 
     "They said this air would be breathable.
     Get in, get out again, and no one gets hurt.

--- a/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
@@ -79,3 +79,23 @@ trait-glassjaw-name = Glass Jaw
 trait-glassjaw-desc = 
     Your body is more fragile than others, resulting in a greater susceptibility to critical injuries
     Your damage threshold for becoming Critical is decreased by 15%.
+
+trait-willtodie-name = Will To Die
+trait-willtodie-desc = 
+    You have an unusually weak "will to live", and will succumb to injuries sooner than others.
+    Your damage threshold for becoming Dead is decreased by 10%.
+
+trait-tenacity-name = Tenacity
+trait-tenacity-desc = 
+    Whether it be through raw grit, willpower, or subtle bionic augmentations, you are hardier than others.
+    Your damage threshold for becoming Critical is increased by 5%.
+
+trait-willtolive-name = Will To Live
+trait-willtolive-desc = 
+    You have an unusually strong "will to live", and will resist death more than others.
+    Your damage threshold for becoming Dead is increased by 5%.
+
+trait-brittlebone-name = Brittle Bones
+trait-brittlebone-desc = 
+    People with this genetic disorder have bones that are easily broken, often simply by moving. 
+    This trait reduces your threshold for critical injury by 50%, and reduces your death threshold by 25%.

--- a/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
@@ -74,3 +74,8 @@ trait-heatintolerance-desc =
 trait-heatintoleranceadvanced-name = Heat Intolerance - Advanced
 trait-heatintoleranceadvanced-desc = 
     You simply can't handle the heat. 
+
+trait-glassjaw-name = Glass Jaw
+trait-glassjaw-desc = 
+    Your body is more fragile than others, resulting in a greater susceptibility to critical injuries
+    Your damage threshold for becoming Critical is decreased by 15%.

--- a/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
@@ -98,4 +98,4 @@ trait-willtolive-desc =
 trait-brittlebone-name = Brittle Bones
 trait-brittlebone-desc = 
     People with this genetic disorder have bones that are easily broken, often simply by moving. 
-    This trait reduces your threshold for critical injury by 50%, and reduces your death threshold by 25%.
+    This trait reduces your threshold for critical injury by 50%.

--- a/Resources/Prototypes/_DV/Traits/medical.yml
+++ b/Resources/Prototypes/_DV/Traits/medical.yml
@@ -80,17 +80,14 @@
   description: trait-redshirt-desc
   category: DisabilitiesPhysical # Euphoria
   cost: -6 #floof
+  conflicts:
+    - WillToLive
   effects:
   - !type:AddCompsEffect
     components:
     - type: Redshirt
-  - !type:OverrideCompsEffect
-    components:
-    - type: MobThresholds
-      thresholds:
-        0: Alive
-        99.9: Critical
-        100: Dead
+  - !type:ModifyCritDeadThresholdEffect
+    deadModifier: 0.5 #-50%
 
 - type: trait
   id: Synthetic

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -528,6 +528,10 @@
   cost: -2
   conflicts:
     - Tenacity
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 0.85 #-15%
@@ -552,6 +556,11 @@
   cost: 3
   conflicts:
     - GlassJaw
+    - BrittleBones
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 1.05 #+5%
@@ -576,6 +585,10 @@
   cost: -10
   conflicts:
     - Tenacity
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 0.5 #-50%

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -517,3 +517,16 @@
   effects:
   - !type:ModifyTemperatureToleranceEffect
     heatToleranceModifier: -10 # 10 worse (less tolerant) than base (which should be 325).
+# =================================================== #
+
+# =============Crit and Dead Threshold=============== #
+- type: trait
+  id: GlassJaw
+  name: trait-glassjaw-name
+  description: trait-glassjaw-desc
+  category: Skills
+  cost: -2
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    critModifier: 0.85 #-15%
+# =================================================== #

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -526,7 +526,57 @@
   description: trait-glassjaw-desc
   category: Skills
   cost: -2
+  conflicts:
+    - Tenacity
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 0.85 #-15%
+
+- type: trait
+  id: WillToDie
+  name: trait-willtodie-name
+  description: trait-willtodie-desc
+  category: Skills
+  cost: -1
+  conflicts:
+    - WillToLive
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    deadModifier: 0.9 #-10%
+
+- type: trait
+  id: Tenacity
+  name: trait-tenacity-name
+  description: trait-tenacity-desc
+  category: Skills
+  cost: 3
+  conflicts:
+    - GlassJaw
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    critModifier: 1.05 #+5%
+
+- type: trait
+  id: WillToLive
+  name: trait-willtolive-name
+  description: trait-willtolive-desc
+  category: Skills
+  cost: 2
+  conflicts:
+    - WillToDie
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    deadModifier: 1.05 #+5%
+
+- type: trait
+  id: BrittleBones
+  name: trait-brittlebone-name
+  description: trait-brittlebone-desc
+  category: Skills
+  cost: -10
+  conflicts:
+    - Tenacity
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    critModifier: 0.5 #-50%
 # =================================================== #

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -532,6 +532,10 @@
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 0.85 #-15%
@@ -561,6 +565,10 @@
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 1.05 #+5%
@@ -589,6 +597,10 @@
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 0.5 #-50%

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -581,6 +581,7 @@
   cost: 2
   conflicts:
     - WillToDie
+    - Redshirt
   effects:
   - !type:ModifyCritDeadThresholdEffect
     deadModifier: 1.05 #+5%


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Added 5 traits related to crit/dead thresholds, modified Redshirt to use this new trait effect. 

Glass Jaw: Decrease your Critical Threshold by 15%. (+2 points)
Will to Die: Decrease your Dead Threshold by 10%. (+1 point)
Brittle Bones: Decrease your Critical Threshold by 50% (+10 points)

Tenacity: Increase your Critical Threshold by 5%.  (-3 points)
Will to Live: Increase your Death Threshold by 5%. (-2 points)

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We used to have these traits on Floof, and they were desired. The positive traits are not very powerful. The negative traits are fun. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Yml changes, and a new trait effect. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="1306" height="970" alt="image" src="https://github.com/user-attachments/assets/74db500c-edc6-49bb-aebe-2c6539b770e9" />

<img width="1003" height="776" alt="image" src="https://github.com/user-attachments/assets/4f92f701-1a5a-4320-aad9-60dc2df2695d" />

The highest numbers you can get, I think:
<img width="1019" height="940" alt="image" src="https://github.com/user-attachments/assets/d29c8462-68f6-450e-b6ca-4dd6c01ce950" />

The lowest numbers you can get, I think:
<img width="983" height="839" alt="image" src="https://github.com/user-attachments/assets/dbb78b39-50f8-454f-ab74-0ef3d55fd9c1" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Added traits for increasing or decreasing Critical and Dead thresholds. Die to a stiff breeze if you want!
- tweak: Adjusted Redshirt to halve your Dead threshold instead of making it a flat 100. Same result in most cases.
