### PR TITLE
Cultral Disconnect Trait

### DIFF
--- a/Content.Shared/_Floof/Traits/Effects/RemoveSpeciesLanguageEffect.cs
+++ b/Content.Shared/_Floof/Traits/Effects/RemoveSpeciesLanguageEffect.cs
@@ -1,0 +1,24 @@
+﻿using Content.Shared._DV.Traits.Effects;
+using Content.Shared._Floof.Language;
+using Content.Shared._Floof.Language.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Utility;
+
+namespace Content.Shared._Floof.Traits.Effects;
+/// <summary>
+///     Removes all species granted languages.
+/// </summary>
+public sealed partial class RemoveSpeciesLanguageEffect : BaseTraitEffect
+{
+    public override void Apply(TraitEffectContext ctx)
+    {
+        var languageSys = ctx.EntMan.System<SharedLanguageSystem>();
+        var user = ctx.Player;
+        var languages = languageSys.GetUnderstoodLanguages(user).ShallowClone();
+        foreach (var language in languages)
+        {
+            if (language.Id != "TauCetiBasic")
+                languageSys.RemoveLanguage(user, language);
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Floof/traits/foreigner.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/foreigner.ftl
@@ -8,7 +8,7 @@ trait-foreigner-desc =
     For some reason, you do not speak this station's primary language.
     Instead, you have been issued a translator that only you can use.
 
-trait-foreign-origin-name = Foreign Origin
+trait-foreign-origin-name = Cultural Disconnect
 trait-foreign-origin-desc =
     For some reason, you do not speak the common languages of your species.
     Removes all languages granted by your species.

--- a/Resources/Locale/en-US/_Floof/traits/foreigner.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/foreigner.ftl
@@ -7,3 +7,8 @@ trait-foreigner-name = Foreigner
 trait-foreigner-desc =
     For some reason, you do not speak this station's primary language.
     Instead, you have been issued a translator that only you can use.
+
+trait-foreign-origin-name = Foreigner Origin
+trait-foreign-origin-desc =
+    For some reason, you do not speak the common languages of your species.
+    Removes all languages granted by your species.

--- a/Resources/Locale/en-US/_Floof/traits/foreigner.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/foreigner.ftl
@@ -8,7 +8,7 @@ trait-foreigner-desc =
     For some reason, you do not speak this station's primary language.
     Instead, you have been issued a translator that only you can use.
 
-trait-foreign-origin-name = Foreigner Origin
+trait-foreign-origin-name = Foreign Origin
 trait-foreign-origin-desc =
     For some reason, you do not speak the common languages of your species.
     Removes all languages granted by your species.

--- a/Resources/Prototypes/_Floof/Traits/Languages/foreigner.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/foreigner.yml
@@ -34,3 +34,19 @@
   - !type:ForeignerTraitEffect
     baseLanguage: TauCetiBasic
     baseTranslator: TranslatorForeigner
+
+- type: trait
+  id: ForeignOrigin
+  name: trait-foreign-origin-name
+  description: trait-foreign-origin-desc
+  category: Languages
+  cost: -2
+  priority: 1
+  conflicts:
+    - Foreigner
+    - ForeignerLight
+  conditions:
+  - !type:HasCompCondition
+    component: LanguageKnowledge
+  effects:
+  - !type:RemoveSpeciesLanguageEffect

--- a/Resources/Prototypes/_Floof/Traits/Languages/foreigner.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/foreigner.yml
@@ -40,7 +40,7 @@
   name: trait-foreign-origin-name
   description: trait-foreign-origin-desc
   category: Languages
-  cost: -2
+  cost: -1
   priority: 1
   conflicts:
     - Foreigner


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Adds a new trait that removes all languages granted from the player's species.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Greater customization for languages.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Adds a new trait effect and trait. The trait is applied at the highest priority among language traits to allow for other alterations to known languages.
## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Fixes applied after this image: Foreigner Origin was corrected to Foreign Origin, Cost was changed from -2 to -1.
<img width="786" height="234" alt="image" src="https://github.com/user-attachments/assets/e6cf34b7-ec0f-499e-b8f1-9093b53f0d10" />

No other language traits:
<img width="342" height="257" alt="image" src="https://github.com/user-attachments/assets/8b875bb7-0653-4f73-a9b7-59ba427be28b" />

With another language selected:
<img width="326" height="282" alt="image" src="https://github.com/user-attachments/assets/789de9bd-39ef-4a5e-83f0-8f17d16a4850" />
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Combining this trait with any natural trait results in a free language. As natural language traits are limit one the points granted by this trait were reduced by one to account for the free replacement language.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- add: Added the Foreign Origin trait. A clean slate for customizing languages.