### PR TITLE
Make Some Traits Not Take Slots

### DIFF
--- a/Resources/Prototypes/_Coyote/smell_traits.yml
+++ b/Resources/Prototypes/_Coyote/smell_traits.yml
@@ -5,6 +5,7 @@
   description: trait-scent-vanilla-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -16,6 +17,7 @@
   description: trait-scent-citrus-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -27,6 +29,7 @@
   description: trait-scent-linen-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -38,6 +41,7 @@
   description: trait-scent-sandalwood-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -49,6 +53,7 @@
   description: trait-scent-lavender-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -60,6 +65,7 @@
   description: trait-scent-greentea-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -71,6 +77,7 @@
   description: trait-scent-bergamot-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -82,6 +89,7 @@
   description: trait-scent-eucalyptus-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -93,6 +101,7 @@
   description: trait-scent-cedarwood-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -104,6 +113,7 @@
   description: trait-scent-mint-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -115,6 +125,7 @@
   description: trait-scent-rosewater-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -126,6 +137,7 @@
   description: trait-scent-jasmine-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -137,6 +149,7 @@
   description: trait-scent-lemonzest-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -148,6 +161,7 @@
   description: trait-scent-pine-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -159,6 +173,7 @@
   description: trait-scent-warmhoney-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -170,6 +185,7 @@
   description: trait-scent-rain-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -181,6 +197,7 @@
   description: trait-scent-apples-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -192,6 +209,7 @@
   description: trait-scent-cloves-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -203,6 +221,7 @@
   description: trait-scent-darkchocolate-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -214,6 +233,7 @@
   description: trait-scent-orangeblossoms-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -225,6 +245,7 @@
   description: trait-scent-leather-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -236,6 +257,7 @@
   description: trait-scent-aloe-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -247,6 +269,7 @@
   description: trait-scent-cardamom-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -258,6 +281,7 @@
   description: trait-scent-peaches-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -269,6 +293,7 @@
   description: trait-scent-basil-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -280,6 +305,7 @@
   description: trait-scent-smokedwood-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -291,6 +317,7 @@
   description: trait-scent-milkandsugar-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -302,6 +329,7 @@
   description: trait-scent-iris-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -313,6 +341,7 @@
   description: trait-scent-grapefruit-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -324,6 +353,7 @@
   description: trait-scent-frankincense-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -335,6 +365,7 @@
   description: trait-scent-pears-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -346,6 +377,7 @@
   description: trait-scent-tobacco-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -357,6 +389,7 @@
   description: trait-scent-soap-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -368,6 +401,7 @@
   description: trait-scent-chamomile-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -379,6 +413,7 @@
   description: trait-scent-fig-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -390,6 +425,7 @@
   description: trait-scent-ozone-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -401,6 +437,7 @@
   description: trait-scent-sweat-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -412,6 +449,7 @@
   description: trait-scent-oil-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -423,6 +461,7 @@
   description: trait-scent-motoroil-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -434,6 +473,7 @@
   description: trait-scent-soil-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -445,6 +485,7 @@
   description: trait-scent-almond-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -456,6 +497,7 @@
   description: trait-scent-patchouli-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -467,6 +509,7 @@
   description: trait-scent-blueberry-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -478,6 +521,7 @@
   description: trait-scent-cinnamon-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -489,6 +533,7 @@
   description: trait-scent-seasalt-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -500,6 +545,7 @@
   description: trait-scent-wildflowers-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -512,6 +558,7 @@
   description: trait-scent-musk-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -523,6 +570,7 @@
   description: trait-scent-heat-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -534,6 +582,7 @@
   description: trait-scent-latex-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -545,6 +594,7 @@
   description: trait-scent-boystink-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -556,6 +606,7 @@
   description: trait-scent-boysmell-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -567,6 +618,7 @@
   description: trait-scent-skunk-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -578,6 +630,7 @@
   description: trait-scent-girlstink-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -589,6 +642,7 @@
   description: trait-scent-girlsmell-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -600,6 +654,7 @@
   description: trait-scent-spaceweed-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -615,6 +670,7 @@
   description: trait-scent-gunmetal-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -626,6 +682,7 @@
   description: trait-scent-disinfectant-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -637,6 +694,7 @@
   description: trait-scent-ink-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -648,6 +706,7 @@
   description: trait-scent-dust-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -659,6 +718,7 @@
   description: trait-scent-metal-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -670,6 +730,7 @@
   description: trait-scent-omni-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -681,6 +742,7 @@
   description: trait-scent-gunpowder-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -692,6 +754,7 @@
   description: trait-scent-moss-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -703,6 +766,7 @@
   description: trait-scent-weldfuel-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -714,6 +778,7 @@
   description: trait-scent-jolly-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -725,6 +790,7 @@
   description: trait-scent-gingerbread-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -736,6 +802,7 @@
   description: trait-scent-hellstone-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -747,6 +814,7 @@
   description: trait-scent-rust-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -758,6 +826,7 @@
   description: trait-scent-flowers-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -769,6 +838,7 @@
   description: trait-scent-stillwater-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -780,6 +850,7 @@
   description: trait-scent-uranium-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -791,6 +862,7 @@
   description: trait-scent-blacktea-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -802,6 +874,7 @@
   description: trait-scent-seafood-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -813,6 +886,7 @@
   description: trait-scent-wetdog-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -824,6 +898,7 @@
   description: trait-scent-phoron-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -835,6 +910,7 @@
   description: trait-scent-grass-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -846,6 +922,7 @@
   description: trait-scent-bday-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -857,6 +934,7 @@
   description: trait-scent-unwashedfox-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -868,6 +946,7 @@
   description: trait-scent-iron-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -879,6 +958,7 @@
   description: trait-scent-frezon-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -890,6 +970,7 @@
   description: trait-scent-fish-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -901,6 +982,7 @@
   description: trait-scent-cheapcologne-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -912,6 +994,7 @@
   description: trait-scent-expensivecologne-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -923,6 +1006,7 @@
   description: trait-scent-alcohol-desc
   category: Scents
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -936,6 +1020,7 @@
   description: trait-scent-piss-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:
@@ -947,6 +1032,7 @@
   description: trait-scent-pomegranate-desc
   category: ScentsNSFW
   cost: 0 # Euphoria
+  usesSlots: false # Euphoria
   effects:
   - !type:AddScentTraitEffect
     scents:

--- a/Resources/Prototypes/_DV/Traits/disabilities.yml
+++ b/Resources/Prototypes/_DV/Traits/disabilities.yml
@@ -39,6 +39,7 @@
   description: trait-monochromacy-desc
   category: DisabilitiesPhysical # Euphoria
   cost: 0 #floof
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -50,6 +51,7 @@
   description: trait-deuteranopia-desc
   category: DisabilitiesPhysical # Euphoria
   cost: 0 #floof
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -61,6 +63,7 @@
   description: trait-ultravision-desc
   category: DisabilitiesPhysical # Euphoria
   cost: 0 #floof
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/mental.yml
+++ b/Resources/Prototypes/_DV/Traits/mental.yml
@@ -43,6 +43,7 @@
   description: trait-liar-desc
   category: DisabilitiesMental # Euphoria
   cost: -1 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/mental.yml
+++ b/Resources/Prototypes/_DV/Traits/mental.yml
@@ -43,7 +43,7 @@
   description: trait-liar-desc
   category: DisabilitiesMental # Euphoria
   cost: -1 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/meta.yml
+++ b/Resources/Prototypes/_DV/Traits/meta.yml
@@ -4,7 +4,7 @@
   description: trait-protected-desc
   category: Meta
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   conditions:
   - !type:InDepartmentCondition
     department: Command

--- a/Resources/Prototypes/_DV/Traits/meta.yml
+++ b/Resources/Prototypes/_DV/Traits/meta.yml
@@ -4,6 +4,7 @@
   description: trait-protected-desc
   category: Meta
   cost: 0 #floof
+  usesSlots: false
   conditions:
   - !type:InDepartmentCondition
     department: Command

--- a/Resources/Prototypes/_DV/Traits/speech.yml
+++ b/Resources/Prototypes/_DV/Traits/speech.yml
@@ -6,7 +6,7 @@
   description: trait-pirate-accent-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -18,7 +18,7 @@
   description: trait-southern-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -30,7 +30,7 @@
   description: trait-cowboy-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -43,7 +43,7 @@
   description: trait-italian-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -56,7 +56,7 @@
   description: trait-muted-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -73,7 +73,7 @@
   description: trait-french-accent-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -85,7 +85,7 @@
   description: trait-spanish-accent-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -97,7 +97,7 @@
   description: trait-irish-accent-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -109,7 +109,7 @@
   description: trait-mobster-accent-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -121,7 +121,7 @@
   description: trait-scottish-accent-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -133,7 +133,7 @@
   description: trait-accentless-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -150,7 +150,7 @@
   description: trait-socialanxiety-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -166,7 +166,7 @@
   description: trait-frontal-lisp-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -178,7 +178,7 @@
   description: trait-hushed-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -195,7 +195,7 @@
   description: trait-anglish-desc
   category: Accents
   cost: 0 #floof
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -207,7 +207,7 @@
   description: trait-slavic-desc
   category: Accents
   cost: 0
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:
@@ -220,7 +220,7 @@
   description: trait-rrrolling-accent-desc
   category: Accents
   cost: 0
-  usesSlots: false
+  usesSlots: false # Euphoria
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_DV/Traits/speech.yml
+++ b/Resources/Prototypes/_DV/Traits/speech.yml
@@ -6,6 +6,7 @@
   description: trait-pirate-accent-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -17,6 +18,7 @@
   description: trait-southern-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -28,6 +30,7 @@
   description: trait-cowboy-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -40,6 +43,7 @@
   description: trait-italian-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -52,6 +56,7 @@
   description: trait-muted-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -68,6 +73,7 @@
   description: trait-french-accent-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -79,6 +85,7 @@
   description: trait-spanish-accent-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -90,6 +97,7 @@
   description: trait-irish-accent-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -101,6 +109,7 @@
   description: trait-mobster-accent-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -112,6 +121,7 @@
   description: trait-scottish-accent-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -123,6 +133,7 @@
   description: trait-accentless-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -139,6 +150,7 @@
   description: trait-socialanxiety-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -154,6 +166,7 @@
   description: trait-frontal-lisp-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -165,6 +178,7 @@
   description: trait-hushed-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -181,6 +195,7 @@
   description: trait-anglish-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -192,6 +207,7 @@
   description: trait-slavic-desc
   category: Accents
   cost: 0
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:
@@ -204,6 +220,7 @@
   description: trait-rrrolling-accent-desc
   category: Accents
   cost: 0
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_Euphoria/Traits/speech.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/speech.yml
@@ -4,6 +4,7 @@
   description: trait-german-desc
   category: Accents
   cost: 0 #floof
+  usesSlots: false #Euph
   effects:
   - !type:AddCompsEffect
     components:

--- a/Resources/Prototypes/_Floof/Traits/meta.yml
+++ b/Resources/Prototypes/_Floof/Traits/meta.yml
@@ -4,6 +4,7 @@
   description: trait-marked-teach-desc
   category: Meta
   cost: 0
+  usesSlots: false
   conditions:
   - !type:InDepartmentCondition
     department: Command
@@ -26,6 +27,7 @@
   description: trait-marked-remove-desc
   category: Meta
   cost: 0
+  usesSlots: false
   conditions:
   - !type:HasCompCondition
     component: TargetObjectiveImmune

--- a/Resources/Prototypes/_Floof/Traits/speech.yml
+++ b/Resources/Prototypes/_Floof/Traits/speech.yml
@@ -6,6 +6,7 @@
   description: trait-dog-accent-desc
   category: Accents
   cost: 0
+  usesSlots: false
   effects:
   - !type:AddCompsEffect
     components:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Made some traits no longer count towards your total number of trait slots. Not to be confused with point costs.
The types of traits affected:
Meta traits (marked for removal, etc)
Scent traits
Accent traits
Colorblindness traits

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
More traits keep getting added, but the slot limit remains the same, which has become quite limiting. This should hopefully mitigate that to a small degree.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just yml changes.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
In this image, you can see that I selected many traits (only from the ones I adjusted), and none of them took up a trait slot. 
<img width="1709" height="1318" alt="image" src="https://github.com/user-attachments/assets/4ca330e5-693b-43bd-8e8b-30736b6fa1d6" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Made some traits not count towards your total trait slot limit (Meta traits, accent traits, scent traits, colorblind traits)
