### PR TITLE
Loadout improvements and fixes

### DIFF
--- a/Content.Client/Lobby/LobbyUIController.cs
+++ b/Content.Client/Lobby/LobbyUIController.cs
@@ -358,16 +358,20 @@ public sealed class LobbyUIController : UIController, IOnStateEntered<LobbyState
         if (roleLoadout == null)
             return;
 
-        foreach (var group in roleLoadout.SelectedLoadouts.Values)
-        {
-            foreach (var loadout in group)
-            {
-                if (!_prototypeManager.Resolve(loadout.Prototype, out var loadoutProto))
-                    continue;
+        // Floofstation - replaced the below shitcode with a call to StationSpawningSystem to avoid code duplication
+        if (_prototypeManager.TryIndex(roleLoadout.Role, out var roleLoadoutPrototype))
+            _spawn.EquipRoleLoadout(uid, roleLoadout, roleLoadoutPrototype);
 
-                _spawn.EquipStartingGear(uid, loadoutProto);
-            }
-        }
+        // foreach (var group in roleLoadout.SelectedLoadouts.Values)
+        // {
+        //     foreach (var loadout in group)
+        //     {
+        //         if (!_prototypeManager.Resolve(loadout.Prototype, out var loadoutProto))
+        //             continue;
+        //
+        //         _spawn.EquipStartingGear(uid, loadoutProto);
+        //     }
+        // }
     }
 
     /// <summary>

--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -1211,28 +1211,7 @@ namespace Content.Client.Lobby.UI
                 ReloadPreview();
             };
 
-            _loadoutWindow.OnRequestLoadoutMetadataEdit += (groupProto, loadoutProto) =>
-            {
-                if (!roleLoadout.SelectedLoadouts.TryGetValue(groupProto, out var group)
-                    || group.Find(it => it.Prototype == loadoutProto) is not { } loadout)
-                    return;
-
-                var dlg = new LoadoutMetadataEditorDialog(loadout, loadoutProto, groupProto);
-                dlg.OnSave += (newLoadout) =>
-                {
-                    // The role loadouts could have changed, we cant trust the old value
-                    if (!roleLoadout.SelectedLoadouts.TryGetValue(groupProto, out var newGroup))
-                        return;
-
-                    newGroup.RemoveAll(it => it.Prototype == loadoutProto);
-                    newGroup.Add(newLoadout);
-                    Profile = Profile?.WithLoadout(roleLoadout);
-                    _loadoutWindow.RefreshLoadouts(roleLoadout, session, collection);
-                    SetDirty();
-                    ReloadPreview();
-                };
-                dlg.OpenCentered();
-            };
+            OpenLoadoutFloof(jobProto, roleLoadout, roleLoadoutProto, session, collection); // Floofstation
 
             JobOverride = jobProto;
             ReloadPreview();

--- a/Content.Client/Lobby/UI/Loadouts/LoadoutContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutContainer.xaml.cs
@@ -66,4 +66,11 @@ public sealed partial class LoadoutContainer : BoxContainer
 
         _entManager.DeleteEntity(_entity);
     }
+
+    protected override void ExitedTree()
+    {
+        // Floofstation - for some reason, delta-v decided to only delete the entity when disposing the control with disposing = true
+        // This causes a memory leak
+        _entManager.DeleteEntity(_entity);
+    }
 }

--- a/Content.Client/_Floof/Lobby/UI/HumanoidProfileEditor.cs
+++ b/Content.Client/_Floof/Lobby/UI/HumanoidProfileEditor.cs
@@ -1,0 +1,69 @@
+using Content.Client._Floof.Lobby.UI;
+using Content.Shared.Preferences.Loadouts;
+using Robust.Shared.Player;
+using Content.Shared.Roles;
+using Robust.Shared.Utility;
+
+// ReSharper disable once CheckNamespace
+namespace Content.Client.Lobby.UI;
+
+// Floofstation-specific extensions of the profile editor
+public sealed partial class HumanoidProfileEditor
+{
+    private void OpenLoadoutFloof(JobPrototype? jobProto,
+        RoleLoadout roleLoadout,
+        RoleLoadoutPrototype roleLoadoutProto,
+        ICommonSession session,
+        IDependencyCollection collection)
+    {
+        // Loadout metadata editor
+        _loadoutWindow!.OnRequestLoadoutMetadataEdit += (groupProto, loadoutProto) =>
+        {
+            if (!roleLoadout.SelectedLoadouts.TryGetValue(groupProto, out var group)
+                || group.Find(it => it.Prototype == loadoutProto) is not { } loadout)
+                return;
+
+            var dlg = new LoadoutMetadataEditorDialog(loadout, loadoutProto, groupProto);
+            dlg.OnSave += (args) =>
+            {
+                var (newLoadout, copyMetadataToAll, copyLoadoutToAll) = args;
+                // The role loadouts could have changed, we cant trust the old value
+                if (!roleLoadout.SelectedLoadouts.TryGetValue(groupProto, out var newGroup))
+                    return;
+
+                newGroup.RemoveAll(it => it.Prototype == loadoutProto);
+                newGroup.Add(newLoadout);
+                Profile = Profile?.WithLoadout(roleLoadout);
+
+                // If "copy to all" is checked, we go through all other role loadouts and try to edit all matching loadouts
+                if (copyMetadataToAll && Profile is not null)
+                {
+                    foreach (var (otherJob, otherRoleLoadout) in Profile.Loadouts)
+                    {
+                        if (!_prototypeManager.TryIndex(otherRoleLoadout.Role, out var roleLoadoutPrototype))
+                            continue;
+
+                        foreach (var otherGroupId in roleLoadoutPrototype.Groups)
+                        {
+                            var otherLoadouts = otherRoleLoadout.SelectedLoadouts.GetOrNew(otherGroupId);
+
+                            // I assume no one is going to create more than 1 loadout proto per entity prototype, so no entProtoId checks here
+                            // We only add the loadout if it was chosen before OR if "copy loadout to all" is checked
+                            if (otherLoadouts.RemoveAll(it => it.Prototype == loadoutProto) > 0 || copyLoadoutToAll)
+                                otherLoadouts.Add(newLoadout);
+                        }
+
+                        // When copying to other role loadouts, some of them may become invalid
+                        otherRoleLoadout.EnsureValid(Profile, session, collection);
+                        Profile = Profile.WithLoadout(otherRoleLoadout);
+                    }
+                }
+
+                _loadoutWindow.RefreshLoadouts(roleLoadout, session, collection);
+                SetDirty();
+                ReloadPreview();
+            };
+            dlg.OpenCentered();
+        };
+    }
+}

--- a/Content.Client/_Floof/Lobby/UI/LoadoutMetadataEditorDialog.xaml
+++ b/Content.Client/_Floof/Lobby/UI/LoadoutMetadataEditorDialog.xaml
@@ -36,6 +36,24 @@
 
         <controls:HLine Color="#404040" Thickness="2" Margin="0 5" />
 
+        <!-- "Apply to all" toggles -->
+        <BoxContainer Orientation="Horizontal" Margin="2 0">
+            <CheckBox
+                Name="CopyMetadataToAllCheckbox"
+                Text="{Loc 'loadout-metadata-editor-apply-to-all'}"
+                ToolTip="{Loc 'loadout-metadata-editor-apply-to-all-tooltip'}"
+                Pressed="False"/>
+
+            <Control SetWidth="5"/>
+
+            <CheckBox
+                Name="CopyLoadoutToAllCheckbox"
+                Text="{Loc 'loadout-metadata-editor-copy-loadout-to-all'}"
+                ToolTip="{Loc 'loadout-metadata-editor-copy-loadout-to-all-tooltip'}"
+                Pressed="False"
+                Disabled="True"/>
+        </BoxContainer>
+
         <!-- I took this from QuickDialog, sue me -->
         <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center">
             <Button Name="SaveButton" Text="{Loc 'quick-dialog-ui-ok'}"/>

--- a/Content.Client/_Floof/Lobby/UI/LoadoutMetadataEditorDialog.xaml.cs
+++ b/Content.Client/_Floof/Lobby/UI/LoadoutMetadataEditorDialog.xaml.cs
@@ -20,7 +20,7 @@ public sealed partial class LoadoutMetadataEditorDialog : FancyWindow
     [Dependency] private readonly IEntityManager _entMan = default!;
     [Dependency] private readonly IPrototypeManager _protoMan = default!;
 
-    public event Action<Loadout>? OnSave;
+    public event Action<(Loadout loadout, bool copyMetadata, bool copyLoadout)>? OnSave;
 
     private readonly ProtoId<LoadoutPrototype> _loadoutProto;
     private readonly ProtoId<LoadoutGroupPrototype> _groupProto;
@@ -59,6 +59,19 @@ public sealed partial class LoadoutMetadataEditorDialog : FancyWindow
         {
             ColorSelector.Visible = args.Pressed;
         };
+
+        ColorSelector.OnColorChanged += color =>
+        {
+            // Update entity color on user input as well
+            ColorEntity(_previewContainer.SpriteEntity, color, _entMan);
+        };
+
+        CopyMetadataToAllCheckbox.OnToggled += args =>
+        {
+            // The "copy loadout to all" check does nothing if "copy metadata to all" is not checked
+            CopyLoadoutToAllCheckbox.Pressed = false;
+            CopyLoadoutToAllCheckbox.Disabled = !args.Pressed;
+        };
     }
 
     public void Load(Loadout currentState)
@@ -72,7 +85,7 @@ public sealed partial class LoadoutMetadataEditorDialog : FancyWindow
             ? Color.FromHex(customColor, Color.White)
             : Color.White;
 
-        ColorEntity(_previewContainer.SpriteEntity, ColorSelector.Color, _entMan);
+        ColorEntity(_previewContainer.SpriteEntity, currentState.ColorOverride, _entMan);
     }
 
     public void Save(bool raiseEvent = true)
@@ -95,7 +108,11 @@ public sealed partial class LoadoutMetadataEditorDialog : FancyWindow
         _loadout.ColorOverride = customColor?.ToHexNoAlpha();
 
         if (raiseEvent)
-            OnSave?.Invoke(_loadout);
+        {
+            var copyMetadata = CopyMetadataToAllCheckbox.Pressed;
+            var copyLoadout = copyMetadata && CopyLoadoutToAllCheckbox.Pressed;
+            OnSave?.Invoke((_loadout, copyMetadata, copyLoadout));
+        }
 
         Load(_loadout); // Just to update the fields with sanitized values
     }

--- a/Resources/ConfigPresets/Build/development.toml
+++ b/Resources/ConfigPresets/Build/development.toml
@@ -57,3 +57,8 @@ rules_file = "FloofstationRuleset"
 
 [control] # DeltaV
 storage_limit = 3
+
+
+# Floof - annoying
+[vote]
+autovote_enabled = false

--- a/Resources/Locale/en-US/_Floof/lobby/loadout-metadata-edit.ftl
+++ b/Resources/Locale/en-US/_Floof/lobby/loadout-metadata-edit.ftl
@@ -9,3 +9,15 @@ loadout-metadata-editor-custom-desc-tooltip = If this field is not empty, the de
 
 loadout-metadata-editor-custom-color = Custom color tint
 loadout-metadata-editor-custom-color-tooltip = If you turn this on, the entity will be automatically painted on spawn. You can wash the paint off using soap.
+
+loadout-metadata-editor-apply-to-all = Apply to all
+loadout-metadata-editor-apply-to-all-tooltip =
+    If checked, this loadout's custom metadata (name, description, etc.)
+    will be copied to all other selected job loadouts that grant the same item (identified by the entity prototype).
+    This will NOT automatically select this loadout for other jobs - only edit existing selections.
+
+loadout-metadata-editor-copy-loadout-to-all = Copy everywhere
+loadout-metadata-editor-copy-loadout-to-all-tooltip =
+    If checked, this loadout will be copied to all other job loadouts that support it.
+    Only job loadouts where at least one item is selected will end up getting affected.
+    THIS MAY OVERWRITE OTHER LOADOUTS. Use this function with caution and make profile backups if you're unsure!


### PR DESCRIPTION
## About the PR
- Adds "copy metadata" and "copy loadout" checkboxes to the metadata editor. The first one makes it so that all other instances of the edited loadout get their metadata changed as well. The other makes the loadout get copied to all other job loadouts (only those loadouts where the character has at least 1 loadout selected will be affected, to avoid polluting the db).
- Fixes several bugs with the custom metadata editor, including the one that caused the preview dummy to not have its loadout items painted (it was because of code duplication. i hateeee.)
- Moves some of the code from the upstream HumanoidProfileEditor class into a new part in the floof namespace, to keep the upstream one more clean.

I also tried to fix a memory leak related to loadouts, but i dont think I succeeded. Spamming the "loadout" button in the job menu still causes the client's memory usage to go up by a few megabytes on each click.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

I fucked some shit up and didn't bother re-recording, but here. The last minute or so is blank i think. The first two minutes showcase the fixes and new features.

https://github.com/user-attachments/assets/c5d00429-8811-47fc-8540-b423fc3a3acf

</p></details>

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: When editing loadouts, you can now choose to copy loadout metadata or even the entire loadout to other jobs. Hover your mouse over the checkboxes in the loadout metadata editor for more info.
- fix: Fixed a couple bugs related to loadouts. Most notably, the character preview should now correctly display loadouts with a custom color tint.
