### PR TITLE
Duplicate PDA Fix

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Wildcards/prisoner.yml
@@ -26,6 +26,6 @@
   id: PrisonerChameleonOutfit
   job: Prisoner
   equipment:
-    id: PrisonerPDA
+    #id: PrisonerPDA # Floofstation - let loadouts handle pdas
     ears: ClothingHeadsetPrison
     jumpsuit: ClothingUniformJumpsuitPrisoner

--- a/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/librarian.yml
@@ -16,7 +16,7 @@
   id: LibrarianGear
   equipment:
     #shoes: ClothingShoesBootsLaceup # Floofstation - allow loadouts to handle shoe customization
-    id: LibrarianPDA
+    #id: LibrarianPDA # Floofstation - let loadouts handle pdas
     ears: ClothingHeadsetScience # DeltaV - moved to epi
     pocket1: d20Dice
     pocket2: HandLabeler # for making named bestsellers

--- a/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Civilian/musician.yml
@@ -21,7 +21,7 @@
   equipment:
     eyes: ClothingEyesGlassesSunglasses
     #shoes: ClothingShoesBootsLaceup # Floofstation - allow loadouts to handle shoe customization
-    id: MusicianPDA
+    #id: MusicianPDA # Floofstation - let loadouts handle pdas
     ears: ClothingHeadsetService
   #storage:
     #back:

--- a/Resources/Prototypes/_DV/Roles/Jobs/Justice/clerk.yml
+++ b/Resources/Prototypes/_DV/Roles/Jobs/Justice/clerk.yml
@@ -32,7 +32,7 @@
     #jumpsuit: ClothingUniformJumpsuitClerk
     #back: ClothingBackpackFilled
     #shoes: ClothingShoesBootsLaceup
-    id: ClerkPDA
+    #id: ClerkPDA # Floofstation - let loadouts handle pdas
     ears: ClothingHeadsetJustice
     #innerClothingSkirt: ClothingUniformJumpskirtClerk
     #satchel: ClothingBackpackSatchelFilled

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
@@ -838,7 +838,6 @@
     - NanoTaskCartridge
     - NewsReaderCartridge
     - NanoChatCartridge
-    - MedTekCartridge # needed for medical roles
 
 - type: entity
   parent: ClothingNeckCollarEmotionalSupportLogisticsBase

--- a/Resources/Prototypes/_Floof/Entities/Objects/Devices/Misc/identification_card.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Devices/Misc/identification_card.yml
@@ -664,11 +664,21 @@
   - type: IdCard
     jobTitle: job-alt-title-command-emotional-support-cj
 
-# security technican
+# security technician
 - type: entity
-  parent: SecurityIDCard
+  parent: [SecurityIDCard]
   id: SecurityTechnicianIDCard
   name: Security Technician ID card
   components:
-  - type: IdCard
-    jobTitle: job-alt-title-security-technician
+  - type: Sprite
+    layers:
+    - state: default
+    - state: stripe_top
+      color: &color-security-top "#39393c"
+    - state: stripe_bottom
+      color: &color-security-bottom "#262626"
+    - sprite: &icon-rsi-floof /Textures/_Floof/Interface/Misc/floof_job_icons.rsi
+      offset: -0.09375, 0.0625 #3 pixels left, 2 pixels up
+      state: SecurityTechnician
+  - type: PresetIdCard
+    job: SecurityTechnician

--- a/Resources/Prototypes/_Floof/Entities/Objects/Devices/Misc/identification_card.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Devices/Misc/identification_card.yml
@@ -433,7 +433,7 @@
     jobTitle: job-alt-title-security-emotional-support-prisonguard
 
 - type: entity
-  parent: SeniorOfficerPDA # senior officer
+  parent: SeniorOfficerIDCard # senior officer
   id: EmotionalSupportSecuritySeniorOfficerIDCard
   name: Emotional Support Senior Officer ID card
   components:
@@ -441,14 +441,14 @@
     jobTitle: job-alt-title-security-emotional-support-seniorofficer
 
 - type: entity
-  parent: SeniorOfficerPDA # warden
+  parent: WardenIDCard # warden
   id: EmotionalSupportSecurityWardenIDCard
   name: Emotional Support Warden ID card
   components:
   - type: IdCard
     jobTitle: job-alt-title-security-emotional-support-warden
 
-# service, this will be fucky since we don't have a service collar
+# service
 - type: entity
   parent: BartenderIDCard # bartender
   id: EmotionalSupportServiceBartenderIDCard


### PR DESCRIPTION
## About the PR
A few roles had duplicate PDAs spawning so i took the time to fix them.

Fixes for:
- Musican
- Warden
- Librarian
- Clerk
- Prisoner
- Senior Officer

Since i already had the PR open and was fixing PDAs and some IDs i fixed the Sech Techs ID card will now have the proper Icon on it and the proper icon will be displayed through huds.

## Why / Balance
Needed to let loadouts handle giving out pdas, not starting gear.

## Technical details
Some yaml edits.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Clerk, Librarian, Musician, Prisoner, Senior Officer & Warden should no longer get duplicate PDAs when joining a round.
- fix; Sech Techs ID card will now have the proper Icon on it and the proper icon will be displayed through huds.
