### PR TITLE
Increased The Reduction Of Glimmer From Sacrificing A Psionic

### DIFF
--- a/Content.Shared/_DV/Chapel/SacrificialAltarComponent.cs
+++ b/Content.Shared/_DV/Chapel/SacrificialAltarComponent.cs
@@ -37,7 +37,7 @@ public sealed partial class SacrificialAltarComponent : Component
     /// Random amount to reduce glimmer by.
     /// </summary>
     [DataField]
-    public MinMax GlimmerReduction = new(30, 60);
+    public MinMax GlimmerReduction = new(300, 400); //Euphoria change, life is generally considered valuable here, reward for sacrifice should be significant.
 
     [DataField]
     public ProtoId<EntityTablePrototype> RewardPool = "PsionicSacrificeRewards";


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
The Glimmer reduction from a Psionic Sacrifice used to be 30 to 60. Now it's 300 to 400.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
30 to 60 glimmer is barely anything. Certainly not worth not only killing, but gibbing a person. 
The person also must be a psionic, so the pool of people that can be sacrificed is already limited. 
300 to 400 glimmer reduction seems much more reasonable for RRing someone. Could get you out of a Code White, potentially. 
Plus, making a sacrifice actually worthwhile will encourage people to do so, and thus invite the moral and ethical questions of doing so, and the drama. Good RP potential. 
Discussed in this Discord thread: https://discord.com/channels/1255902263667331193/1523211700751302776/1523211700751302776

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Single line change, just adjusting numbers. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="617" height="563" alt="image" src="https://github.com/user-attachments/assets/34f9e074-ad51-4279-b78f-9ad941914375" />
<img width="429" height="450" alt="image" src="https://github.com/user-attachments/assets/90897ca4-8052-4df6-9df9-e40c3a1dc465" />

<img width="566" height="41" alt="image" src="https://github.com/user-attachments/assets/7f0754ca-a0a6-43d1-a596-5adbacc922b0" />
<img width="354" height="270" alt="image" src="https://github.com/user-attachments/assets/d8bc4abd-433b-4566-8003-4e447ca136ff" />



</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Sacrificing a psionic at the altar now reduces glimmer by 300 to 400 (was 30 to 60).
