### PR TITLE
Dispelga

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -102,4 +102,4 @@
   - type: DamageOnDispel # Euphoria - requires more then 1 dispel to kill
     damage:
       types:
-        Holy: 5 # actual damage 25 based on damage modifier
+        Holy: 25

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -102,4 +102,4 @@
   - type: DamageOnDispel # Euphoria - requires more then 1 dispel to kill
     damage:
       types:
-        Heat: 25
+        Holy: 5 # actual damage 25 based on damage modifier

--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -99,3 +99,7 @@
     - SlowImmune
     - KnockdownImmune
   - type: UniversalLanguageSpeaker # Floofstation - boo.
+  - type: DamageOnDispel # Euphoria - requires more then 1 dispel to kill
+    damage:
+      types:
+        Heat: 25

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -115,7 +115,7 @@
   - type: DamageOnDispel
     damage:
       types:
-        Heat: 100
+        Heat: 150 # Euphoria - Increased so Wisp are weaker to it
   - type: SlowOnDamage
     speedModifierThresholds:
       150: 0.8

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -115,7 +115,7 @@
   - type: DamageOnDispel
     damage:
       types:
-        Holy: 50 # Euphoria - Increased so Wisp are weaker to it
+        Holy: 150 # Euphoria - 2 Hits Wisp (instead of 3) for future reference dispel ignores resistances thus weaknesses too.
   - type: SlowOnDamage
     speedModifierThresholds:
       150: 0.8

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -115,7 +115,7 @@
   - type: DamageOnDispel
     damage:
       types:
-        Heat: 150 # Euphoria - Increased so Wisp are weaker to it
+        Holy: 50 # Euphoria - Increased so Wisp are weaker to it
   - type: SlowOnDamage
     speedModifierThresholds:
       150: 0.8

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -131,4 +131,4 @@
   - type: DamageOnDispel # Euphoria - Added Dispel damage 1/4 of their HP
     damage:
       types:
-        Holy: 15
+        Holy: 30

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -131,4 +131,4 @@
   - type: DamageOnDispel # Euphoria - Added Dispel damage 1/4 of their HP
     damage:
       types:
-        Heat: 30
+        Holy: 15

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -128,3 +128,7 @@
     immuneTo:
       components:
       - FlareGunPellet
+  - type: DamageOnDispel # Euphoria - Added Dispel damage 1/4 of their HP
+    damage:
+      types:
+        Heat: 30

--- a/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/artifact.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/NPCs/artifact.yml
@@ -60,7 +60,6 @@
     thresholds:
       0: Alive
       350: Dead
-  - type: Dispellable
   - type: DamageOnDispel
     damage:
       types:


### PR DESCRIPTION
## About the PR
Changes various dispel values, due to dispel blowing up revenants and apparently skia in 1 (i didn't see anything on skia that makes them dispelable but apparently they can be).
Revenants take less damage. (1/3 of their starting essence)
Skia take less damage (1/4 of the HP)
Wisp take MORE damage from dispel (1/2, up from 1/3)

Fixes Behonker being deleted on dispel.

This bit of code means the damage type is irreverent it will ignore resistances and weaknesses - ft SharedDispelPowerSystem
`_damageable.TryChangeDamage(dispelled, damage, ignoreResistances: true);`

## Why
Dispel wasn't very RP friendly when it simply 1 shot revenants and apparently Skias (even tho it shouldn't work on em, going from a statement in a request thread), and makes it more dangerous to Wisp which you can't RP with.

**Changelog**
:cl:
- tweak: Changed Dispel to deal less to player controlled entities.
- fix: Fixed Behonker being deleted on dispel.
