### PR TITLE
Add traits to replace your species' default blood

### DIFF
--- a/Content.Client/Damage/DamageVisualsComponent.cs
+++ b/Content.Client/Damage/DamageVisualsComponent.cs
@@ -158,4 +158,9 @@ public sealed partial class DamageVisualizerSprite
     ///     Supports only hexadecimal format.
     /// </summary>
     [DataField("color")] public  string? Color;
+
+    #region Euphoria: Damage visual overlays can be coloured from bloodstream
+    [DataField("colorFromBlood")]
+    public bool ColorFromBlood = false;
+    #endregion
 }

--- a/Content.Client/Damage/DamageVisualsSystem.cs
+++ b/Content.Client/Damage/DamageVisualsSystem.cs
@@ -1,4 +1,6 @@
 using System.Linq;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Reagent;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Prototypes;
@@ -333,6 +335,15 @@ public sealed class DamageVisualsSystem : VisualizerSystem<DamageVisualsComponen
             index
         );
         SpriteSystem.LayerMapSet(spriteEnt, mapKey, newLayer);
+        #region Euphoria: Add damage visuals colour from bloodstream
+        if (TryComp<BloodstreamComponent>(spriteEnt, out var bloodstream)
+            && bloodstream.BloodReferenceSolution != null
+            && _prototypeManager.Resolve<ReagentPrototype>(bloodstream.BloodReferenceSolution.Contents[0].Reagent.Prototype, out var reagent))
+        {
+            SpriteSystem.LayerSetColor(spriteEnt, newLayer, reagent.SubstanceColor);
+        }
+        else
+        # endregion
         if (sprite.Color != null)
             SpriteSystem.LayerSetColor(spriteEnt, newLayer, Color.FromHex(sprite.Color));
         SpriteSystem.LayerSetVisible(spriteEnt, newLayer, false);

--- a/Content.Shared/_Euphoria/Traits/Effects/ReplaceBloodReagentTraitEffect.cs
+++ b/Content.Shared/_Euphoria/Traits/Effects/ReplaceBloodReagentTraitEffect.cs
@@ -22,14 +22,9 @@ public sealed partial class ReplaceBloodReagentTraitEffect : BaseTraitEffect
             var totalVolume = referenceSolution.Volume;
             referenceSolution.RemoveAllSolution();
             referenceSolution.AddReagent(Reagent, totalVolume);
-            if (
-                ctx.EntMan.TryGetComponent<ContainerManagerComponent>(ctx.Player, out var containerManager) &&
-                containerManager.Containers.TryGetValue($"solution@{bloodstream.BloodSolutionName}", out var solutionContainer) &&
-                solutionContainer is ContainerSlot solutionSlot &&
-                solutionSlot.ContainedEntity is { } containedSolution
-            )
+            if (bloodstream.BloodSolution.HasValue)
             {
-                var bloodSolution = ctx.EntMan.GetComponent<SolutionComponent>(containedSolution).Solution;
+                var bloodSolution = ctx.EntMan.GetComponent<SolutionComponent>(bloodstream.BloodSolution.Value).Solution;
                 bloodSolution.RemoveAllSolution();
                 bloodSolution.AddReagent(Reagent, totalVolume);
             }

--- a/Content.Shared/_Euphoria/Traits/Effects/ReplaceBloodReagentTraitEffect.cs
+++ b/Content.Shared/_Euphoria/Traits/Effects/ReplaceBloodReagentTraitEffect.cs
@@ -12,8 +12,8 @@ namespace Content.Shared._Euphoria.Traits.Effects;
 public sealed partial class ReplaceBloodReagentTraitEffect : BaseTraitEffect
 {
 
-    [DataField(required: true)]
-    public string Reagent = null;
+    [DataField("reagent", required: true)]
+    public string Reagent;
 
     public override void Apply(TraitEffectContext ctx) {
         if (ctx.EntMan.TryGetComponent<BloodstreamComponent>(ctx.Player, out var bloodstream))

--- a/Content.Shared/_Euphoria/Traits/Effects/ReplaceBloodReagentTraitEffect.cs
+++ b/Content.Shared/_Euphoria/Traits/Effects/ReplaceBloodReagentTraitEffect.cs
@@ -1,0 +1,38 @@
+using Content.Shared._DV.Traits.Effects;
+using Content.Shared.Body.Components;
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.EntitySystems;
+using Robust.Shared.Containers;
+using Robust.Shared.Prototypes;
+using System.ComponentModel;
+using System.Xml.Linq;
+
+namespace Content.Shared._Euphoria.Traits.Effects;
+
+public sealed partial class ReplaceBloodReagentTraitEffect : BaseTraitEffect
+{
+
+    [DataField(required: true)]
+    public string Reagent = null;
+
+    public override void Apply(TraitEffectContext ctx) {
+        if (ctx.EntMan.TryGetComponent<BloodstreamComponent>(ctx.Player, out var bloodstream))
+        {
+            var referenceSolution = bloodstream.BloodReferenceSolution;
+            var totalVolume = referenceSolution.Volume;
+            referenceSolution.RemoveAllSolution();
+            referenceSolution.AddReagent(Reagent, totalVolume);
+            if (
+                ctx.EntMan.TryGetComponent<ContainerManagerComponent>(ctx.Player, out var containerManager) &&
+                containerManager.Containers.TryGetValue($"solution@{bloodstream.BloodSolutionName}", out var solutionContainer) &&
+                solutionContainer is ContainerSlot solutionSlot &&
+                solutionSlot.ContainedEntity is { } containedSolution
+            )
+            {
+                var bloodSolution = ctx.EntMan.GetComponent<SolutionComponent>(containedSolution).Solution;
+                bloodSolution.RemoveAllSolution();
+                bloodSolution.AddReagent(Reagent, totalVolume);
+            }
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Euphoria/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_Euphoria/reagents/meta/biological.ftl
@@ -1,0 +1,2 @@
+reagent-name-yellow-blood = yellow blood
+reagent-desc-yellow-blood = But why is it yellow?

--- a/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
+++ b/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
@@ -1,0 +1,8 @@
+trait-replace-blood-red-name = Blood: Red
+trait-replace-blood-ammonia-name = Blood: Ammonia
+trait-replace-blood-copper-name = Blood: Copper
+trait-replace-blood-insect-name = Blood: Insect
+trait-replace-blood-sap-name = Blood: Sap
+trait-replace-blood-slime-name = Blood: Slime
+trait-replace-blood-yellow-name = Blood: Yellow
+trait-blood-desc = Your blood is unusual for your species. This doesn't affect what medicines work on you.

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -60,7 +60,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#162581"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#162581"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Speech

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -68,7 +68,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#FF0000"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#FF0000"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -24,7 +24,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#cd7314"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#cd7314"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Butcherable

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -42,7 +42,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#808A51"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#808A51"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: MothAccent

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -96,7 +96,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#2cf274"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#2cf274"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -116,7 +116,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#7a8bf2"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#7a8bf2"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
   - type: Bloodstream

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_fun.yml
@@ -126,6 +126,11 @@
     - Rum
     - Tequila
     - Absinthe
+    # Euphoria start: Add more blood variants to random tables
+    - AmmoniaBlood
+    - InsectBlood
+    - Sap
+    # Euphoria end
   - quantity: 10
     weight: 1
     reagents:
@@ -136,6 +141,7 @@
     - SpaceCleaner
     - MilkSpoiled
     - FourteenLoko
+    - YellowBlood # Euphoria: Add more blood variants to random tables
 
 - type: entity
   parent: [DrinkVisualsAllFilled, DrinkBottleGlassSmallBaseFull]

--- a/Resources/Prototypes/GameRules/variation.yml
+++ b/Resources/Prototypes/GameRules/variation.yml
@@ -116,6 +116,11 @@
     - Blood
     - CopperBlood
     - Slime
+    # Euphoria start: Add more blood variants to random tables
+    - AmmoniaBlood
+    - Sap
+    - YellowBlood
+    # Euphoria end
   - quantity: 25
     weight: 1
     reagents:

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -259,6 +259,7 @@
     - AmmoniaBlood
     - ZombieBlood
     - Sap
+    - YellowBlood # Euphoria: Add yellow blood.
 
 - type: xenoArchTrigger
   id: TriggerThrow

--- a/Resources/Prototypes/_DV/Entities/Effects/puddles.yml
+++ b/Resources/Prototypes/_DV/Entities/Effects/puddles.yml
@@ -22,6 +22,7 @@
     - AmmoniaBlood
     - Ichor
     - SynthBlood
+    - YellowBlood # Euphoria: Add more blood variants to random tables
 
 - type: entity
   id: PuddleRandomDrinks

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -61,7 +61,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#808A51"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#808A51"
       Burn:
         sprite: Mobs/Effects/burn_damage.rsi
 

--- a/Resources/Prototypes/_Euphoria/Reagents/biological.yml
+++ b/Resources/Prototypes/_Euphoria/Reagents/biological.yml
@@ -1,0 +1,9 @@
+
+- type: reagent
+  parent: Blood
+  id: YellowBlood
+  name: reagent-name-yellow-blood
+  group: Biological
+  desc: reagent-desc-yellow-blood
+  color: "#ffc900"
+  recognizable: true

--- a/Resources/Prototypes/_Euphoria/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/_Euphoria/Recipes/Reactions/biological.yml
@@ -1,0 +1,14 @@
+- type: reaction
+  id: YellowBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    YellowBlood:
+      amount: 20
+  products:
+    Water: 11
+    Iron: 0.5
+    Sugar: 2
+    CarbonDioxide: 3
+    Protein: 4

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -24,7 +24,7 @@
     - Diona #Sap
     - Moth #InsectBlood
     - Resomi #AmmoniaBlood
-    - Slime #Slime
+    - SlimePerson #Slime
     - Vox #AmmoniaBlood
   effects:
   - !type:ReplaceBloodReagentTraitEffect
@@ -106,7 +106,7 @@
     invert: true
     species:
     - Chitinid
-    - Mot
+    - Moth
   effects:
   - !type:ReplaceBloodReagentTraitEffect
     reagent: InsectBlood
@@ -158,7 +158,7 @@
   - !type:OneOfSpeciesCondition
     invert: true
     species:
-    - Slime
+    - SlimePerson
   effects:
   - !type:ReplaceBloodReagentTraitEffect
     reagent: Slime

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -1,0 +1,186 @@
+- type: trait
+  id: ReplaceBloodRed
+  name: trait-replace-blood-red-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    species:
+    - Arachnid #CopperBlood
+    - Avali #AmmoniaBlood
+    - Chitinid #InsectBlood
+    - Diona #Sap
+    - Moth #InsectBlood
+    - Resomi #AmmoniaBlood
+    - Slime #Slime
+    - Vox #AmmoniaBlood
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: Blood
+
+- type: trait
+  id: ReplaceBloodAmmonia
+  name: trait-replace-blood-ammonia-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - Avali
+    - Resomi
+    - Vox
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: AmmoniaBlood
+
+- type: trait
+  id: ReplaceBloodCopper
+  name: trait-replace-blood-copper-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - Arachnid
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: CopperBlood
+
+- type: trait
+  id: ReplaceBloodInsect
+  name: trait-replace-blood-insect-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - Chitinid
+    - Mot
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: InsectBlood
+
+- type: trait
+  id: ReplaceBloodSap
+  name: trait-replace-blood-sap-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - Diona
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: Sap
+
+- type: trait
+  id: ReplaceBloodSlime
+  name: trait-replace-blood-slime-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodYellow
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - Slime
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: Slime
+
+- type: trait
+  id: ReplaceBloodYellow
+  name: trait-replace-blood-yellow-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: YellowBlood

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Species/avali.yml
@@ -33,7 +33,7 @@
     damageOverlayGroups:
       Brute:
         sprite: Mobs/Effects/brute_damage.rsi
-        color: "#7a8bf2"
+        colorFromBlood: true # Euphoria: Add damage overlay colours from blood, was color: "#7a8bf2"
       Burn: # DeltaV
         sprite: Mobs/Effects/burn_damage.rsi
   - type: MeleeWeapon


### PR DESCRIPTION
## About the PR
Added traits that replace your species' default blood. Also added yellow blood, primarily intended for expies but the lore is left generic.

## Why / Balance
In line with unrestricted markings and custom species names, this change furthers the ability of players to create their own custom species. While some blood types have minor effects on chemistry, I consider the effect on gameplay balance to be insignificant. The most useful blood type is red, and that is also the most commonly available blood type.

## Technical details
Adds a set of new traits.
Adds a new trait effect to replace blood type.
Modifies DamageVisualsComponent and DamageVisualsSystem to allow damage visuals to automatically match bloodstream colour.
Adds the new colorFromBlood effect to all playable species mobs.
Adds a new reagent for Yellow Blood, with one reaction for the centrifuge.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="1008" height="426" alt="Blood traits" src="https://github.com/user-attachments/assets/90567335-6e70-4d6c-9ff4-3d6b05246afd" />
<img width="269" height="213" alt="Modified blood and wound visuals" src="https://github.com/user-attachments/assets/3cbdb24d-a048-4fbc-9b15-748a2004966e" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

## Breaking changes
Modified DamageVisualsSystem. While I don't believe I have introduced any breaking changes, this is a risk.

**Changelog**
:cl:
- add: An array of new traits allows you to customise your characters' blood. Custom species rejoice.
