### PR TITLE
Fix errors in HealthAnalyzerPrinterSystem

### DIFF
--- a/Content.Server/_NF/Medical/HealthAnalyzerPrinterSystem.cs
+++ b/Content.Server/_NF/Medical/HealthAnalyzerPrinterSystem.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using Content.Server._DV.Traits.Assorted;
 using Content.Server._NF.CartridgeLoader.Cartridges;
 using Content.Server.Atmos.Rotting;
+using Content.Server.Body.Systems;
 using Content.Server.CartridgeLoader;
 using Content.Server.Hands.Systems;
 using Content.Server.Medical.Components;
@@ -46,12 +47,14 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
     [Dependency] private readonly TransformSystem _transform = default!;
     [Dependency] private readonly CartridgeLoaderSystem _cartridgeLoader = default!;
 
-    // Euphoria: Add basic diagnostics and patient alerts to printout.
+    #region Euphoria: Add basic diagnostics and patient alerts to printout.
     [Dependency] private readonly UnborgableSystem _unborgable = default!;
     [Dependency] private readonly RedshirtSystem _redshirt = default!;
     [Dependency] private readonly UncloneableSystem _uncloneable = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly RottingSystem _rottingSystem = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstream = default!;
+    #endregion
 
     private static readonly Regex TemplateInsert = new(@"\{([\w.]+)\}");
 
@@ -211,7 +214,7 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
                 ("damageGroup", group.LocalizedName),
                 ("amount", groupDamage)
             );
-            report.AddText(groupTitleText);
+            report.AddMarkupPermissive(groupTitleText); // Euphoria: Use AddMarkupPermissive instead of AddText to preserve markup.
             report.PushNewline();
 
             // List individual damage types
@@ -223,7 +226,7 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
                     continue;
                 }
 
-                report.AddText(Loc.GetString(
+                report.AddMarkupPermissive(Loc.GetString( // Euphoria: Use AddMarkupPermissive instead of AddText to preserve markup.
                     "health-analyzer-printout-damage-type-text",
                     ("damageType", _prototypes.Index<DamageTypePrototype>(type).LocalizedName),
                     ("amount", amount)
@@ -281,25 +284,17 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
 
     private string GetBloodLevel(EntityUid patient)
     {
-        float bloodLevel = float.NaN;
-        if (TryComp<BloodstreamComponent>(patient, out var bloodstream) &&
-            _solutionContainerSystem.ResolveSolution(patient, bloodstream.BloodSolutionName,
-                ref bloodstream.BloodSolution, out var bloodSolution))
-            bloodLevel = bloodSolution.FillFraction;
+        float bloodLevel = HasComp<BloodstreamComponent>(patient) ? _bloodstream.GetBloodLevel(patient) : float.NaN;
 
         return !float.IsNaN(bloodLevel)
             ? $"{bloodLevel * 100:F1} %"
             : Loc.GetString("health-analyzer-window-entity-unknown-value-text");
     }
 
-    private string GetTotalDamage(EntityUid patient)
-    {
-        return "";
-    }
-
     private string ComposeAlerts(EntityUid patient)
     {
         StringBuilder alerts = new StringBuilder();
+        var isDead = TryComp<MobStateComponent>(patient, out var mobStateComponent) && mobStateComponent.CurrentState == MobState.Dead;
 
         if (TryComp<UnrevivableComponent>(patient, out var unrevivableComp) && unrevivableComp.Analyzable)
             alerts.AppendLine(Loc.GetString("health-analyzer-window-entity-unrevivable-text-short"));
@@ -310,6 +305,7 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
         alerts.AppendLine(Loc.GetString("health-analyzer-window-entity-bleeding-text"));
          */
 
+        // Technically possible to be rotting and alive with admemes, and this is examinable, so put it in the printout.
         if (_rottingSystem.IsRotten(patient))
             alerts.AppendLine(Loc.GetString(_rottingSystem.RotStage(patient) switch
             {
@@ -320,6 +316,10 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
 
         if (_unborgable.IsUnborgable(patient))
             alerts.AppendLine(Loc.GetString("health-analyzer-window-entity-unborgable-text-short"));
+
+        // All alerts after this are only displayed if dead. Move this condition if this ever changes.
+        if (!isDead)
+            return alerts.ToString();
 
         if (_redshirt.IsRedshirt(patient))
             alerts.AppendLine(Loc.GetString("health-analyzer-window-entity-redshirt-text-short"));

--- a/Content.Server/_NF/Medical/HealthAnalyzerPrinterSystem.cs
+++ b/Content.Server/_NF/Medical/HealthAnalyzerPrinterSystem.cs
@@ -214,7 +214,10 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
                 ("damageGroup", group.LocalizedName),
                 ("amount", groupDamage)
             );
-            report.AddMarkupPermissive(groupTitleText); // Euphoria: Use AddMarkupPermissive instead of AddText to preserve markup.
+            #region Euphoria: Use AddMarkupPermissive instead of AddText to preserve Markup.
+            //report.AddText(groupTitleText);
+            report.AddMarkupPermissive(groupTitleText);
+            #endregion
             report.PushNewline();
 
             // List individual damage types
@@ -226,7 +229,10 @@ public sealed class HealthAnalyzerPrinterSystem : EntitySystem
                     continue;
                 }
 
-                report.AddMarkupPermissive(Loc.GetString( // Euphoria: Use AddMarkupPermissive instead of AddText to preserve markup.
+                #region Euphoria: Use AddMarkupPermissive instead of AddText to preserve Markup.
+                //report.AddText(Loc.GetString(
+                report.AddMarkupPermissive(Loc.GetString(
+                #endregion
                     "health-analyzer-printout-damage-type-text",
                     ("damageType", _prototypes.Index<DamageTypePrototype>(type).LocalizedName),
                     ("amount", amount)


### PR DESCRIPTION
## About the PR
Do not interpret markup in damage messages as plain text.
Fix incorrect blood level value.
Do not print special alerts which are not displayed in the analyser UI for living patients.
Removed unused and unimplemented GetTotalDamage method.

## Why / Balance
This brings the printout more in line with the health analyser UI and fixes formatting errors.

## Technical details
In ComposeDamageList: Used AddMarkupPermissive instead of AddText.
In GetBloodLevel: Used the BloodstreamSystem's GetBloodLevel method instead of the BloodstreamComponent's FillFraction property.
- FillFraction returned the ratio of all chems against the bloodstream's maximum volume
- GetBloodLevel returns the ratio of actual blood against its ideal blood volume.

In ComposeAlerts: Check that the patient's MobState is Alive before adding certain alerts.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

Note that the health analyser UI never shows rotting state, but that this is examinable and matches what the printout shows for both alive and dead patients.
<img width="788" height="832" alt="MedicalPrintoutAlive" src="https://github.com/user-attachments/assets/d13094ea-24bf-4df6-aeca-501236911d07" />
<img width="810" height="827" alt="MedicalPrintoutDead" src="https://github.com/user-attachments/assets/7bde2c90-b65e-44d6-983d-126bd544c919" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

## Breaking changes
Removed unused and unimplemented GetTotalDamage method.

**Changelog**
:cl:
- fix: Fixed numerous errors in the health analyser printouts. They now more closely match the health analyser readout.
