### PR TITLE
Added Shadekin Light Damage

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadowkin.yml
@@ -147,7 +147,7 @@
         Toxin: -0.15
         Airloss: -0.15
     lightDamage:
-      groups:
+      types:
         Heat: 1
     healWhenDead: true
     darkMovementSpeedMultiplier: 1.1

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadowkin.yml
@@ -135,6 +135,23 @@
     color: "#A58ECC"
     activateSound: null
     deactivateSound: null
+  - type: LightReactive # Euphoria
+    manual: true
+  - type: LightLevelHealth # Euphoria
+    darkThreshold: 0.4
+    lightThreshold: 0.9
+    darkDamage:
+      groups:
+        Brute: -0.15
+        Burn: -0.15
+        Toxin: -0.15
+        Airloss: -0.15
+    lightDamage:
+      groups:
+        Heat: 1
+    healWhenDead: true
+    darkMovementSpeedMultiplier: 1.1
+    lightMovementSpeedMultiplier: 0.9
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
Adds Light damage to Shadekin, they now take heat damage in the light and slowly heal in the dark. With a 10% slow in light and 10% speed boost in darkness.

:) I left heal when dead on so medical needs to fix them in a dark room.

## Why / Balance
Lore reasons.

## Technical details
Uses pre-existing components from Diona and Skia.

**Changelog**
:cl:
- add: Shadekin are now properly allergic to light again.