### PR TITLE
Flippo Lighters Can Cauterize

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -222,7 +222,7 @@
   - type: UseDelay
   - type: IgnitionSource
     ignited: false
-  - type: Cautery # Shitmed Euph This is needed in order to burn yourself to reduce bleeding. 
+  - type: Cautery # Shitmed Euph
     speed: 0.45
   - type: SurgeryTool # Shitmed Euph
   - type: Tag # DeltaV
@@ -330,7 +330,7 @@
         shader: unshaded
   - type: ItemTogglePointLight
   - type: UseDelay
-  - type: Cautery # Shitmed Euph This is needed in order to burn yourself. 
+  - type: Cautery # Shitmed Euph
     speed: 0.45
   - type: SurgeryTool # Shitmed Euph
   - type: IgnitionSource

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -222,7 +222,7 @@
   - type: UseDelay
   - type: IgnitionSource
     ignited: false
-  - type: Cautery # Shitmed Euph
+  - type: Cautery # Shitmed Euph This is needed in order to burn yourself to reduce bleeding. 
     speed: 0.45
   - type: SurgeryTool # Shitmed Euph
   - type: Tag # DeltaV
@@ -272,7 +272,7 @@
     activatedDamage:
         types:
             Heat: 1
-  - type: MeleeWeapon #Euph
+  - type: MeleeWeapon #Euph This is needed in order to make attacks. 
     wideAnimationRotation: 180
     damage:
       types:
@@ -330,7 +330,7 @@
         shader: unshaded
   - type: ItemTogglePointLight
   - type: UseDelay
-  - type: Cautery # Shitmed Euph
+  - type: Cautery # Shitmed Euph This is needed in order to burn yourself. 
     speed: 0.45
   - type: SurgeryTool # Shitmed Euph
   - type: IgnitionSource

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -272,6 +272,11 @@
     activatedDamage:
         types:
             Heat: 1
+  - type: MeleeWeapon #Euph
+    wideAnimationRotation: 180
+    damage:
+      types:
+        Blunt: 1 # does a little bit of damage on hit when off
   - type: ItemToggleSize
     activatedSize: Small
   - type: ItemToggleHot

--- a/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/lighters.yml
@@ -222,6 +222,9 @@
   - type: UseDelay
   - type: IgnitionSource
     ignited: false
+  - type: Cautery # Shitmed Euph
+    speed: 0.45
+  - type: SurgeryTool # Shitmed Euph
   - type: Tag # DeltaV
     tags:
     - WeldingTool
@@ -322,6 +325,9 @@
         shader: unshaded
   - type: ItemTogglePointLight
   - type: UseDelay
+  - type: Cautery # Shitmed Euph
+    speed: 0.45
+  - type: SurgeryTool # Shitmed Euph
   - type: IgnitionSource
     ignited: false
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Made it so more lighters can cauterize wounds in the same way that the basic lighter does. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Players have reported that the basic lighter can cauterize wounds, but the flippo cannot. 
In testing, it seems the branded flippo lighters lacked an ability to attack. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just a change to the lighters yml.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="1032" height="1175" alt="image" src="https://github.com/user-attachments/assets/19287532-cc1f-48ee-999f-d15bebe6ada5" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Made flippo lighters able to cauterize wounds in the same way that the basic lighter does. 
