### PR TITLE
Change most holy book item names to use title case

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Chapel/bibles.yml
@@ -1,5 +1,5 @@
 - type: entity
-  name: space bible
+  name: Space Bible
   description: New Interstellar Version 2340.
   parent: BaseStorageItem
   id: Bible
@@ -76,7 +76,7 @@
 
 - type: entity
   parent: [Bible, BaseSyndicateContraband]
-  name: necronomicon
+  name: Necronomicon
   description: "There's a note: Klatuu, Verata, Nikto -- Don't forget it again!"
   id: BibleNecronomicon
   components:
@@ -138,7 +138,7 @@
 
 - type: entity
   id: BibleNarsie
-  name: tome of nar'sie
+  name: Tome of Nar'Sie
   parent: Bible
   description: "What could possibly go wrong with a book covered in blood?"
   components:
@@ -149,7 +149,7 @@
 
 - type: entity
   id: BibleNanoTrasen
-  name: codex nanotrasimus
+  name: Codex NanoTrasimus
   parent: Bible
   description: "A familiar book containing the Sacred Operating Procedures."
   components:
@@ -160,7 +160,7 @@
 
 - type: entity
   id: BibleHonk
-  name: mirth of the honkmother
+  name: Mirth of the Honkmother
   parent: Bible
   description: "Oh great and glorious Mother, Mistress of Mirth, Matron of Mask and Merriments, Blessed is she amongst us jesters."
   components:
@@ -171,7 +171,7 @@
 
 - type: entity
   id: BibleRatvar
-  name: tablet of ratvar
+  name: Tablet of Ratvar
   parent: Bible
   description: "A holy relic of the Clockwork Cult, blessed by the Clockwork Justice, Ratvar."
   components:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Specific/Chapel/bibles.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: Bible
   id: BibleMystagogue
-  name: book of mysteries
+  name: Book of Mysteries
   description: The mystagogue's holy book.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Chapel/bibles.yml
@@ -1,7 +1,7 @@
 - type: entity
   parent: Bible
   id: BibleLustroEcclesia
-  name: ritus ignis
+  name: Ritus Ignis
   description: The holy book of Lustro Ecclesia. Praise be Sol'Magmus...
   components:
   - type: Sprite
@@ -25,7 +25,7 @@
 - type: entity
   parent: Bible
   id: BibleGorlexGF
-  name: gorlex goddess
+  name: Gorlex Goddess
   description: The holy book of Lust.
   components:
   - type: Sprite
@@ -43,7 +43,7 @@
 - type: entity
   parent: Bible
   id: BibleChaddiusThundercockis
-  name: chaddius thundercockis's guide to getting laid
+  name: Chaddius Thundercockis's Guide To Getting Laid
   description: The holy book of Lust.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Chapel/bibles.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Chapel/bibles.yml
@@ -43,7 +43,7 @@
 - type: entity
   parent: Bible
   id: BibleChaddiusThundercockis
-  name: Chaddius Thundercockis's Guide To Getting Laid
+  name: Chaddius Thundercockis's Guide to Getting Laid
   description: The holy book of Lust.
   components:
   - type: Sprite


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

Changes the capitalisation of most holy book item names to use title case.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

There is no well-established standard for how items should be capitalised in SS14 (see Syndicate weapons like the Python being capitalised while security weapons like the mk 58 are not, despite both being names of specific guns), so it does not hurt to ensure that holy books are consistently capitalised in title case where appropriate.

Reasoning for each holy book below.
**Book of Mysteries:** This book might be a reference to the Book of Mysteries found in the Dead Sea Scrolls, which if true means it should be in title case. Also, it is a specific book held by the mystagogue. However, nothing in its description actually suggests it is a specific book, so title case may be inappropriate.
**Chaddius Thundercockis's Guide to Getting Laid:** I initially was going to capitalise the "to" in this one, but then realised that probably wouldn't be appropriate as "Getting" is not in its base form. Other that that, it's based off CentComm Chads, which is a magazine and should be in title case. CentComm Chads is also capitalised, so capitalising this holy book improves consistency between item names of similar types.
**Codex NanoTrasimus:** "NanoTrasimus" is based of "NanoTrasen", which has inconsistent capitalisation, but I've chosen to go with "-Trasen" also being capitalised and applied that logic to "NanoTrasimus". "Codex" is capitalised as the description states the book is familiar, possibly suggesting some kind of corporatocratic religion with its own canon.
**Gorlex Goddess:** Based on the Gorlex Girlfriends magazine. It being a magazine means it should be in title case. The Gorlex Girlfriends magazine is also capitalised, so this improves consistency between item names of similar types.
**Mirth of the Honkmother:** I actually can't justify this one. The item's name seems to suggest it's the title of a book, so I'm applied title case. However, without lore on clown religions and the Honkmother, I can't be certain.
**Necronomicon:** A reference to the works of H.P. Lovecraft, in which Necronomicon is a specific book and is written in title case.
**Ritus Ignis:** Referred to in the Lustro Ecclesia lore document with both words capitalised. Due to ambiguity as to whether this was referring to the ritual by the same name, I asked moonz_n_cats on Discord, who confirmed that it should be capitalised in title case.
**Space Bible:** The item description of the Space Bible ("New Interstellar Edition 2340.") suggests it is a specific book, and therefore should be in title case. It's worth noting that the Christian altar has the name "space-Christian altar", capitalised as such, suggesting that Space Christianity might not be a specific denomination of Christianity. However, given that the Space Bible seems to a specific publication of the Bible from 2340, I have chosen to capitalise it in title case.
**Tablet of Ratvar:** Item description states it is a "holy relic" implying this is a specific book that should be in title case.
**Tome of Nar'Sie:** No justification for capitalisation of "Tome", other than keeping it consistent with the Tablet of Ratvar. "Nar'Sie" is a proper noun and should be capitalised.
**communist manifesto:** While it's obvious that this book is referencing The Communist Manifesto, from an in-character perspective this could be the manifesto of any communist party in the galaxy. I like that ambiguity and therefore have not changed the capitalisation of this.
**druidic tablet:** The most difficult one to make a decision on by far. Taking inspiration from Celtic druids, they did not leave extensive written records and do not have any canon that we know of. Although the druids of 2526 are likely not Celtic specifically, drawing inspiration from them is a nice idea when determining the capitalisation of this holy book. Leaving it uncapitalised reflects a focus on oral tradition and emphasises that this druidic tablet contains whatever text the station's druid (the chaplain bringing the tablet with them) is interested in.
**mother loaf bread bible:** It's a loaf of bread, but holy. We know from the description that "mother loaf" is actually not a proper noun, since it's not capitalised. Also, "bible" here seems to refer to bible when not used to refer to a specific holy text, like how you could call Space Law the "security department bible".

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Makes changes to the name of various holy books in the bibles.yml across different namespaces.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="455" height="411" alt="image" src="https://github.com/user-attachments/assets/fce235e2-7cf9-4ffd-bef6-0eeefe46b298" />
<img width="376" height="426" alt="image" src="https://github.com/user-attachments/assets/325f0108-cc49-4d4c-a351-e4ee4120ba78" />
<img width="804" height="801" alt="image" src="https://github.com/user-attachments/assets/c9647b5c-b9dd-4210-930e-bb07f8e02614" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Changed punctuation in most holy book names to use title case for capitalisation.
