### PR TITLE
Re-enable Fire Alarm

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/fire_alarm.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/WallmountMachines/fire_alarm.yml
@@ -42,7 +42,7 @@
       - FireAlarm
   - type: Clickable
   - type: InteractionOutline
-  #- type: FireAlarm # DeltaV - disable fire alarms
+  - type: FireAlarm # Floofstation - idk why delta-v disabled this but un 1984 fire alarms
   - type: AtmosAlertsDevice
     group: FireAlarm
   - type: ContainerFill


### PR DESCRIPTION
## About the PR
No clue why but delta-v disabled fire alarms so re-enabling them.

## Why / Balance
We need to press the big red button.

## Technical details
Fishy.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Pressing a fire alarm will make fire locks activate again.
