### PR TITLE
[FIX] Cherrypick Upstream No. 5747 and Fix Missing Gas Canister Sprites

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -46,11 +46,11 @@
           enum.PaperLabelVisuals.Layer:
             True: { visible: false }
         enum.PaperLabelVisuals.LabelType:
-          enum.PaperLabelVisuals.Layer:
-            Paper: { state: paper }
-            Bounty: { state: bounty }
-            CaptainsPaper: { state: captains_paper }
-            Invoice: { state: invoice }
+          enum.PaperLabelVisuals.Layer: # Euphoria - M3739 - PaperLabelFixes - Base sprite lacks such states, point to Wizden sprites
+            Paper: { sprite: Structures/Storage/canister.rsi, state: paper }
+            Bounty: { sprite: Structures/Storage/canister.rsi, state: bounty }
+            CaptainsPaper: { sprite: Structures/Storage/canister.rsi, state: captains_paper }
+            Invoice: { sprite: Structures/Storage/canister.rsi, state: invoice }
     - type: ActivatableUI
       key: enum.GasCanisterUiKey.Key
     - type: UIRequiresLock

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
@@ -72,3 +72,41 @@
   components:
   - type: Flatpack
     entity: OperatingTable
+
+- type: entity
+  abstract: true
+  parent: BaseStructureDynamic
+  id: HeavyFlatpackBase
+  name: heavy flatpack
+  description: A large flatpack used to store a worryingly large machine.
+  components:
+  - type: Sprite
+    sprite: Objects/Devices/flatpack.rsi
+    layers:
+    - state: large
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.4,-0.4,0.4,0.29"
+        density: 100
+        mask:
+        - CrateMask
+        layer:
+        - MachineLayer
+  - type: Damageable
+    damageContainer: StructuralInorganic
+    damageModifierSet: StructuralMetallic
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 75
+      behaviors:
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+  - type: InteractionOutline

--- a/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Objects/Devices/flatpack.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: CrateEngineering
+  parent: HeavyFlatpackBase # Delta-V was CrateEngineering
   id: NuclearReactorFlatpack
   name: nuclear reactor flatpack
   description: A flatpack used for constructing a nuclear reactor. Parts sold separately.
@@ -12,7 +12,7 @@
     entity: NuclearReactorEmpty
 
 - type: entity
-  parent: CrateEngineering
+  parent: HeavyFlatpackBase # Delta-V was CrateEngineering
   id: GasTurbineFlatpack
   name: gas turbine flatpack
   description: A flatpack used for constructing a gas turbine.


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

This PR aims to fix the missing paper label sprites of the nuclear reactor flatpack and the gas canisters.

This was achieved by cherrypicking the relevant upstream PR, which removes the ability to attach labels in the first place. It's a nuclear reactor **flatpack**, not a crate. For the gas canisters, the Goob sprites implemented by #387 lacks paper label sprites. So `gas_canisters.yml` has been updated to point to the Wizden sprites.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Missing sprites look bad and makes the game feel unpolished/discordant.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

Creates a new base prototype, `HeavyFlatpackBase`, for flatpacks like the nuclear reactor and gas turbine flatpacks, and parents them accordingly to said new prototype. `PaperLabelVisuals`'s sprite states belonging to the `GasCanister` base prototype have been changed to point to Wizden's sprites instead of relying on the Goob sprites.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="524" height="584" alt="image" src="https://github.com/user-attachments/assets/37ad11c0-a60c-475c-91f3-a2542285b7a4" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Heavy flatpacks like the gas turbine flatpack can no longer have paper labels attached to them.
- fix: Gas canisters now have working paper label sprites. Atmos and Logi shall no longer be plagued by ERROR canisters.
