### PR TITLE
Vector

### DIFF
--- a/Resources/Prototypes/_Floof/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Fills/Crates/armory.yml
@@ -2,7 +2,7 @@
   id: CrateArmoryVector
   parent: [ CrateWeaponSecure, BaseSecurityContraband ]
   name: vector crate
-  description: Contains a Gen-2 Vector with two fourty round mags. Requires Armory access to open.
+  description: Contains a Gen-2 Vector with two thirty round mags. Requires Armory access to open.
   components:
   - type: EntityTableContainerFill
     containers:
@@ -10,5 +10,5 @@
         children:
         - id: WeaponSubMachineGunVector
           amount: 1
-        - id: MagazineMagnumSubMachineGun
+        - id: MagazinePistolSubMachineGun
           amount: 2

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -60,10 +60,10 @@
 
 - type: entity
   name: Vector-B
-  suffix: Magnum
+  suffix: 9x19mm, Security
   parent: [BaseWeaponSubMachineGun, BaseSecurityContraband]
   id: WeaponSubMachineGunVector
-  description: An old sol-made PDW. With an accruate and fast burst. Uses .45 magnum ammo.
+  description: An old sol-made PDW. With an accurate and fast burst. Uses .35 auto ammo.
   components:
   - type: Sprite
     sprite: _Floof/Objects/Weapons/Guns/SMGs/vector.rsi
@@ -77,12 +77,12 @@
   - type: Wieldable
     unwieldOnUse: false
   - type: GunWieldBonus
-    minAngle: -50
-    maxAngle: -25
+    minAngle: -23
+    maxAngle: -30
   - type: Gun
-    minAngle: 30
-    maxAngle: 60
-    fireRate: 8
+    minAngle: 25
+    maxAngle: 45
+    fireRate: 20
     burstFireRate: 30
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mk58.ogg
@@ -90,27 +90,28 @@
     availableModes:
     - Burst
     - SemiAuto
+    - FullAuto
     shotsPerBurst: 2
     burstCooldown: 0.255
   - type: ItemSlots
     slots:
       gun_magazine:
         name: Magazine
-        startingItem: MagazineMagnumSubMachineGun
+        startingItem: MagazinePistolSubMachineGun
         insertSound: /Audio/Weapons/Guns/MagIn/smg_magin.ogg
         ejectSound: /Audio/Weapons/Guns/MagOut/smg_magout.ogg
         priority: 2
         whitelist:
           tags:
-          - MagazineMagnumSubMachineGun
+          - MagazinePistolSubMachineGun
         whitelistFailPopup: gun-magazine-whitelist-fail
       gun_chamber:
         name: Chamber
-        startingItem: CartridgeMagnum
+        startingItem: CartridgePistol
         priority: 1
         whitelist:
           tags:
-          - CartridgeMagnum
+          - CartridgePistol
   - type: MagazineVisuals
     magState: mag
     steps: 1
@@ -119,7 +120,7 @@
 
 - type: entity
   name: Vector-F
-  suffix: High-Velocity
+  suffix: High-Velocity,  Syndicate
   parent: [BaseWeaponSubMachineGun, BaseSyndicateContraband]
   id: WeaponSubMachineGunVectorSyndie
   description: An newer version of the PDW. With high fire-rate and velocity but at the cost of accuracy, heck, the stock is missing. Uses .10 high-velocity ammo.

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -82,7 +82,7 @@
   - type: Gun
     minAngle: 25
     maxAngle: 45
-    fireRate: 20
+    fireRate: 10
     burstFireRate: 30
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mk58.ogg

--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -77,12 +77,12 @@
   - type: Wieldable
     unwieldOnUse: false
   - type: GunWieldBonus
-    minAngle: -23
-    maxAngle: -30
+    minAngle: -20
+    maxAngle: -25
   - type: Gun
     minAngle: 25
     maxAngle: 45
-    fireRate: 10
+    fireRate: 8
     burstFireRate: 30
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/mk58.ogg
@@ -92,7 +92,7 @@
     - SemiAuto
     - FullAuto
     shotsPerBurst: 2
-    burstCooldown: 0.255
+    burstCooldown: 0.25
   - type: ItemSlots
     slots:
       gun_magazine:


### PR DESCRIPTION
## About the PR
This PR changes the Vector to shoot 35 auto (at the suggestion of Tech because making a 45 ACP ammo type is more work then just swapping it and the gun sprite is the 9x19mm one). 

## Why / Balance
Why, because it shot 45 magnum before.
Balance, it's still expensive as hell, However, you can't use it to 2 tap unarmored people with 45 magnum damage anymore. (realistically using "hold to attack" gives it around the same full auto fire rate) We can come back to this

**Changelog**
:cl:
- tweak: Changed Vector-B to shoot 9x19mm (or 35 auto).
