### PR TITLE
Fixes race condition with lewd organs

### DIFF
--- a/Content.Shared/_Floof/Lewd/Systems/LewdOrganSystem.cs
+++ b/Content.Shared/_Floof/Lewd/Systems/LewdOrganSystem.cs
@@ -129,11 +129,33 @@ public sealed class LewdOrganSystem : EntitySystem
     /// <summary>
     ///     Updates the organ on a mob.
     /// </summary>
-    public void UpdateOrgan(Entity<LewdOrganComponent> organ, EntityUid mob)
+    public void UpdateOrgan(Entity<LewdOrganComponent> organ, EntityUid body)
     {
-        DebugTools.Assert(CompOrNull<OrganComponent>(organ)?.Body == mob);
-        DetachOrgan(organ, mob);
-        AttachOrgan(organ, mob);
+        DebugTools.Assert(CompOrNull<OrganComponent>(organ)?.Body == body);
+
+        // Original implementation removed and re-added the organ, which seemed to detach the solution from the mob and not add it back.
+        // This approach just tries to update the relevant components without removing it.
+        LewdMobDataComponent bodyData = EnsureComp<LewdMobDataComponent>(body);
+        LewdOrganData organData = organ.Comp.Data;
+
+        // If this organ produces anything, change its produced reagents to contain the body's DNA
+        // This is primarily so that if e.g. somehow chemicals from person A get into person B's organs, they will get drained
+        if (organData.ProducedReagents is { Length: > 0 } && TryComp<DnaComponent>(body, out var donorComp) && donorComp.DNA != null)
+        {
+            var dna = new List<ReagentData> { new DnaData { DNA = donorComp.DNA } };
+            for (var i = 0; i < organData.ProducedReagents.Length; i++)
+            {
+                var reagent = organData.ProducedReagents[i];
+                organData.ProducedReagents[i] = new(reagent.Reagent.Prototype, reagent.Quantity, dna);
+            }
+        }
+
+        // Add the solution to the mob
+        _solContainer.EnsureSolutionEntity(body, organData.SolutionName, out var solution, organData.SolutionVolume);
+
+        UpdateData(organData);
+        bodyData.OrganKinds |= organData.OrganKind;
+        bodyData.CachedData[organData.OrganKind] = organData;
     }
 
     /// <summary>
@@ -194,27 +216,7 @@ public sealed class LewdOrganSystem : EntitySystem
 
     private void AttachOrgan(Entity<LewdOrganComponent> organ, EntityUid body)
     {
-        var bodyData = EnsureComp<LewdMobDataComponent>(body);
-        var organData = organ.Comp.Data;
-
-        // If this organ produces anything, change its produced reagents to contain the body's DNA
-        // This is primarily so that if e.g. somehow chemicals from person A get into person B's organs, they will get drained
-        if (organData.ProducedReagents is { Length: > 0 } && TryComp<DnaComponent>(body, out var donorComp) && donorComp.DNA != null)
-        {
-            var dna = new List<ReagentData> { new DnaData { DNA = donorComp.DNA } };
-            for (var i = 0; i < organData.ProducedReagents.Length; i++)
-            {
-                var reagent = organData.ProducedReagents[i];
-                organData.ProducedReagents[i] = new(reagent.Reagent.Prototype, reagent.Quantity, dna);
-            }
-        }
-
-        UpdateData(organData);
-        bodyData.OrganKinds |= organData.OrganKind;
-        bodyData.CachedData[organData.OrganKind] = organData;
-
-        // Add the solution to the mob
-        _solContainer.EnsureSolution(body, organData.SolutionName, out var solution, organData.SolutionVolume);
+        UpdateOrgan(organ, body);
     }
 
     private void DetachOrgan(Entity<LewdOrganComponent> ent, EntityUid body)


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

## Why / Balance
Fixes a race condition with lewd organs that causes solution entities to become detached from the solution manager. Necessary for #408.

## Technical details
The current implementation of the lewd organs system has a function to update lewd organs when they are changed. As it currently works, it will call DetachOrgan to reset the existing organ and qdel the attached solution, then call AttachOrgan to recreate that solution with the new parameters.

The issue is that the solution would be queued for deletion, removing it from the solution manager, but keeping it in stasis for garbage collection. It remains referenced by the lewd organ, allowing it to function in some capacity. When attach organ attempts to recreate the solution, it sees that the solution already exists and brings it back to life - but without adding it back to the solution manager. This creates a ghost solution entity which technically exists and can be accessed by the lewd organ, but which is no longer attached to the entity's solution manager.

The fix is to instead not use DetachOrgan and AttachOrgan, but instead just perform all the relevant updates in UpdateOrgan. This includes all of the original AttachOrgan code, thus AttachOrgan now calls UpdateOrgan to avoid code duplication. Otherwise, it should function as before.

This fix is needed for #408, as otherwise, the milker cannot function on people with modified lewd organs (such as with the productivity traits), as it cannot access their solutions.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [ ] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes

**Changelog**
:cl:
- fix: Fixed an issue with lewd modifier traits disconnecting organ solutions from the body.
