### PR TITLE
Ninja Dash Cooldown And Doorjack Objective Removal

### DIFF
--- a/Resources/Prototypes/Actions/ninja.yml
+++ b/Resources/Prototypes/Actions/ninja.yml
@@ -77,6 +77,7 @@
   description: Teleport to anywhere you can see, if your Energy Katana is in your hand.
   components:
   - type: Action
+    useDelay: 60
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: blink

--- a/Resources/Prototypes/Objectives/ninja.yml
+++ b/Resources/Prototypes/Objectives/ninja.yml
@@ -11,20 +11,21 @@
     roles:
     - NinjaRole
 
-- type: entity
-  parent: BaseNinjaObjective
-  id: DoorjackObjective
-  components:
-  - type: Objective
-    icon:
-      sprite: Objects/Tools/emag.rsi
-      state: icon
-  - type: NumberObjective
-    min: 15
-    max: 40
-    title: objective-condition-doorjack-title
-    description: objective-condition-doorjack-description
-  - type: DoorjackCondition
+#This isn't really fun or engaging for the ninja or the rest of the crew.
+#- type: entity
+#  parent: BaseNinjaObjective
+#  id: DoorjackObjective
+#  components:
+#  - type: Objective
+#    icon:
+#      sprite: Objects/Tools/emag.rsi
+#      state: icon
+#  - type: NumberObjective
+#    min: 15
+#    max: 40
+#    title: objective-condition-doorjack-title
+#    description: objective-condition-doorjack-description
+#  - type: DoorjackCondition
 
 - type: entity
   parent: BaseNinjaObjective


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
This PR adds a 60-second cooldown period to the Ninja's Katana Dash (the teleport move). 
This PR also removes the Ninja objective for doorjacking a whole bunch of doors. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some people have been complaining about Ninja. The most common complaint seems to be that the Katana Dash allows a Ninja to escape any situation with ease. 
I've put a 60 second cooldown on the ability. This should make it much less of a "get out of jail free card". 

I've also removed the doorjacking objective, as it does not seem to be fun for the Ninja or the crew. It typically just leads to a Ninja walking up and down the hall, hacking every random door. It's not thematic. It's not engaging. It's just busy work for the Ninja, and for the crew. (If people don't like this, I could instead decrease the amount of doors in the objective.)

Further adjustments can be made down the line if these prove to be not enough.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just simple yml changes.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="644" height="772" alt="image" src="https://github.com/user-attachments/assets/1ace9ae7-47f5-4643-88bb-644aac6fd339" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- remove: Removed Ninja's Doorjacking objective. They can still doorjack, they're just not required to do so. 
- tweak: Added a 60 second cooldown to Ninja's teleport. Should make it a little easier for Sec to catch their slippery foe. 
