### PR TITLE
Fix order-dependant trait validation

### DIFF
--- a/Content.Server/_DV/Traits/TraitSystem.cs
+++ b/Content.Server/_DV/Traits/TraitSystem.cs
@@ -185,20 +185,8 @@ public sealed class TraitSystem : EntitySystem
         }
 
         // Sort negative and zero point costs first, and then lower costs last. The order of the negative and zero-cost traits is unimportant.
-        resolvedTraits.Sort((a, b) => {
-            if (a.Cost > 0 != b.Cost > 0)
-            {
-                // A and B have different signs. Sort in ascending order.
-                return a.Cost.CompareTo(b.Cost);
-            }
-            else
-            {
-                // A and B have the same sign. Sort in descending order.
-                return b.Cost.CompareTo(a.Cost);
-            }
-        });
-
-        foreach (var trait in resolvedTraits) {
+        foreach (var trait in resolvedTraits.OrderBy((trait) => trait.Cost > 0).ThenByDescending((trait) => trait.Cost))
+        {
             var traitId = trait.ID;
 
             #endregion

--- a/Content.Server/_DV/Traits/TraitSystem.cs
+++ b/Content.Server/_DV/Traits/TraitSystem.cs
@@ -65,20 +65,9 @@ public sealed class TraitSystem : EntitySystem
         var validTraits = ValidateTraits(args.Mob, args.Profile.TraitPreferences, args.Player, args.JobId, speciesId, args.Profile, disabledTraits);
 
         // Apply valid traits
-        // Floofstation edit: first, sort valid traits by cost
-        var sortedPrototypes = new List<TraitPrototype>();
-        foreach (var traitId in validTraits)
-        {
-            if (!_prototype.TryIndex(traitId, out var trait))
-                continue;
-
-            sortedPrototypes.Add(trait);
-        }
-
-        sortedPrototypes = sortedPrototypes.OrderBy(a => -a.Priority).ThenBy(a => a.Cost).ToList(); //Floof - get all traits from negative cost to positive cost
-        foreach (var trait in sortedPrototypes)
+        // Euphoria: Move trait resolution and ordering to static methods.
+        foreach (var trait in OrderTraitPrototypesForApplication(ResolveTraitPrototypes(validTraits)))
             ApplyTrait(args.Mob, trait);
-        // Floofstation edit end
 
         // Send disabled traits notification to client if any were rejected
         if (disabledTraits.Count > 0)
@@ -107,20 +96,9 @@ public sealed class TraitSystem : EntitySystem
         var validTraits = ValidateTraits(args.Spawned, args.Character.TraitPreferences, args.Session, ghostjob, speciesId, args.Character, disabledTraits);
 
         // Apply valid traits
-        // Floofstation edit: first, sort valid traits by cost
-        var sortedPrototypes = new List<TraitPrototype>();
-        foreach (var traitId in validTraits)
-        {
-            if (!_prototype.TryIndex(traitId, out var trait))
-                continue;
-
-            sortedPrototypes.Add(trait);
-        }
-
-        sortedPrototypes = sortedPrototypes.OrderBy(a => -a.Priority).ThenBy(a => a.Cost).ToList(); //Floof - get all traits from negative cost to positive cost
-        foreach (var trait in sortedPrototypes)
+        // Euphoria: Move trait resolution and ordering to static methods.
+        foreach (var trait in OrderTraitPrototypesForApplication(ResolveTraitPrototypes(validTraits)))
             ApplyTrait(args.Spawned, trait);
-        // Floofstation edit end
 
         // Send disabled traits notification to client if any were rejected
         if (disabledTraits.Count > 0 && args.Session != null)
@@ -147,7 +125,6 @@ public sealed class TraitSystem : EntitySystem
         var traitCount = 0;
         var categoryTraitCounts = new Dictionary<ProtoId<TraitCategoryPrototype>, int>();
         var categoryPointTotals = new Dictionary<ProtoId<TraitCategoryPrototype>, int>();
-        var resolvedTraits = new List<TraitPrototype>(selectedTraits.Count); // Euphoria: Fix order-dependant trait validation
 
         // Build condition context
         var conditionCtx = new TraitConditionContext
@@ -164,31 +141,11 @@ public sealed class TraitSystem : EntitySystem
             StatusEffects = _statusEffects
         };
 
-        foreach (var traitId in selectedTraits)
-        {
-            if (!_prototype.TryIndex(traitId, out var trait))
-            {
-                Log.Warning($"Unknown trait ID in player preferences: {traitId}");
-                continue;
-            }
-
-            #region Euphoria: Fix order-dependant trait validation
-            /**
-             * Trait validation is order-dependant due to counting point limits. Try to put traits in an order that makes sense.
-             * This means add all point-negative traits first, then all the positive traits, so that traits can never get rejected for points
-             * if the final total points are under the limit.
-             * Finally, evaluate more expensive traits before less expensive traits, so that the final validated set is as close to the point
-             * limit as possible.
-             */
-
-            resolvedTraits.Add(trait);
-        }
-
-        // Sort negative and zero point costs first, and then lower costs last. The order of the negative and zero-cost traits is unimportant.
-        foreach (var trait in resolvedTraits.OrderBy((trait) => trait.Cost > 0).ThenByDescending((trait) => trait.Cost))
+        #region Euphoria: Fix order-dependant trait validation
+        // Resolution of traits from ids moved to static method.
+        foreach (var trait in OrderTraitPrototypesForValidation(ResolveTraitPrototypes(selectedTraits)))
         {
             var traitId = trait.ID;
-
             #endregion
 
             var rejectionReasons = new List<string>();
@@ -277,6 +234,61 @@ public sealed class TraitSystem : EntitySystem
 
         return validTraits;
     }
+
+    #region Euphoria: Fix order-dependant trait validation.
+    /**
+     * Trait validation is order-dependant due to counting point limits. Try to put traits in an order that makes sense.
+     * This means add all point-negative traits first, then all the positive traits, so that traits can never get rejected for points
+     * if the final total points are under the limit.
+     * Finally, evaluate more expensive traits before less expensive traits, so that the final validated set is as close to the point
+     * limit as possible.
+     */
+
+    /// <summary>
+    /// Orders traits to prevent errors in order-dependant trait validation. When iterating accross the returned enumerable, a trait with
+    /// zero or negative cost will never be encountered after a trait with positive cost. Among traits with positive cost, lowest-cost
+    /// traits will be encountered last.
+    /// </summary>
+    /// <param name="traitPrototypes">An enumerable of trait prototypes.</param>
+    /// <returns>An ordered enumerable of trait prototypes ready to run through trait validation.</returns>
+    public static IOrderedEnumerable<TraitPrototype> OrderTraitPrototypesForValidation(IEnumerable<TraitPrototype> traitPrototypes)
+    {
+        return traitPrototypes.OrderBy((trait) => trait.Cost > 0).ThenByDescending((trait) => trait.Cost);
+    }
+
+    /// <summary>
+    /// Orders traits ready for to apply. Higher priority traits are ordered first.
+    /// </summary>
+    /// <param name="traitPrototypes">An enumerable of trait prototypes.</param>
+    /// <returns>An ordered enumerable of trait prototypes ready to apply.</returns>
+    private static IOrderedEnumerable<TraitPrototype> OrderTraitPrototypesForApplication(IEnumerable<TraitPrototype> traitPrototypes)
+    {
+        return traitPrototypes.OrderByDescending((a) => a.Priority);
+    }
+
+    /// <summary>
+    /// Resolve each trait ID in selectedTraits to its corresponding trait, where that trait exists. Invalid trait IDs are rejected.
+    /// </summary>
+    /// <param name="traitIds">A collection of arbitrary trait ids</param>
+    /// <returns>An enumerable containing trait prototypes</returns>
+    public IEnumerable<TraitPrototype> ResolveTraitPrototypes(IReadOnlyCollection<ProtoId<TraitPrototype>> traitIds)
+    {
+        var resolvedTraits = new List<TraitPrototype>(traitIds.Count);
+
+        foreach (var traitId in traitIds)
+        {
+            if (!_prototype.TryIndex(traitId, out var trait))
+            {
+                Log.Warning($"Unknown trait ID in player preferences: {traitId}");
+                continue;
+            }
+
+            resolvedTraits.Add(trait);
+        }
+
+        return resolvedTraits;
+    }
+    #endregion
 
     /// <summary>
     /// Validates that adding a trait wouldn't exceed category-specific limits.

--- a/Content.Server/_DV/Traits/TraitSystem.cs
+++ b/Content.Server/_DV/Traits/TraitSystem.cs
@@ -147,6 +147,7 @@ public sealed class TraitSystem : EntitySystem
         var traitCount = 0;
         var categoryTraitCounts = new Dictionary<ProtoId<TraitCategoryPrototype>, int>();
         var categoryPointTotals = new Dictionary<ProtoId<TraitCategoryPrototype>, int>();
+        var resolvedTraits = new List<TraitPrototype>(selectedTraits.Count); // Euphoria: Fix order-dependant trait validation
 
         // Build condition context
         var conditionCtx = new TraitConditionContext
@@ -170,6 +171,37 @@ public sealed class TraitSystem : EntitySystem
                 Log.Warning($"Unknown trait ID in player preferences: {traitId}");
                 continue;
             }
+
+            #region Euphoria: Fix order-dependant trait validation
+            /**
+             * Trait validation is order-dependant due to counting point limits. Try to put traits in an order that makes sense.
+             * This means add all point-negative traits first, then all the positive traits, so that traits can never get rejected for points
+             * if the final total points are under the limit.
+             * Finally, evaluate more expensive traits before less expensive traits, so that the final validated set is as close to the point
+             * limit as possible.
+             */
+
+            resolvedTraits.Add(trait);
+        }
+
+        // Sort negative and zero point costs first, and then lower costs last. The order of the negative and zero-cost traits is unimportant.
+        resolvedTraits.Sort((a, b) => {
+            if (a.Cost > 0 != b.Cost > 0)
+            {
+                // A and B have different signs. Sort in ascending order.
+                return a.Cost.CompareTo(b.Cost);
+            }
+            else
+            {
+                // A and B have the same sign. Sort in descending order.
+                return b.Cost.CompareTo(a.Cost);
+            }
+        });
+
+        foreach (var trait in resolvedTraits) {
+            var traitId = trait.ID;
+
+            #endregion
 
             var rejectionReasons = new List<string>();
 


### PR DESCRIPTION
## About the PR
Fixed by ordering all free and negative-point cost traits first, then most expensive to least expensive traits (this means lower-cost traits are lost first if too many points are spent).

## Why / Balance
Inconsistent trait resolution order means that some traits were rejected due to being too expensive, even when the final point total would have been correct.

## Technical details
The ValidateTraits method of TraitSystem sorts traits into two regions before running individual trait validation:
1. Traits with a cost <= 0, in descending order.
2. Traits with a cost > 0, in descending order.

Order of traits in the region 1 is unimportant, with a matching sort order to region 2 for simplicity of implementation.
## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

## Breaking changes
Changes to the ValidateTraits method should be non-breaking (input and output parameters are unchanged).

**Changelog**
:cl:
- fix: Traits should no longer be erroneously rejected for being too expensive.
