### PR TITLE
Sticky Hand Temporary Removal

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
@@ -287,8 +287,8 @@
         children:
         - id: GrenadeDummy
         - id: SyndieTrickyBomb
-    - !type:GroupSelector # Guns type group
-      children:
+    #- !type:GroupSelector # Guns type group
+      #children:
       #- id: WeaponStickyHand # Floofstation - removed due to bug abuse
       - !type:GroupSelector # Water subgroup
         children:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
@@ -289,7 +289,7 @@
         - id: SyndieTrickyBomb
     - !type:GroupSelector # Guns type group
       children:
-      - id: WeaponStickyHand
+      #- id: WeaponStickyHand # Floofstation - removed due to bug abuse
       - !type:GroupSelector # Water subgroup
         children:
         - id: WeaponWaterBlaster

--- a/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
@@ -138,6 +138,7 @@
 - type: entity
   parent: [ BaseItem, BaseToyGun ]
   id: WeaponStickyHand
+  categories: [ HideSpawnMenu ]
   name: sticky hand
   description: They're saying you're reaching. They're saying it's a stretch. You'll show them all, and you'll stick it to them.
   components:

--- a/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/weapons.yml
@@ -138,7 +138,7 @@
 - type: entity
   parent: [ BaseItem, BaseToyGun ]
   id: WeaponStickyHand
-  categories: [ HideSpawnMenu ]
+  categories: [ HideSpawnMenu ] # Floofstation - remove this because of bug abuse.
   name: sticky hand
   description: They're saying you're reaching. They're saying it's a stretch. You'll show them all, and you'll stick it to them.
   components:


### PR DESCRIPTION
## About the PR
Removes the sticky hand from the toy crate due to players bypassing airlocks using an old exploit.

## Why / Balance
No more airlock and wall clipping.

## Technical details
Removes it from the toy crate temporarily.

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- remove: The stick hand has been temporarily removed due to bug abuse.
