### PR TITLE
Hallucination Adjustments

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -431,7 +431,7 @@
         minScale: 1
         effectProto: StatusEffectSeeingRainbow
         type: Add
-        time: 500
+        time: 200 # Euphoria - Lasts all round was 500
       - !type:Drunk
         boozePower: 500
         minScale: 1

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -431,7 +431,7 @@
         minScale: 1
         effectProto: StatusEffectSeeingRainbow
         type: Add
-        time: 200 # Euphoria - Lasts all round was 500
+        time: 240 # Euphoria - Lasts all round was 500
       - !type:Drunk
         boozePower: 500
         minScale: 1

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1527,7 +1527,7 @@
         type: Remove
       - !type:ModifyStatusEffect
         effectProto: StatusEffectSeeingRainbow
-        time: 10.0
+        time: 30.0 # Euphoria - Made Halo work better
         type: Remove
       - !type:AdjustReagent
         reagent: Desoxyephedrine


### PR DESCRIPTION
## About the PR
Adjusts Frezon to have 50% less duration (down from adding 500 seconds per half unit) and Haloperidol from 10 seconds to 30.

## Why / Balance
Frezon IS making people high for the whole shift, and probably the NEXT shift, I've halved it so -> Haloperidol was buffed so you don't need to drink 3 liters to remove Frezon.

**Changelog**
:cl:
- tweak: Changed Frezon to make you high for half the time, and Haloperidol to be 3 times as effective against being high.

