### PR TITLE
Fix thaven-specific clothing sprites being unused

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -84,6 +84,7 @@
     - Snout
   - type: Inventory
     templateId: thaven
+    speciesId: thaven
     displacements:
       jumpsuit:
         sizeMaps:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Thaven sprites should now be used when included in an RSI folder.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
We have existing thaven-specific sprites, such as those for longcoats, which are not in use. This also adds functionality for other contributors to make thaven-specific sprites when displacement maps are not adequate.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Edited the InventoryComponent used by thavens to include a speciesId with value "thaven". I did not change the template that thavens are based off, as this may have unintended effects on any other entity using that template.

## Media
This test uses a resprited black longcoat, which already had a species-specific sprite for thavens. This is not included in the PR.
<details> <summary><h3>Click to show</h3></summary> <p>
<img width="891" height="804" alt="image" src="https://github.com/user-attachments/assets/0aa99ec7-abb8-457e-bed4-61cb4527fc60" />


<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Fixed thaven species-specific sprites not being used when worn by thavens.
