### PR TITLE
Fix A few Epi Altenrative PDAs

### DIFF
--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Devices/pda.yml
@@ -571,7 +571,7 @@
     - state: "id_overlay"
       map: [ "enum.PdaVisualLayers.IdLight" ]
   - type: Pda
-    id: LabTechIDCard
+    id: AcolyteIDCard
   - type: Appearance
     appearanceDataInit:
       enum.PdaVisuals.PdaType: !type:String
@@ -596,7 +596,7 @@
     - state: "id_overlay"
       map: [ "enum.PdaVisualLayers.IdLight" ]
   - type: Pda
-    id: LabTechIDCard
+    id: GolemancerIDCard
   - type: Appearance
     appearanceDataInit:
       enum.PdaVisuals.PdaType: !type:String
@@ -651,7 +651,6 @@
     appearanceDataInit:
       enum.PdaVisuals.PdaType: !type:String
         pda-noviciate
-# ===========================================
 
 # security technician
 - type: entity


### PR DESCRIPTION
## About the PR
Acoltye and Golemancer had the wrong id, i forgor to change it so thats fixed.

## Why / Balance
I made the id and forgor to swap it out.

## Technical details
Yaml.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Acolyte and Golemancer should now have their proper IDs for their alternative PDAs.
