### PR TITLE
Fix envelopes starting at the "start" pseudo-node

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/paper.yml
@@ -495,5 +495,5 @@
   # Floofstation additions start
   - type: Construction
     graph: Envelope
-    node: start
+    node: envelope
   # Floofstation aditions end


### PR DESCRIPTION
## About the PR
This mistake was missed in #676 and integration tests didnt catch it because EntityTest can only be run manually (because it keeps crashing our github runners).

**Changelog**
:cl:
- fix: Envelopes will no longer eat the first paper you put into them after manually crafting.
