### PR TITLE
Fixed Sec Viper 

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -5,5 +5,23 @@
   description: A small, easily concealable, but somewhat underpowered gun, produced by a bulk arms manufacturer now defunct for over a century. Uses .35 auto ammo.
   suffix: Security
   components:
-   - type: Gun
-     fireRate: 5
+  - type: Gun
+    fireRate: 5
+  - type: ItemSlots
+    slots:
+      gun_magazine:
+        name: Magazine
+        startingItem: MagazinePistol
+        insertSound: /Audio/Weapons/Guns/MagIn/pistol_magin.ogg
+        ejectSound: /Audio/Weapons/Guns/MagOut/pistol_magout.ogg
+        priority: 2
+        whitelist:
+          tags:
+            - MagazinePistol
+      gun_chamber:
+        name: Chamber
+        startingItem: CartridgePistol
+        priority: 1
+        whitelist:
+          tags:
+            - CartridgePistol


### PR DESCRIPTION
## About the PR
Fixes Sec Viper starting with a extended mag.

## Why / Balance
DV added it and it just parents off the viper, so this just changes it so it uses a normal pistol mag.

**Changelog**
:cl:
- fix: Sec Viper starting with a extended mag was not intended.