### PR TITLE
Vector to use 45 auto

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -32,6 +32,7 @@
   - SpeedLoaderMagnumPractice
   - MagazinePistolSubMachineGunPractice
   - WeaponFlareGunSecurity
+  - MagazineBox45PistolPractice # Euphoria
 
 # Shared between secfab and emagged autolathe
 - type: latheRecipePack
@@ -58,6 +59,7 @@
   - MagazineRifleEmpty
   - SpeedLoaderMagnum
   - SpeedLoaderMagnumEmpty
+  - MagazineBox45Pistol # Euphoria
 
 - type: latheRecipePack
   parent:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -140,6 +140,8 @@
   - MagazineShotgunIncendiary
   - SpeedLoaderMagnumIncendiary
   - SpeedLoaderMagnumUranium
+  - MagazineBox45PistolIncendiary # Euphoria
+  - MagazineBox45PistolUranium # Euphoria
 
 - type: latheRecipePack
   parent:

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -25,9 +25,10 @@
     proto: CartridgeMagnumIncendiary
     capacity: 12
 
-- type: entity
+# Euphoria - Vector
+- type: entity # Euphoria - I will suffer this no longer, they made a gun that shoots 45 ACP shoot 45 magnum simply because they have the same number
   id: BaseMagazineMagnumSubMachineGun
-  name: SMG magazine (.45 magnum)
+  name: SMG magazine (.45 auto)
   parent: BaseItem
   abstract: true
   components:
@@ -38,7 +39,7 @@
     mayTransfer: true
     whitelist:
       tags:
-        - CartridgeMagnum
+        - Cartridge45Pistol
     capacity: 25
   - type: Item
     size: Small
@@ -61,7 +62,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunEmpty
-  name: SMG magazine (.45 magnum any)
+  name: SMG magazine (.45 auto any)
   suffix: empty
   parent: BaseMagazineMagnumSubMachineGun
   components:
@@ -82,11 +83,11 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGun
-  name: SMG magazine (.45 magnum)
+  name: SMG magazine (.45 auto)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
-    proto: CartridgeMagnum
+    proto: Cartridge45Pistol
   - type: Sprite
     layers:
     - state: base
@@ -102,11 +103,11 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunPractice
-  name: SMG magazine (.45 magnum practice)
+  name: SMG magazine (.45 auto practice)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
-    proto: CartridgeMagnumPractice
+    proto: Cartridge45PistolPractice
   - type: Sprite
     layers:
     - state: base
@@ -128,11 +129,11 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunUranium
-  name: SMG magazine (.45 magnum uranium)
+  name: SMG magazine (.45 auto uranium)
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
-    proto: CartridgeMagnumUranium
+    proto: Cartridge45PistolUranium
   - type: Sprite
     layers:
     - state: base

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -40,7 +40,7 @@
     whitelist:
       tags:
         - Cartridge45Pistol
-    capacity: 25
+    capacity: 30
   - type: Item
     size: Small
   - type: ContainerContainer

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -40,7 +40,7 @@
     whitelist:
       tags:
         - Cartridge45Pistol
-    capacity: 30
+    capacity: 25
   - type: Item
     size: Small
   - type: ContainerContainer

--- a/Resources/Prototypes/_DV/Research/arsenal.yml
+++ b/Resources/Prototypes/_DV/Research/arsenal.yml
@@ -40,6 +40,7 @@
   - SpeedLoaderSpecialUranium
   - MagazineBoxSpecialUranium
   - MagazinePistolHighCapacityUranium
+  - MagazineBox45PistolUranium # Euphoria
   # Incendiary
   - BoxShotgunIncendiary
   - MagazineRifleIncendiary
@@ -56,6 +57,7 @@
   - MagazineBoxSpecialIncendiary
   - MagazineBoxSpecialHoly
   - MagazinePistolHighCapacityIncendiary
+  - MagazineBoxPistolIncendiary # Euphoria
 
 - type: technology
   id: EnergyGuns

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
@@ -1,0 +1,97 @@
+- type: entity
+  abstract: true
+  parent: BaseItem
+  id: BaseMagazineBox45Pistol
+  name: ammunition box (.45 auto)
+  components:
+  - type: EmitSoundOnPickup # Euphoria - Port over Goob's interaction sounds.
+    sound:
+      path: /Audio/_Goobstation/Items/handling/ammobox_pickup.ogg
+  - type: EmitSoundOnDrop
+    sound: &magBoxDropSound
+      path: /Audio/_Goobstation/Items/handling/ammobox_drop.ogg
+  - type: EmitSoundOnLand
+    sound: *magBoxDropSound
+  - type: BallisticAmmoProvider
+    mayTransfer: true
+    whitelist:
+      tags:
+        - Cartridge45Pistol
+    proto: Cartridge45Pistol
+    capacity: 30
+  - type: Item
+    size: Small
+  - type: ContainerContainer
+    containers:
+      ballistic-ammo: !type:Container
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Boxes/pistol.rsi
+  - type: MagazineVisuals
+    magState: mag
+    steps: 3
+    zeroVisible: false
+  - type: Appearance
+
+# Boxes
+- type: entity
+  parent: BaseMagazineBoxPistol
+  id: MagazineBox45Pistol
+  name: ammunition box (.45 auto)
+  description: A cardboard box of .45 auto rounds. Intended to hold general-purpose kinetic ammunition.
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45Pistol
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+
+- type: entity
+  parent: BaseMagazineBoxPistol
+  id: MagazineBox45PistolPractice
+  name: ammunition box (.45 auto practice)
+  description: A cardboard box of .45 auto rounds. Intended to hold harmless practice ammunition.
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45PistolPractice
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: practice
+
+- type: entity
+  id: MagazineBoxPistolIncendiary
+  parent: BaseMagazineBox45Pistol
+  name: ammunition box (.45 auto incendiary)
+  description: A cardboard box of .45 auto rounds. Intended to hold self-igniting incendiary ammunition.
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45PistolIncendiary
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: incendiary
+
+- type: entity
+  parent: BaseMagazineBoxPistol
+  id: MagazineBox45PistolUranium
+  name: ammunition box (.45 auto uranium)
+  description: A cardboard box of .45 auto rounds. Intended to hold exotic uranium-core ammunition.
+  components:
+  - type: BallisticAmmoProvider
+    proto: Cartridge45PistolUranium
+  - type: Sprite
+    layers:
+    - state: base
+      map: ["enum.GunVisualLayers.Base"]
+    - state: mag-1
+      map: ["enum.GunVisualLayers.Mag"]
+    - state: uranium

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
@@ -34,7 +34,7 @@
 
 # Boxes
 - type: entity
-  parent: BaseMagazineBoxPistol
+  parent: BaseMagazineBox45Pistol
   id: MagazineBox45Pistol
   name: ammunition box (.45 auto)
   description: A cardboard box of .45 auto rounds. Intended to hold general-purpose kinetic ammunition.
@@ -49,7 +49,7 @@
       map: ["enum.GunVisualLayers.Mag"]
 
 - type: entity
-  parent: BaseMagazineBoxPistol
+  parent: BaseMagazineBox45Pistol
   id: MagazineBox45PistolPractice
   name: ammunition box (.45 auto practice)
   description: A cardboard box of .45 auto rounds. Intended to hold harmless practice ammunition.
@@ -65,7 +65,7 @@
     - state: practice
 
 - type: entity
-  id: MagazineBoxPistolIncendiary
+  id: MagazineBoxPistol45Incendiary
   parent: BaseMagazineBox45Pistol
   name: ammunition box (.45 auto incendiary)
   description: A cardboard box of .45 auto rounds. Intended to hold self-igniting incendiary ammunition.
@@ -81,7 +81,7 @@
     - state: incendiary
 
 - type: entity
-  parent: BaseMagazineBoxPistol
+  parent: BaseMagazineBox45Pistol
   id: MagazineBox45PistolUranium
   name: ammunition box (.45 auto uranium)
   description: A cardboard box of .45 auto rounds. Intended to hold exotic uranium-core ammunition.

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -1,7 +1,7 @@
 - type: entity
   abstract: true
   parent: [ BaseCartridge, BaseSecurityContraband ]
-  id: BaseCartridgePistol
+  id: BaseCartridge45Pistol
   name: cartridge (.45 auto)
   components:
   - type: Tag
@@ -18,8 +18,8 @@
   - type: SpentAmmoVisuals
 
 - type: entity
-  parent: BaseCartridgePistol
-  id: CartridgePistol
+  parent: BaseCartridge45Pistol
+  id: Cartridge45Pistol
   name: cartridge (.45 auto)
   description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Standard kinetic ammunition is common and useful in most situations.
   components:
@@ -27,8 +27,8 @@
     proto: Bullet45Pistol
 
 - type: entity
-  parent: BaseCartridgePistol
-  id: CartridgePistolPractice
+  parent: BaseCartridge45Pistol
+  id: Cartridge45PistolPractice
   name: cartridge (.45 auto practice)
   description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Practice ammunition fires a chalk projectile that stings a little, but otherwise causes no lasting damage.
   components:
@@ -43,8 +43,8 @@
          color: "#dbdbdb"
 
 - type: entity
-  parent: BaseCartridgePistol
-  id: CartridgePistolIncendiary
+  parent: BaseCartridge45Pistol
+  id: Cartridge45PistolIncendiary
   name: cartridge (.45 auto incendiary)
   description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Incendiary ammunition contains a self-igniting compound that sets targets ablaze.
   components:
@@ -59,10 +59,10 @@
         color: "#ff6e52"
 
 - type: entity
-  id: CartridgePistolUranium
+  id: Cartridge45PistolUranium
   name: cartridge (.45 auto uranium)
   description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Uranium ammunition replaces the lead core of the bullet with fissile material, irradiating targets from the inside.
-  parent: BaseCartridgePistol
+  parent: BaseCartridge45Pistol
   components:
   - type: CartridgeAmmo
     proto: Bullet45PistolUranium
@@ -75,8 +75,8 @@
         color: "#65fe08"
 
 - type: entity
-  parent: BaseCartridgePistol
-  id: CartridgePistolSpent
+  parent: BaseCartridge45Pistol
+  id: Cartridge45PistolSpent
   name: cartridge (.45 auto)
   suffix: spent
   components:

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -1,0 +1,95 @@
+- type: entity
+  abstract: true
+  parent: [ BaseCartridge, BaseSecurityContraband ]
+  id: BaseCartridgePistol
+  name: cartridge (.45 auto)
+  components:
+  - type: Tag
+    tags:
+      - Cartridge45Pistol
+  - type: CartridgeAmmo
+    proto: Bullet45Pistol
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: Appearance
+  - type: SpentAmmoVisuals
+
+- type: entity
+  parent: BaseCartridgePistol
+  id: CartridgePistol
+  name: cartridge (.45 auto)
+  description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Standard kinetic ammunition is common and useful in most situations.
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet45Pistol
+
+- type: entity
+  parent: BaseCartridgePistol
+  id: CartridgePistolPractice
+  name: cartridge (.45 auto practice)
+  description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Practice ammunition fires a chalk projectile that stings a little, but otherwise causes no lasting damage.
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet45PistolPractice
+  -  type: Sprite
+     layers:
+       - state: base
+         map: [ "enum.AmmoVisualLayers.Base" ]
+       - state: tip
+         map: [ "enum.AmmoVisualLayers.Tip" ]
+         color: "#dbdbdb"
+
+- type: entity
+  parent: BaseCartridgePistol
+  id: CartridgePistolIncendiary
+  name: cartridge (.45 auto incendiary)
+  description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Incendiary ammunition contains a self-igniting compound that sets targets ablaze.
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet45PistolIncendiary
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#ff6e52"
+
+- type: entity
+  id: CartridgePistolUranium
+  name: cartridge (.45 auto uranium)
+  description: High caliber round designed with increased stopping power in mind, used by all manner of pistols and submachine guns. Uranium ammunition replaces the lead core of the bullet with fissile material, irradiating targets from the inside.
+  parent: BaseCartridgePistol
+  components:
+  - type: CartridgeAmmo
+    proto: Bullet45PistolUranium
+  - type: Sprite
+    layers:
+      - state: base
+        map: [ "enum.AmmoVisualLayers.Base" ]
+      - state: tip
+        map: [ "enum.AmmoVisualLayers.Tip" ]
+        color: "#65fe08"
+
+- type: entity
+  parent: BaseCartridgePistol
+  id: CartridgePistolSpent
+  name: cartridge (.45 auto)
+  suffix: spent
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Guns/Ammunition/Casings/ammo_casing.rsi
+    layers:
+    - state: base-spent
+      map: [ "enum.AmmoVisualLayers.Base" ]
+  - type: SpentAmmoVisuals
+  - type: CartridgeAmmo
+    proto: Bullet45Pistol
+    spent: true
+  - type: Tag
+    tags:
+    - Cartridge45Pistol
+    - Trash # surely theres a way to automatically add this...

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -1,0 +1,45 @@
+- type: entity
+  parent: BaseBullet
+  id: Bullet45Pistol
+  categories: [ HideSpawnMenu ]
+  name: bullet (.45 auto)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 25
+
+- type: entity
+  parent: BaseBulletPractice
+  id: Bullet45PistolPractice
+  categories: [ HideSpawnMenu ]
+  name: bullet (.45 auto practice)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Blunt: 2
+
+- type: entity
+  parent: BaseBulletIncendiary
+  id: Bullet45PistolIncendiary
+  categories: [ HideSpawnMenu ]
+  name: bullet (.45 auto incendiary)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Piercing: 19
+        Heat: 7
+
+- type: entity
+  parent: BaseBulletUranium
+  id: Bullet45PistolUranium
+  categories: [ HideSpawnMenu ]
+  name: bullet (.45 auto uranium)
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Radiation: 11
+        Piercing: 15

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -78,7 +78,7 @@
     unwieldOnUse: false
   - type: GunWieldBonus
     minAngle: -50
-    maxAngle: -25
+    maxAngle: -45 # Decreased the amount of damage it deals
   - type: Gun
     minAngle: 30
     maxAngle: 60
@@ -106,11 +106,11 @@
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgeMagnum
+        startingItem: Cartridge45Pistol
         priority: 1
         whitelist:
           tags:
-          - CartridgeMagnum
+          - Cartridge45Pistol
   - type: MagazineVisuals
     magState: mag
     steps: 1

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -52,6 +52,7 @@
         whitelist:
           tags:
           - CartridgeMagnum
+          - Cartridge45Pistol
   - type: MagazineVisuals
     magState: mag
     steps: 1

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -64,7 +64,7 @@
   suffix: Magnum
   parent: [BaseWeaponSubMachineGun, BaseSecurityContraband]
   id: WeaponSubMachineGunVector
-  description: An old sol-made PDW. With an accruate and fast burst. Uses .45 magnum ammo.
+  description: An old sol-made PDW. With an accruate and fast burst. Uses .45 auto ammo.
   components:
   - type: Sprite
     sprite: _Floof/Objects/Weapons/Guns/SMGs/vector.rsi
@@ -91,7 +91,7 @@
     availableModes:
     - Burst
     - SemiAuto
-    shotsPerBurst: 2
+    shotsPerBurst: 3
     burstCooldown: 0.255
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -91,7 +91,7 @@
     availableModes:
     - Burst
     - SemiAuto
-    shotsPerBurst: 3
+    shotsPerBurst: 2
     burstCooldown: 0.255
   - type: ItemSlots
     slots:

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/ammo.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/ammo.yml
@@ -18,3 +18,33 @@
   completetime: 5
   materials:
     Steel: 1000
+
+#.45 Auto
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBox45Pistol
+  result: MagazineBox45Pistol
+  materials:
+    Steel: 240
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBox45PistolIncendiary
+  result: MagazineBox45PistolIncendiary
+  materials:
+    Plastic: 240
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBox45PistolPractice
+  result: MagazineBox45PistolPractice
+  materials:
+    Steel: 60
+
+- type: latheRecipe
+  parent: BaseAmmoBoxRecipe
+  id: MagazineBox45PistolUranium
+  result: MagazineBox45PistolUranium
+  materials:
+    Plastic: 240
+    Uranium: 180


### PR DESCRIPTION
## About the PR
This PR fixes the Security Vector by giving it 45 auto instead of magnum.
This PR decreases the Vector's damage by 33%, but decreases it's spread. 
(I rolled back on the burst and mag size changes because those are based on it's real sizes)

Codewise - Creates a new ammo type (45 Auto) which uses the (35 auto sprites) and replaces the Vector's SMG mags to use that. 

Future stuff - Maybe make the Universal also shoot 45 auto? I don't mind the admin 1984 pistol still shooting magnum tho.

## Why / Balance
Why? They made a gun that shoots 45 ACP shoot 45 magnum.
Balance, 45 auto projectile damage is in the middle (actual half way point rounded up for odd numbers) between 35 auto and 45 magnum. It's still very good, but also the gun is very expensive still. 

**Changelog**
:cl:
- tweak: Tweaked Vector (Security) to fire 45 auto, which decreases it's damage output by 33%, decreased it's spread slightly.
