### PR TITLE
Fix Paper Plane, Coupon and Swan Crafting

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Misc/paper.yml
@@ -31,10 +31,10 @@
     maxWritableArea: 256.0, 0.0
   - type: Construction
     graph: PaperCoupon
-    node: start
+    node: coupon
 
 - type: entity
-  parent: BaseItem
+  parent: BasePaper
   id: PaperPlane
   name: Paper Plane
   description: It's a bird! No its a plane! No is just a paper plane.
@@ -66,7 +66,17 @@
     - Trash
   - type: Construction
     graph: PaperPlane
-    node: start
+    node: paperplane
+  - type: Paper
+  - type: PaperLabelType
+  - type: ActivatableUI
+    key: enum.PaperUiKey.Key
+    requiresComplex: false
+  - type: UserInterface
+    interfaces:
+      enum.PaperUiKey.Key:
+        type: PaperBoundUserInterface
+  - type: FaxableObject
 
 - type: entity
   parent: BaseItem
@@ -85,4 +95,4 @@
     - Trash
   - type: Construction
     graph: PaperPlane
-    node: start
+    node: origamiswan

--- a/Resources/Prototypes/_Floof/Entities/Objects/Misc/paper.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Misc/paper.yml
@@ -34,14 +34,24 @@
     node: coupon
 
 - type: entity
-  parent: BasePaper
+  parent: Paper # using base paper
   id: PaperPlane
   name: Paper Plane
   description: It's a bird! No its a plane! No is just a paper plane.
   components:
   - type: Sprite
     sprite: _Floof/Objects/Misc/paper_plane.rsi
-    state: icon
+    layers:
+    - state: icon # actual sprite of the plane
+    - state: icon # we dont have a written on paper plane sprite so overriding this with our icon
+      map: ["enum.PaperVisualLayers.Writing"]
+      visible: false
+    - sprite: /Textures/Objects/Misc/bureaucracy.rsi # point to the stamp sprites so we can use them
+      map: ["enum.PaperVisualLayers.Stamp"]
+      visible: false
+      state: paper_stamp-generic
+      scale: 0.3, 0.3 # scale them down so we can have a tiny stamp on the wing
+      offset: -0.13, 0.07 # offset just enough so the stamp is on the wing
   - type: Fixtures
     fixtures:
       fix1:
@@ -67,16 +77,6 @@
   - type: Construction
     graph: PaperPlane
     node: paperplane
-  - type: Paper
-  - type: PaperLabelType
-  - type: ActivatableUI
-    key: enum.PaperUiKey.Key
-    requiresComplex: false
-  - type: UserInterface
-    interfaces:
-      enum.PaperUiKey.Key:
-        type: PaperBoundUserInterface
-  - type: FaxableObject
 
 - type: entity
   parent: BaseItem


### PR DESCRIPTION
## About the PR
Noticed I messed up the nodes on these as well so fixed them.

Edit: also made it possible to write text on airplanes.

## Why / Balance
I did a silly and needed to fix 

## Technical details
shrimple yaml

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Paper Planes, Coupon and Swan will not longer require two pieces of paper to fully make them.
- fix: Paper Planes will now work like regular paper, you can write on them, burn them, eat them and fax them.