### PR TITLE
allow wearing translator in ID slot for people using ID collars

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Devices/translators.yml
@@ -25,7 +25,7 @@
   - type: HandheldTranslator
     enabled: false
   - type: Clothing # To allow equipping translators on the neck slot
-    slots: [neck]
+    slots: [neck, idcard]
     equipDelay: 0.3
     unequipDelay: 0.3
     quickEquip: false # Would conflict


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Very small change, just allows the translator to be worn in the ID slot as an alternative to the neck slot for people who use collar IDs

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Makes it easier to use a translator while using a collar ID and makes the ID slot not entirely useless for people with ID collars instead.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Tiny yml change, not much else.

## Media
N/A
## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Translators can now be used from the PDA slot for people who use their collar as ID!
