### PR TITLE
Remove MedTek From Salvage Emotional Support PDA Collar

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
@@ -838,7 +838,6 @@
     - NanoTaskCartridge
     - NewsReaderCartridge
     - NanoChatCartridge
-#    - MedTekCartridge # needed for medical roles # Euphoria: Remove MedTek from salvage emotional support collar
 
 - type: entity
   parent: ClothingNeckCollarEmotionalSupportLogisticsBase

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Neck/Collar_Ids/collars_ids.yml
@@ -838,7 +838,7 @@
     - NanoTaskCartridge
     - NewsReaderCartridge
     - NanoChatCartridge
-    - MedTekCartridge # needed for medical roles
+#    - MedTekCartridge # needed for medical roles # Euphoria: Remove MedTek from salvage emotional support collar
 
 - type: entity
   parent: ClothingNeckCollarEmotionalSupportLogisticsBase


### PR DESCRIPTION
## About the PR
Removed MedTek cartridge from the salvage emotional support PDA collar

## Why / Balance
The salvage emotional support PDA collar, and only the PDA collar, as opposed to any of the alternatives, comes with MedTek. This change brings it to functional parity with the other salvage PDAs.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="370" height="502" alt="Emotional Support Collars" src="https://github.com/user-attachments/assets/4abd9fad-135a-427e-9a74-2d279ed624bf" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- remove: Removed MedTek software from salvage PDA collar.
