### PR TITLE
Add traits: Regeneration compromised, superior, and enhanced.

### DIFF
--- a/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/HungerSystem.cs
@@ -273,4 +273,26 @@ public sealed class HungerSystem : EntitySystem
             DoContinuousHungerEffects(uid, hunger);
         }
     }
+
+    #region Euphoria: Add access to BaseHungerDecay for ModifyHungerDecayEffect
+    /// <summary>
+    /// Sets an entity's base hunger decay in a safe way. Silently fails if entity has no Hunger component.
+    /// </summary>
+    /// <param name="ent">The entity to which the hunger component belongs.</param>
+    /// <param name="baseDecayRate">The value to set the base decay rate to.</param>
+    /// <param name="component">The Hunger component to set the base decay rate for, or null.</param>
+    public void SetBaseDecayRate(EntityUid ent, float baseDecayRate, HungerComponent? component = null)
+    {
+        if (!Resolve(ent, ref component))
+            return;
+
+        // First calculate and set current hunger value.
+        SetHunger(ent, GetHunger(component), component);
+        component.BaseDecayRate = baseDecayRate;
+
+        // Force hunger threshold effects to set actual decay based on base decay and threshold modifier.
+        // Current threshold does not need to be re-calculated.
+        DoHungerThresholdEffects(ent, component, true);
+    }
+    #endregion
 }

--- a/Content.Shared/_Floof/Traits/Effects/ModifyHungerDecayEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/ModifyHungerDecayEffect.cs
@@ -1,0 +1,26 @@
+using Content.Shared._DV.Traits.Effects;
+using Content.Shared.Nutrition.Components;
+using Content.Shared.Nutrition.EntitySystems;
+
+namespace Content.Shared._Floof.Traits.Effects;
+
+public sealed partial class ModifyHungerDecayEffect : BaseTraitEffect
+{
+    [DataField(required: true)]
+    public float Amount;
+
+    public override void Apply(TraitEffectContext ctx)
+    {
+        if (!ctx.EntMan.TryGetComponent<HungerComponent>(ctx.Player, out var hungerComp))
+        {
+            Log.Error($"Trying to apply ModifyHungerDecayEffect on {ctx.Player}, but entity has no HungerComponent.");
+            return;
+        }
+        if (!ctx.EntMan.TrySystem<HungerSystem>(out var _hunger))
+        {
+            Log.Error($"Trying to apply ModifyHungerDecayEffect on {ctx.Player}, but HungerSystem cannot be found.");
+            return;
+        }
+        _hunger.SetBaseDecayRate(ctx.Player, hungerComp.BaseDecayRate + Amount, hungerComp);
+    }
+}

--- a/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
+++ b/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
@@ -6,3 +6,10 @@ trait-replace-blood-sap-name = Blood: Sap
 trait-replace-blood-slime-name = Blood: Slime
 trait-replace-blood-yellow-name = Blood: Yellow
 trait-blood-desc = Your blood is unusual for your species. This doesn't affect what medicines work on you.
+
+trait-healing-minus-name = Regeneration: Compromised
+trait-healing-minus-desc = Your heal slower than others.
+trait-healing-plus-name = Regeneration: Enhanced
+trait-healing-plus-desc = You heal faster than others (equivalent to a slime person).
+trait-healing-plus-2-name = Regeneration: Superior
+trait-healing-plus-2-desc = Your ability to heal is even better, more effectively healing from brute and poison damage.

--- a/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
+++ b/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
@@ -10,6 +10,6 @@ trait-blood-desc = Your blood is unusual for your species. This doesn't affect w
 trait-healing-minus-name = Regeneration: Compromised
 trait-healing-minus-desc = Your heal slower than others.
 trait-healing-plus-name = Regeneration: Enhanced
-trait-healing-plus-desc = You heal faster than others (equivalent to a slime person).
+trait-healing-plus-desc = You heal faster than others, but have a higher metabolism
 trait-healing-plus-2-name = Regeneration: Superior
 trait-healing-plus-2-desc = Your ability to heal is even better, more effectively healing from brute and poison damage.

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -197,6 +197,18 @@
   - HealingMinus
   - HealingPlus2
   conditions:
+  - !type:InDepartmentCondition
+    department: Security
+    invert: true
+  - !type:HasJobCondition
+    job: SalvageSpecialist
+    invert: true
+  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
+    component: NukeOperative
+    invert: true
+  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
+    component: NinjaRole
+    invert: true
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -228,6 +240,18 @@
   - HealingMinus
   - HealingPlus
   conditions:
+  - !type:InDepartmentCondition
+    department: Security
+    invert: true
+  - !type:HasJobCondition
+    job: SalvageSpecialist
+    invert: true
+  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
+    component: NukeOperative
+    invert: true
+  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
+    component: NinjaRole
+    invert: true
   - !type:HasCompCondition
     component: BorgChassis
     invert: true

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -220,15 +220,17 @@
   effects:
   - !type:OverrideCompsEffect
     components:
-    - type: PassiveDamage # Equal to slime person healing
+    - type: PassiveDamage
       allowedStates:
       - Alive
-      damageCap: 65
+      damageCap: 50 # +30 over default
       damage:
         types:
-          Heat: -0.14
+          Heat: -0.14 # -0.07 over default
         groups:
-          Brute: -0.14
+          Brute: -0.14 # -0.07 over default
+    - type: Hunger
+      baseDecayRate: 0.035 # 2.1 times default
 
 - type: trait
   id: HealingPlus2
@@ -265,13 +267,15 @@
     - type: PassiveDamage
       allowedStates:
       - Alive
-      damageCap: 65 # same as lower trait
+      damageCap: 60 # +10 over lower trait
       damage:
         types:
           Heat: -0.14 # same as lower trait
           Poison: -0.07 # not present in lower trait
         groups:
           Brute: -0.21 # increased 50% over lower trait
+    - type: Hunger
+      baseDecayRate: 0.035 # same as lower trait
 
 - type: trait
   id: HealingMinus

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -1,3 +1,4 @@
+# Blood
 - type: trait
   id: ReplaceBloodRed
   name: trait-replace-blood-red-name
@@ -184,3 +185,96 @@
   effects:
   - !type:ReplaceBloodReagentTraitEffect
     reagent: YellowBlood
+
+# Regeneration
+- type: trait
+  id: HealingPlus
+  name: trait-healing-plus-name
+  description: trait-healing-plus-desc
+  category: BonusPhysical
+  cost: 4
+  conflicts:
+  - HealingMinus
+  - HealingPlus2
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
+    - SlimePerson
+  effects:
+  - !type:OverrideCompsEffect
+    components:
+    - type: PassiveDamage # Equal to slime person healing
+      allowedStates:
+      - Alive
+      damageCap: 65
+      damage:
+        types:
+          Heat: -0.14
+        groups:
+          Brute: -0.14
+
+- type: trait
+  id: HealingPlus2
+  name: trait-healing-plus-2-name
+  description: trait-healing-plus-2-desc
+  category: BonusPhysical
+  cost: 8
+  conflicts:
+  - HealingMinus
+  - HealingPlus
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
+  effects:
+  - !type:OverrideCompsEffect
+    components:
+    - type: PassiveDamage
+      allowedStates:
+      - Alive
+      damageCap: 65 # same as lower trait
+      damage:
+        types:
+          Heat: -0.14 # same as lower trait
+          Poison: -0.07 # not present in lower trait
+        groups:
+          Brute: -0.21 # increased 50% over lower trait
+
+- type: trait
+  id: HealingMinus
+  name: trait-healing-minus-name
+  description: trait-healing-minus-desc
+  category: DisabilitiesPhysical
+  cost: -1
+  conflicts:
+  - HealingPlus
+  - HealingPlus2
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
+  effects:
+  - !type:OverrideCompsEffect
+    components:
+    - type: PassiveDamage # Half of base, with 75% of the cap
+      allowedStates:
+      - Alive
+      damageCap: 15
+      damage:
+        types:
+          Heat: -0.03
+        groups:
+          Brute: -0.03

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -210,6 +210,8 @@
     component: NinjaRole
     invert: true
   - !type:HasCompCondition
+    component: Hunger
+  - !type:HasCompCondition
     component: BorgChassis
     invert: true
   - !type:OneOfSpeciesCondition
@@ -229,8 +231,8 @@
           Heat: -0.14 # -0.07 over default
         groups:
           Brute: -0.14 # -0.07 over default
-    - type: Hunger
-      baseDecayRate: 0.035 # 2.1 times default
+  - !type:ModifyHungerDecayEffect
+    amount: 0.00833333333 # +50% over default
 
 - type: trait
   id: HealingPlus2
@@ -255,6 +257,8 @@
     component: NinjaRole
     invert: true
   - !type:HasCompCondition
+    component: Hunger
+  - !type:HasCompCondition
     component: BorgChassis
     invert: true
   - !type:OneOfSpeciesCondition
@@ -274,8 +278,8 @@
           Poison: -0.07 # not present in lower trait
         groups:
           Brute: -0.21 # increased 50% over lower trait
-    - type: Hunger
-      baseDecayRate: 0.035 # same as lower trait
+  - !type:ModifyHungerDecayEffect
+    amount: 0.00833333333 # same as lower trait
 
 - type: trait
   id: HealingMinus
@@ -287,6 +291,8 @@
   - HealingPlus
   - HealingPlus2
   conditions:
+  - !type:HasCompCondition
+    component: Hunger
   - !type:HasCompCondition
     component: BorgChassis
     invert: true


### PR DESCRIPTION
## About the PR
Adds three traits, which enhance or reduce passive healing.

## Why / Balance
To further the push for custom species (rather than every pet species needing to be added individually), I'm adding these traits. As regards balance, the enhanced regeneration trait only matches slime people's regeneration, and is unlikely to significantly affect the outcome of any conflicts.

Since the comparison has already come up, and were always inevitable, here's a direct comparison to platelets of old.
| | Baseline | Enhanced Regeneration | Superior Regeneration | Platelets of old |
| - | --------- | -------------------------- | ------------------------- | ---------------- |
| Cost | 0 | 4 | 8 | 10 |
| Maximum damage | 20 | 40| 50 | 400 |
| Works when crit | No | No | No | Yes |
| Refills blood | — | — | — | 0.025 |
| Brute (group) | 0.07 | 0.14 | 0.21 | 0.30 |
| Heat | 0.07 | 0.14 | 0.14 | 0.075 |
| Cold, Shock, Caustic | — | — | — | 0.075 |
| Airloss (group, including bloodloss damage and while crit) | — | — | — | 0.25
| Poison | — | — | 0.07 | 0.15 |
| Radiation | — | — | — | 0.15 |
| Genetic (!) | — | — | — | 0.20 |

As you can see, Platelets was problematic in key ways that are completely absent from these traits, including allowing someone to completely heal and get up after going crit, due to a combination of blood regeneration, airloss healing, a damage cap of 400, and working while crit.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="1108" height="159" alt="Traits Positive" src="https://github.com/user-attachments/assets/50a8dc95-0131-40bd-896e-4aa4c1133fb8" />
<img width="1108" height="81" alt="Traits Negative" src="https://github.com/user-attachments/assets/adf7a923-2eff-41e2-9cf2-a3d2b7933019" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

## Breaking changes
None

**Changelog**
:cl:
- add: Three new traits that increase or decrease your natural regeneration.
