### PR TITLE
Revert security and salvage specialist blacklist for regeneration trait

### DIFF
--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -197,18 +197,6 @@
   - HealingMinus
   - HealingPlus2
   conditions:
-  - !type:InDepartmentCondition
-    department: Security
-    invert: true
-  - !type:HasJobCondition
-    job: SalvageSpecialist
-    invert: true
-  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
-    component: NukeOperative
-    invert: true
-  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
-    component: NinjaRole
-    invert: true
   - !type:HasCompCondition
     component: Hunger
   - !type:HasCompCondition
@@ -244,18 +232,6 @@
   - HealingMinus
   - HealingPlus
   conditions:
-  - !type:InDepartmentCondition
-    department: Security
-    invert: true
-  - !type:HasJobCondition
-    job: SalvageSpecialist
-    invert: true
-  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
-    component: NukeOperative
-    invert: true
-  - !type:HasCompCondition # Future-proofing, traits do not currently work for these roles
-    component: NinjaRole
-    invert: true
   - !type:HasCompCondition
     component: Hunger
   - !type:HasCompCondition


### PR DESCRIPTION
## About the PR
Allows security and salvage to use enhanced and superior regeneration traits.

## Why / Balance
See discussion on #679. The question was raised whether the blacklist was necessary with more recent reductions in the traits' effect and additional downsides.

## Technical details
Removed conditions from the traits.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- tweak: Security and salvage can now take enhanced or superior regeneration traits.
