### PR TITLE
Skip in-lobby checks for job and department conditions

### DIFF
--- a/Content.Client/_DV/Traits/UI/TraitEntry.xaml.cs
+++ b/Content.Client/_DV/Traits/UI/TraitEntry.xaml.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared._DV.Traits;
 using Content.Shared._DV.Traits.Conditions;
+using Content.Shared._Euphoria.Traits.Conditions;
 using Content.Shared._Floof.Traits.Condition;
 using Content.Shared._Floof.Util;
 using Content.Shared.Humanoid.Prototypes;
@@ -129,11 +130,16 @@ public sealed partial class TraitEntry : PanelContainer
     // Floofstation - just to eliminate some of this code repetition above. This is still a terrible fucking joke.
     private bool EvaluateCondition(BaseTraitCondition cond, ProtoId<JobPrototype>? jobId, ProtoId<SpeciesPrototype>? speciesId, IReadOnlySet<ProtoId<AntagPrototype>>? antagPreferences) => cond switch
     {
+        ITraitConditionSkipLobbyCheck skipCond => !cond.Invert, // Euphoria: Skip conditions that can't be reliably checked in the lobby.
         IsSpeciesCondition speciesCond => CheckSpeciesCondition(speciesCond, speciesId),
         OneOfSpeciesCondition oneOfSpeciesCond => oneOfSpeciesCond.Species.Any(it => it == speciesId), // Floofstation - terrible hardcoding - I don't care, just rework the system someday
+        #region Euphoria: Skip conditions that can't be reliably checked in the lobby.
+        /*
         HasJobCondition jobCond => CheckJobCondition(jobCond, jobId),
         InDepartmentCondition deptCond => CheckDepartmentCondition(deptCond, jobId),
         HasCompCondition compCond => !compCond.Invert, // can't check in lobby but screws with the inversion logic
+        */
+        #endregion
         IsAntagEligibleCondition antagEligibleCond => CheckAntagEligibleCondition(antagEligibleCond, antagPreferences),
         AnyOfCondition anyOfCond => CheckAnyOfCondition(anyOfCond, jobId, speciesId, antagPreferences),
         _ => WrapExpression.Return(true, _ => Log.Warning($"Condition {cond.GetType()} lacks a client-side handler. This code is horrible.")), // Floofstation - log error

--- a/Content.Shared/_DV/Traits/Conditions/HasCompCondition.cs
+++ b/Content.Shared/_DV/Traits/Conditions/HasCompCondition.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Euphoria.Traits.Conditions;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 
@@ -8,6 +9,7 @@ namespace Content.Shared._DV.Traits.Conditions;
 /// Use Invert = true to check if the player does NOT have the component.
 /// </summary>
 public sealed partial class HasCompCondition : BaseTraitCondition
+    , ITraitConditionSkipLobbyCheck // Euphoria: Skip lobby checks for component conditions.
 {
     /// <summary>
     /// The component name to check for (e.g., "Pacifism").

--- a/Content.Shared/_DV/Traits/Conditions/HasJobCondition.cs
+++ b/Content.Shared/_DV/Traits/Conditions/HasJobCondition.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Euphoria.Traits.Conditions;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 
@@ -8,6 +9,7 @@ namespace Content.Shared._DV.Traits.Conditions;
 /// Use Invert = true to check if the player does NOT have the job.
 /// </summary>
 public sealed partial class HasJobCondition : BaseTraitCondition
+    , ITraitConditionSkipLobbyCheck // Euphoria: Skip lobby check for job-related conditions.
 {
     /// <summary>
     /// The job prototype ID to check for.

--- a/Content.Shared/_DV/Traits/Conditions/InDepartmenCondition.cs
+++ b/Content.Shared/_DV/Traits/Conditions/InDepartmenCondition.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Euphoria.Traits.Conditions;
 using Content.Shared.Roles;
 using Robust.Shared.Prototypes;
 
@@ -8,6 +9,7 @@ namespace Content.Shared._DV.Traits.Conditions;
 /// Use Invert = true to check if the player is NOT in the department.
 /// </summary>
 public sealed partial class InDepartmentCondition : BaseTraitCondition
+    , ITraitConditionSkipLobbyCheck // Euphoria: Skip lobby checks for job-related conditions.
 {
     /// <summary>
     /// The department prototype ID to check for.

--- a/Content.Shared/_Euphoria/Traits/Conditions/ITraitConditionSkipLobbyCheck.cs
+++ b/Content.Shared/_Euphoria/Traits/Conditions/ITraitConditionSkipLobbyCheck.cs
@@ -1,0 +1,6 @@
+namespace Content.Shared._Euphoria.Traits.Conditions;
+
+/// <summary>
+/// Add this to a trait condition to skip checks in the lobby while suppressing not-implemented warnings.
+/// </summary>
+public interface ITraitConditionSkipLobbyCheck;


### PR DESCRIPTION
## About the PR
Skip in-lobby checks for job and department conditions as they cannot be verified in-lobby and will either always fail (or always pass if inverted).
Unify implementation of component condition in-lobby skip for consistency.

## Why / Balance
This allows job-dependant traits to be selected in the client. It does not affect whether those traits will be applied when you spawn.

## Technical details
Added an interface, `ITraitConditionSkipLobbyCheck`. When added to a trait condition class, that trait will be skipped when checking conditions in the trait selection menu without causing a not-implemented warning.
Commented out trait-menu implementations of `HasJobCondition`, `InDepartmentCondition`, and `HasCompCondition`.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<h4>Traits show as selectable in the lobby</h4>
<img width="1007" height="228" alt="traits-selectable-in-lobby" src="https://github.com/user-attachments/assets/8f208a3e-4eb6-41ad-9e89-3cdd80c2f7aa" />
<h4>Omni-eyes will apply to captain and CE, but not secoff</h4>
<img width="107" height="97" alt="omni-can-captain" src="https://github.com/user-attachments/assets/daa5ea37-b412-4a3a-a59e-ab5d8a62002d" />
<img width="108" height="102" alt="omni-can-ce" src="https://github.com/user-attachments/assets/634cf4d8-d2ff-4177-bb33-b8a2cf4d9300" />
<img width="868" height="445" alt="omni-cannot-secoff" src="https://github.com/user-attachments/assets/8cc4ad2b-7bb9-4a5b-9aa7-a1d3952573f2" />
<h4>Sec-eyes will apply to secoff, but not captain</h4>
<img width="114" height="106" alt="sec-can-secoff" src="https://github.com/user-attachments/assets/33725874-9bde-4e03-b3cf-b7fbae8d8146" />
<img width="828" height="471" alt="sec-cannot-captain" src="https://github.com/user-attachments/assets/0d705374-679b-447a-842a-ea5c5cc2835a" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- fix: Premium and SecHud cybereyes modules are selectable.
