### PR TITLE
SmartFridge Tweaks

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -530,8 +530,9 @@
           Quantity: 15 # Funkychem - was 20
         - ReagentId: Salbutamol # Funkychem - was dex+
           Quantity: 15 # Funkychem - was 20
-  - type: Tag
-    tags: []
+  - type: Tag # Floofstation - give the medipens the base tag from detla-v so we can put them in medical fridges
+    tags:
+    - ChemicalMedipen
 
 - type: entity
   parent: ChemicalMedipen

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -294,6 +294,7 @@
     - CargoBoardsStatic
     - MedicalBoardsStatic
     - EngineeringBoardsStatic
+    - FloofstationServiceCircuitBoards # service smartfridge
     dynamicPacks:
     - EngineeringBoards
     - CargoBoards

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/lathe.yml
@@ -178,6 +178,7 @@
     - CollarsAutolatheFloofstation
     - FloofstationServiceCookingEquipment # static packs for food related storage and cooking items
     - FloofstationServiceFoodStorage
+    - FloofstationServiceCircuitBoards # service smartfridge
     # Floofstation section end
     dynamicPacks:
     - Janitor

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/smartfridge.yml
@@ -49,6 +49,7 @@
       - Bottle
       - Syringe
       - ChemDispensable
+      - ChemicalMedipen # Floofstation - allow for medical pens to be put into the smart fridges
   - type: ActivatableUI
     key: enum.SmartFridgeUiKey.Key
   - type: ActivatableUIRequiresPower

--- a/Resources/Prototypes/_Floof/Entities/Objects/Devices/Circuitboards/Machines/production.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Devices/Circuitboards/Machines/production.yml
@@ -1,0 +1,8 @@
+﻿- type: entity
+  parent: SmartFridgeCircuitboard
+  id: SmartFridgeServiceCircuitboard
+  name: Service SmartFridge machine board
+  description: A machine printed circuit board for a Service SmartFridge.
+  components:
+  - type: MachineBoard
+    prototype: SmartFridgeService

--- a/Resources/Prototypes/_Floof/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Machines/smartfridge.yml
@@ -1,0 +1,8 @@
+﻿- type: entity
+  parent: DVSmartFridge
+  id: SmartFridgeService
+  name: Service SmartFridge
+  description: A refrigerated storage unit for keeping plants, food and beverages cold and fresh.
+  components:
+  - type: AccessReader
+    access: [["Service"], ["Bar"], ["Kitchen"], ["Hydroponics"]] # giving access this way not sure if this is the best wya

--- a/Resources/Prototypes/_Floof/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Machines/smartfridge.yml
@@ -6,3 +6,5 @@
   components:
   - type: AccessReader
     access: [["Service"], ["Bar"], ["Kitchen"], ["Hydroponics"]]
+  - type: Machine
+    board: SmartFridgeServiceCircuitboard

--- a/Resources/Prototypes/_Floof/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/_Floof/Entities/Structures/Machines/smartfridge.yml
@@ -5,4 +5,4 @@
   description: A refrigerated storage unit for keeping plants, food and beverages cold and fresh.
   components:
   - type: AccessReader
-    access: [["Service"], ["Bar"], ["Kitchen"], ["Hydroponics"]] # giving access this way not sure if this is the best wya
+    access: [["Service"], ["Bar"], ["Kitchen"], ["Hydroponics"]]

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/Packs/service.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/Packs/service.yml
@@ -20,3 +20,8 @@
   - FoodBoxPizza
   - HappyHonkEmpty
   - HappyHonkMimeEmpty
+
+- type: latheRecipePack
+  id: FloofstationServiceCircuitBoards
+  recipes:
+  - SmartFridgeServiceCircuitboard # Service smartfridge

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/service_fab.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/service_fab.yml
@@ -118,3 +118,12 @@
   completetime: 2.0
   materials:
     Cardboard: 200
+
+- type: latheRecipe # recipe here
+  id: SmartFridgeServiceCircuitboard
+  result: SmartFridgeServiceCircuitboard
+  categories: [Tools]
+  completetime: 2.0
+  materials:
+    Steel: 100
+    Glass: 500

--- a/Resources/Prototypes/_NF/Entities/Objects/Medical/hypospray.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Medical/hypospray.yml
@@ -42,8 +42,9 @@
     onlyAffectsMobs: false
     injectOnly: true
     transferAmount: 15 # Explicitly redefined in case parent changes
-  - type: Tag
-    tags: []
+  - type: Tag # Floofstation - give the medipens the base tag from detla-v so we can put them in medical fridges
+    tags:
+    - ChemicalMedipen
 
 - type: entity
   name: hemostasis auto-injector

--- a/Resources/Prototypes/_NF/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/chemistry.yml
@@ -2,11 +2,11 @@
   id: BlankMediPen
   result: BlankMediPen
   completetime: 2
-  materials: # increased cost to make each pen since this is floof not frontier
+  materials: # Floofstation - increased cost to make each pen since this is floof not frontier
     Steel: 500
     Glass: 500
     Plastic: 250
-    Silver: 400
+    Silver: 100
     Gold: 50
 
 - type: latheRecipe


### PR DESCRIPTION
## About the PR
Medical pens can't be put into medical smart fridges so I fixed that (was an oversight.) Also made them slightly cheaper to produce since they previously took 4 pieces of silver per pen. Also creates a service specific smart fridge that can be mapped to service departments.

## Why / Balance
Allow medical to organize their fridges how they desire and see if lowering the cost makes them more made more. For the service fridge, service jobs currently get a medical one which they cant use unless they take it apart and put it back together which is silly.

## Technical details
yaml with tags

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="350" height="663" alt="image" src="https://github.com/user-attachments/assets/59c2e6fa-871c-43b6-b4c6-df425e364135" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Adds a Service SmartFridge for mappers.
- add: Service SmartFridge machineboard can be found in the circuit imprinter and service techfab on round start.
- tweak: Medical Pens are cheaper to produce and now can be put into Medical smart fridges.