### PR TITLE
Extended mag adjustments

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -40,6 +40,7 @@ research-technology-basic-shuttle-armament = Shuttle Basic Armament
 research-technology-advanced-shuttle-weapon = Advanced Shuttle Weapons
 research-technology-thermal-weaponry = Thermal Weaponry
 research-technology-dual-wielding-technology = Dual Wielding Technology
+research-technology-extended-pistol-magazines = Extended Pistol Magazines
 
 research-technology-basic-robotics = Basic Robotics
 research-technology-basic-anomalous-research = Basic Anomalous Research

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -20,6 +20,7 @@
   recipes:
   - MagazineBoxSpecialPractice
   - SpeedLoaderSpecialPractice
+  #- MagazinePistolHighCapacityPractice
 
 - type: latheRecipePack
   id: SecurityAmmoStaticDeltaV
@@ -32,6 +33,7 @@
   - BoxShellTranquilizer
   - MagazineShotgunBeanbag
   - MagazineLaser
+  #- MagazinePistolHighCapacity
 
 - type: latheRecipePack
   id: SecurityShotgunDrumsStatic
@@ -54,6 +56,7 @@
   - MagazineBoxRifleRubber
   - MagazineBoxSpecialRubber
   - MagazinePistolSubMachineGunRubber
+  #- MagazinePistolHighCapacityRubber
 
 - type: latheRecipePack
   parent: SecurityDisablers

--- a/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/_DV/Recipes/Lathes/Packs/security.yml
@@ -20,7 +20,6 @@
   recipes:
   - MagazineBoxSpecialPractice
   - SpeedLoaderSpecialPractice
-  - MagazinePistolHighCapacityPractice
 
 - type: latheRecipePack
   id: SecurityAmmoStaticDeltaV
@@ -33,7 +32,6 @@
   - BoxShellTranquilizer
   - MagazineShotgunBeanbag
   - MagazineLaser
-  - MagazinePistolHighCapacity
 
 - type: latheRecipePack
   id: SecurityShotgunDrumsStatic
@@ -56,7 +54,6 @@
   - MagazineBoxRifleRubber
   - MagazineBoxSpecialRubber
   - MagazinePistolSubMachineGunRubber
-  - MagazinePistolHighCapacityRubber
 
 - type: latheRecipePack
   parent: SecurityDisablers
@@ -77,6 +74,9 @@
   - MagazineBoxSpecialMindbreaker
   - MagazinePistolHighCapacityUranium
   - MagazinePistolHighCapacityIncendiary
+  - MagazinePistolHighCapacity # Euphoria - Extended Mags to research
+  - MagazinePistolHighCapacityRubber
+  - MagazinePistolHighCapacityPractice
 
 - type: latheRecipePack
   parent: SecurityHardsuits

--- a/Resources/Prototypes/_Floof/Research/research.yml
+++ b/Resources/Prototypes/_Floof/Research/research.yml
@@ -12,3 +12,17 @@
   cost: 15000
   recipeUnlocks:
   - WeaponLaserSvalinn
+
+- type: technology
+  id: ExtendedPistolMagazines
+  name: research-extended-pistol-magazines
+  icon:
+    sprite: Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_high_capacity_mag.rsi
+    state: base-icon
+  discipline: Arsenal
+  tier: 2
+  cost: 5000
+  recipeUnlocks:
+  - MagazinePistolHighCapacity
+  - MagazinePistolHighCapacityRubber
+  - MagazinePistolHighCapacityPractice

--- a/Resources/Prototypes/_Floof/Research/research.yml
+++ b/Resources/Prototypes/_Floof/Research/research.yml
@@ -15,7 +15,7 @@
 
 - type: technology
   id: ExtendedPistolMagazines
-  name: research-extended-pistol-magazines
+  name: research-technology-extended-pistol-magazines
   icon:
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_high_capacity_mag.rsi
     state: base-icon

--- a/Resources/Prototypes/_Floof/Research/research.yml
+++ b/Resources/Prototypes/_Floof/Research/research.yml
@@ -20,7 +20,7 @@
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/Pistol/pistol_high_capacity_mag.rsi
     state: base-icon
   discipline: Arsenal
-  tier: 2
+  tier: 1
   cost: 5000
   recipeUnlocks:
   - MagazinePistolHighCapacity


### PR DESCRIPTION
## About the PR
This PR turns extended mags into a tier 1 research.

## Why / Balance
Why, it was an issue to walk up to the secfab and just printing one round start, so you get it when ever epi researches it.
Why is it tier 1, because exotic ammo would unlock a extended uranium before normal mags, and that ain't ok.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Changed Extended Pistol Mags to require research. (Did you know the MK58 takes extended pistol mags?)
