### PR TITLE
Disable major mass mindswap

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -6,7 +6,7 @@
     - id: NoosphericZap
     - id: NoosphericFry
     - id: NoosphericSilence
-    - id: MassMindSwap
+#    - id: MassMindSwap # Floof - disabled because it RRs peopel
     - id: GlimmerWispSpawn
     - id: FreeProber
     - id: GlimmerRevenantSpawn
@@ -85,6 +85,7 @@
 - type: entity
   id: MassMindSwap
   parent: BaseGlimmerEvent
+  abstracT: true # Floof - disabled beacuse it RRs people
   components:
   - type: GlimmerEvent
     minimumGlimmer: 900

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -85,7 +85,7 @@
 - type: entity
   id: MassMindSwap
   parent: BaseGlimmerEvent
-  abstracT: true # Floof - disabled beacuse it RRs people
+  abstract: true # Floof - disabled beacuse it RRs people
   components:
   - type: GlimmerEvent
     minimumGlimmer: 900


### PR DESCRIPTION
## About the PR
I love mindswap... but not The Mindswap That RRs You.

**Changelog**
:cl:
- tweak: The Major Mass Mindswap has been disabled for the time being. The minor version of it can still occur.