### PR TITLE
Make hands draw over inner clothing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -97,13 +97,13 @@
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "undergarmentSocks" ] # Floof
       - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "gloves" ]
       - map: [ "belt" ]
       - map: [ "id" ]

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -24,13 +24,13 @@
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: ["enum.HumanoidVisualLayers.LFoot"]
     - map: ["enum.HumanoidVisualLayers.RFoot"]
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "undergarmentSocks" ] # Floof
     - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
     - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
     - map: [ "shoes" ] # Floof - moved above jumpsuit
     - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+    - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+    - map: ["enum.HumanoidVisualLayers.RHand"] # ^
     - map: [ "gloves" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
@@ -348,13 +348,13 @@
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: ["enum.HumanoidVisualLayers.LFoot"]
     - map: ["enum.HumanoidVisualLayers.RFoot"]
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "undergarmentSocks" ] # Floof
     - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
     - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
     - map: [ "shoes" ] # Floof - moved above jumpsuit
     - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+    - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+    - map: ["enum.HumanoidVisualLayers.RHand"] # ^
     - map: ["enum.HumanoidVisualLayers.Handcuffs"]
       color: "#ffffff"
       sprite: Objects/Misc/handcuffs.rsi

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -99,8 +99,6 @@
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-      - map: [ "enum.HumanoidVisualLayers.LHand" ]
-      - map: [ "enum.HumanoidVisualLayers.RHand" ]
       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
       - map: [ "undergarmentSocks" ] # Floof
@@ -108,6 +106,8 @@
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
         color: "#ffffff"
         sprite: Objects/Misc/handcuffs.rsi

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -147,13 +147,13 @@
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: [ "enum.HumanoidVisualLayers.LFoot" ]
     - map: [ "enum.HumanoidVisualLayers.RFoot" ]
-    - map: [ "enum.HumanoidVisualLayers.LHand" ]
-    - map: [ "enum.HumanoidVisualLayers.RHand" ]
     - map: [ "undergarmentSocks" ] # Floof
     - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
     - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
     - map: [ "shoes" ] # Floof - moved above jumpsuit
     - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+    - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+    - map: ["enum.HumanoidVisualLayers.RHand"] # ^
     - map: [ "gloves" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/salvage.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/salvage.yml
@@ -62,13 +62,13 @@
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "undergarmentSocks" ] # Floof
       - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "gloves" ]
       - map: [ "ears" ]
       - map: [ "eyes" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/chitinid.yml
@@ -125,8 +125,6 @@
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-      - map: [ "enum.HumanoidVisualLayers.LHand" ]
-      - map: [ "enum.HumanoidVisualLayers.RHand" ]
       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
       - map: [ "undergarmentSocks" ] # Floof
@@ -134,6 +132,8 @@
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
         color: "#ffffff"
         sprite: Objects/Misc/handcuffs.rsi

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/feroxi.yml
@@ -58,8 +58,6 @@
         state: l_leg
       - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-      - map: [ "enum.HumanoidVisualLayers.LHand" ]
-      - map: [ "enum.HumanoidVisualLayers.RHand" ]
       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
       - map: [ "undergarmentSocks" ] # Floof
@@ -67,6 +65,8 @@
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
         color: "#ffffff"
         sprite: Objects/Misc/handcuffs.rsi

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -56,13 +56,13 @@
       - map: [ "socks" ]
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "undergarmentSocks" ] # Floof
       - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
         color: "#ffffff"
         sprite: Objects/Misc/handcuffs.rsi
@@ -205,13 +205,13 @@
       - map: [ "undershirt" ]
       - map: ["enum.HumanoidVisualLayers.LFoot"]
       - map: ["enum.HumanoidVisualLayers.RFoot"]
-      - map: ["enum.HumanoidVisualLayers.LHand"]
-      - map: ["enum.HumanoidVisualLayers.RHand"]
       - map: [ "undergarmentSocks" ] # Floof
       - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "id" ]
       - map: [ "gloves" ]
       - map: [ "ears" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -47,8 +47,6 @@
       - map: [ "enum.HumanoidVisualLayers.LLeg" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-      - map: [ "enum.HumanoidVisualLayers.LHand" ]
-      - map: [ "enum.HumanoidVisualLayers.RHand" ]
       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
       - map: [ "undergarmentSocks" ] # Floof
@@ -56,6 +54,8 @@
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
         color: "#ffffff"
         sprite: Objects/Misc/handcuffs.rsi

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -47,8 +47,6 @@
         visible: false
       - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
       - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-      - map: [ "enum.HumanoidVisualLayers.LHand" ]
-      - map: [ "enum.HumanoidVisualLayers.RHand" ]
       - map: [ "enum.HumanoidVisualLayers.LFoot" ]
       - map: [ "enum.HumanoidVisualLayers.RFoot" ]
       - map: [ "undergarmentSocks" ] # Floof
@@ -56,6 +54,8 @@
       - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
       - map: [ "shoes" ] # Floof - moved above jumpsuit
       - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+      - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+      - map: ["enum.HumanoidVisualLayers.RHand"] # ^
       - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
         color: "#ffffff"
         sprite: Objects/Misc/handcuffs.rsi

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/arachne.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/arachne.yml
@@ -27,13 +27,13 @@
     - map: [ "enum.HumanoidVisualLayers.LArm" ]
     - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "undergarmentSocks" ] # Floof
     - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
     - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
     - map: [ "shoes" ] # Floof - moved above jumpsuit
-    - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+    - map: [ "jumpsuit" ] # Floof - moved below feet
+    - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+    - map: ["enum.HumanoidVisualLayers.RHand"] # ^
     - map: [ "gloves" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/taur.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/taur.yml
@@ -30,13 +30,13 @@
     - map: [ "enum.HumanoidVisualLayers.LArm" ]
     - map: [ "enum.HumanoidVisualLayers.UndergarmentBottom" ]
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "undergarmentSocks" ] # Floof
     - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
     - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
     - map: [ "shoes" ] # Floof - moved above jumpsuit
     - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+    - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+    - map: ["enum.HumanoidVisualLayers.RHand"] # ^
     - map: [ "gloves" ]
     - map: [ "ears" ]
     - map: [ "eyes" ]
@@ -338,13 +338,13 @@
     - map: [ "enum.HumanoidVisualLayers.UndergarmentTop" ]
     - map: ["enum.HumanoidVisualLayers.LFoot"]
     - map: ["enum.HumanoidVisualLayers.RFoot"]
-    - map: ["enum.HumanoidVisualLayers.LHand"]
-    - map: ["enum.HumanoidVisualLayers.RHand"]
     - map: [ "undergarmentSocks" ] # Floof
     - map: [ "undergarmentTop" ] # Floof - this one is for clothing-based undergarment
     - map: [ "undergarmentBottom" ] # Floof - this one is for clothing-based undergarment
     - map: [ "shoes" ] # Floof - moved above jumpsuit
     - map: [ "jumpsuit" ] # Floof - moved below hands and feet
+    - map: ["enum.HumanoidVisualLayers.LHand"] # Floof - moved to keep above jumpsuit (feet and intentionally kept below it)
+    - map: ["enum.HumanoidVisualLayers.RHand"] # ^
     - map: ["enum.HumanoidVisualLayers.Handcuffs"]
       color: "#ffffff"
       sprite: Objects/Misc/handcuffs.rsi


### PR DESCRIPTION
## About the PR
I fucked it up, inner clothing DOES cover hands when viewed FROM THE SIDE. This PR fixes it.

<img width="203" height="188" alt="image" src="https://github.com/user-attachments/assets/5bd47875-4d59-474f-b846-01a89bab22e7" />

Feet are still drawn underneath because:
a) If inner clothing is long enough to obscure feet, then its probably a skirt/dress, in which case the layering's correct. The only known exception is the MNK jumpskirt, which needs to be resprited to not have built-in stockings.
b) Doing otherwise would require layering shoes over feet anyway, and shoes need to be drawn under inner clothing, which is a paradox

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
:cl:
- fix: Hands should now be drawn over inner clothing (and thus remain visible when your character is facing west/east)
