### PR TITLE
Get Consent for Global Ghost Hearing

### DIFF
--- a/Content.Client/_Floof/UI/AcceptPublicERPEUI.cs
+++ b/Content.Client/_Floof/UI/AcceptPublicERPEUI.cs
@@ -1,0 +1,36 @@
+﻿using Content.Client.Eui;
+using Content.Shared._Floof.Ghost.UI;
+using JetBrains.Annotations;
+using Robust.Client.Graphics;
+
+namespace Content.Client._Floof.UI;
+
+[UsedImplicitly]
+public sealed class AcceptPublicERPEui : BaseEui
+{
+    private readonly AcceptPublicERPWindow _window;
+
+    public AcceptPublicERPEui()
+    {
+        _window = new AcceptPublicERPWindow();
+        _window.DenyButton.OnPressed += _ =>
+        {
+            SendMessage(new AcceptPublicERPChoiceMessage(AcceptPublicERPUiButton.Deny));
+            _window.Close();
+        };
+        _window.AcceptButton.OnPressed += _ =>
+        {
+            SendMessage(new AcceptPublicERPChoiceMessage(AcceptPublicERPUiButton.Accept));
+            _window.Close();
+        };
+    }
+    public override void Opened()
+    {
+        IoCManager.Resolve<IClyde>().RequestWindowAttention();
+        _window.OpenCentered();
+    }
+    public override void Closed()
+    {
+        _window.Close();
+    }
+}

--- a/Content.Client/_Floof/UI/AcceptPublicERPWindow.cs
+++ b/Content.Client/_Floof/UI/AcceptPublicERPWindow.cs
@@ -1,0 +1,45 @@
+﻿using System.Numerics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using static Robust.Client.UserInterface.Controls.BoxContainer;
+
+namespace Content.Client._Floof.UI;
+
+public sealed class AcceptPublicERPWindow : DefaultWindow
+{
+    public readonly Button DenyButton;
+    public readonly Button AcceptButton;
+
+    public AcceptPublicERPWindow()
+    {
+        Title = Loc.GetString("accept-public-erp-window-title");
+        Contents.AddChild(new BoxContainer
+        {
+            Orientation = LayoutOrientation.Vertical, Children =
+            {
+                new BoxContainer
+                {
+                    Orientation = LayoutOrientation.Vertical, Children =
+                    {
+                        new Label()
+                        {
+                            Text = Loc.GetString("accept-public-erp-window-prompt-text-part")
+                        },
+                        new BoxContainer
+                        {
+                            Orientation = LayoutOrientation.Horizontal, Align = AlignMode.Center, Children =
+                            {
+                                (AcceptButton = new Button
+                                {
+                                    Text = Loc.GetString("accept-cloning-window-accept-button"),
+                                }),
+                                new Control() { MinSize = new Vector2(20, 0) }, (DenyButton = new Button { Text = Loc.GetString("accept-cloning-window-deny-button"), })
+                            }
+                        },
+                    }
+                },
+            }
+        });
+    }
+}

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -147,7 +147,7 @@ namespace Content.Server.Ghost
                 return;
             }
             if (_player.TryGetSessionByEntity(uid, out var session))
-                _euiManager.OpenEui(new AcceptPublicERPEui(uid, component), session);
+                _euiManager.OpenEui(new AcceptPublicERPEui(uid, component, this), session);
         }
 
         // Euphoria | Handles adding component for Eui message

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -1,5 +1,7 @@
 using System.Linq;
 using System.Numerics;
+using System.Threading.Tasks;
+using Content.Server._Floof.Ghost.UI;
 using Content.Server.Administration.Managers; // DeltaV
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
@@ -41,6 +43,7 @@ using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Content.Server.EUI;
 
 namespace Content.Server.Ghost
 {
@@ -74,6 +77,7 @@ namespace Content.Server.Ghost
         [Dependency] private readonly GhostSpriteStateSystem _ghostState = default!;
         [Dependency] private readonly IServerPreferencesManager _preferencesManager = default!; // DeltaV
         [Dependency] private readonly IAdminManager _admin = default!; // DeltaV
+        [Dependency] private readonly EuiManager _euiManager = default!; // Euph
 
         private EntityQuery<GhostComponent> _ghostQuery;
         private EntityQuery<PhysicsComponent> _physicsQuery;
@@ -129,6 +133,7 @@ namespace Content.Server.Ghost
             }
         }
 
+        //Euphoria | Altered for public ERP consent check changes
         private void OnGhostHearingAction(EntityUid uid, GhostComponent component, ToggleGhostHearingActionEvent args)
         {
             args.Handled = true;
@@ -137,18 +142,20 @@ namespace Content.Server.Ghost
             {
                 RemComp<GhostHearingComponent>(uid);
                 _actions.SetToggled(component.ToggleGhostHearingActionEntity, true);
+                Popup.PopupEntity(Loc.GetString("ghost-gui-toggle-hearing-popup-off"), uid, uid);
+                Dirty(uid, component);
+                return;
             }
-            else
-            {
-                AddComp<GhostHearingComponent>(uid);
-                _actions.SetToggled(component.ToggleGhostHearingActionEntity, false);
-            }
+            if (_player.TryGetSessionByEntity(uid, out var session))
+                _euiManager.OpenEui(new AcceptPublicERPEui(uid, component), session);
+        }
 
-            var str = HasComp<GhostHearingComponent>(uid)
-                ? Loc.GetString("ghost-gui-toggle-hearing-popup-on")
-                : Loc.GetString("ghost-gui-toggle-hearing-popup-off");
-
-            Popup.PopupEntity(str, uid, uid);
+        // Euphoria | Handles adding component for Eui message
+        public void AddGhostHearingComponent(EntityUid uid, GhostComponent component)
+        {
+            AddComp<GhostHearingComponent>(uid);
+            _actions.SetToggled(component.ToggleGhostHearingActionEntity, false);
+            Popup.PopupEntity(Loc.GetString("ghost-gui-toggle-hearing-popup-on"), uid, uid);
             Dirty(uid, component);
         }
 

--- a/Content.Server/_Floof/Ghost/UI/AcceptPublicERPEui.cs
+++ b/Content.Server/_Floof/Ghost/UI/AcceptPublicERPEui.cs
@@ -7,10 +7,8 @@ using Content.Shared.Ghost;
 
 namespace Content.Server._Floof.Ghost.UI;
 
-public sealed class AcceptPublicERPEui(EntityUid uid, GhostComponent component) : BaseEui
+public sealed class AcceptPublicERPEui(EntityUid uid, GhostComponent component, GhostSystem ghostSystem) : BaseEui
 {
-    [Dependency] private readonly GhostSystem _ghostSystem = default!;
-
     public override void HandleMessage(EuiMessageBase message)
     {
         base.HandleMessage(message);
@@ -22,7 +20,7 @@ public sealed class AcceptPublicERPEui(EntityUid uid, GhostComponent component) 
             return;
         }
 
-        _ghostSystem.AddGhostHearingComponent(uid, component);
+        ghostSystem.AddGhostHearingComponent(uid, component);
         Close();
     }
 }

--- a/Content.Server/_Floof/Ghost/UI/AcceptPublicERPEui.cs
+++ b/Content.Server/_Floof/Ghost/UI/AcceptPublicERPEui.cs
@@ -1,0 +1,28 @@
+﻿using Content.Shared.Eui;
+using Content.Server.EUI;
+using Content.Server.Ghost;
+using Content.Shared._Floof.Ghost.UI;
+using Content.Shared.Ghost;
+
+
+namespace Content.Server._Floof.Ghost.UI;
+
+public sealed class AcceptPublicERPEui(EntityUid uid, GhostComponent component) : BaseEui
+{
+    [Dependency] private readonly GhostSystem _ghostSystem = default!;
+
+    public override void HandleMessage(EuiMessageBase message)
+    {
+        base.HandleMessage(message);
+
+        if (message is not AcceptPublicERPChoiceMessage choice ||
+            choice.Button == AcceptPublicERPUiButton.Deny)
+        {
+            Close();
+            return;
+        }
+
+        _ghostSystem.AddGhostHearingComponent(uid, component);
+        Close();
+    }
+}

--- a/Content.Shared/_Floof/Ghost/UI/AcceptPublicERPEuiMessage.cs
+++ b/Content.Shared/_Floof/Ghost/UI/AcceptPublicERPEuiMessage.cs
@@ -1,0 +1,23 @@
+﻿using Content.Shared.Eui;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Floof.Ghost.UI
+{
+    [Serializable, NetSerializable]
+    public enum AcceptPublicERPUiButton
+    {
+        Deny,
+        Accept,
+    }
+
+    [Serializable, NetSerializable]
+    public sealed class AcceptPublicERPChoiceMessage : EuiMessageBase
+    {
+        public readonly AcceptPublicERPUiButton Button;
+
+        public AcceptPublicERPChoiceMessage(AcceptPublicERPUiButton button)
+        {
+            Button = button;
+        }
+    }
+}

--- a/Resources/Locale/en-US/_Floof/abilities/publicERP.ftl
+++ b/Resources/Locale/en-US/_Floof/abilities/publicERP.ftl
@@ -1,0 +1,5 @@
+﻿accept-public-erp-window-title = Do you consent?
+accept-public-erp-window-prompt-text-part = This will enable global hearing.
+                                         If you use this you may be exposed to messages
+                                         of a NSFW nature, such as public ERP.
+                                         Do you still wish to activate global hearing?

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -98,7 +98,7 @@
       Poison: 1
       Asphyxiation: 1
     prefix: "ghost_"
-  - type: GhostHearing
+  #- type: GhostHearing # Euphoria | No global hearing by default
   - type: ShowElectrocutionHUD
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Ghosts will no longer start with global hearing enabled. They will have to expressly consent to possibly being exposed to NSFW messages if they want to activate the global hearing.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This makes it so ghosts aren't getting blasted with messages by default and gives greater breathing room for public ERP areas.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Alters the basic observer to not start with ghost hearing. There are also alterations to the ghost system and the addition of a new ui element. These changes are to support adding a consent question to the ghost hearing toggle ability so ghost hearing will not be granted without consenting first.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Default state:
<img width="716" height="326" alt="image" src="https://github.com/user-attachments/assets/c0416de1-0deb-4cf0-b822-d0779d5e5de3" />
Consent window:
<img width="681" height="361" alt="image" src="https://github.com/user-attachments/assets/fbd8f915-86c4-4f27-93fa-be062ebd62a3" />
Hearing active:
<img width="664" height="388" alt="image" src="https://github.com/user-attachments/assets/ceee8493-8a18-454a-b1ad-eaf832691211" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- tweak: Ghosts no longer start with global hearing by default.
- add: A consent notification has been added for activating ghost hearing.
