### PR TITLE
Fix most species lacking footprints

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -313,6 +313,7 @@
   #- type: StunVisuals # DeltaV - No stars
   - type: CanDoCPR # DeltaV - Addition of CPR
   - type: PotentialPsionic # DeltaV - organic species can all be psionic
+  - type: FootPrints
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
I forgor, apparently. I re-added the FootPrints component to all species mob prototypes EXCEPT the base one. 

## Media
<img width="547" height="305" alt="image" src="https://github.com/user-attachments/assets/76bab4f8-85cb-4a06-8472-f18b7a9ffe20" />


**Changelog**
:cl:
- fix: Most species should leave footprints again.
