### PR TITLE
Big Rods

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
@@ -12,6 +12,12 @@
     state: icon
     noRot: false
   - type: ImmovableRod
+    # Floofstation additions - safer rods start
+    shouldGib: false
+    damage:
+      types:
+        Blunt: 80 # Floofstation - 190 was way to much lowered to have so it crits (depending on species may do a bit more)
+  # Floofstation additions - safer rods end
   - type: GravityAffected
   - type: Physics
     bodyType: Dynamic

--- a/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
+++ b/Resources/Prototypes/Entities/Objects/Magic/immovable_rod.yml
@@ -16,7 +16,7 @@
     shouldGib: false
     damage:
       types:
-        Blunt: 80 # Floofstation - 190 was way to much lowered to have so it crits (depending on species may do a bit more)
+        Blunt: 80 # Floofstation - 190 was way too much, lowered to have it so it crits (depending on species may do a bit more)
   # Floofstation additions - safer rods end
   - type: GravityAffected
   - type: Physics

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -261,7 +261,7 @@
     - id: ImmovableRodWeh
       prob: 0.0075
       orGroup: rodProto
-    - id: ImmovableRodDildo # Floofstation - didlo rod
+    - id: ImmovableRodDildo # Floofstation - dildo rod
       prob: 0.0075
       orGroup: rodProto
 

--- a/Resources/Prototypes/GameRules/meteorswarms.yml
+++ b/Resources/Prototypes/GameRules/meteorswarms.yml
@@ -66,8 +66,12 @@
     minMaxEventTiming:
       min: 750 # 12.5 min
       max: 3600 # 60 min # Floofstation - increased to 60
-    scheduledGameRules: !type:EntSelector # DeltaV: use old event
-      id: MeteorSwarm
+    scheduledGameRules: !type:GroupSelector # Floofstatoin - add rods to the pool
+      children:
+      - id: MeteorSwarm
+        weight: 1
+      - id: ImmovableRodSpawn # Floofstation - 1/10 chance a rod spawns
+        weight: 0.1
 
 - type: entity
   parent: BaseGameRule
@@ -255,6 +259,9 @@
       prob: 0.0075
       orGroup: rodProto
     - id: ImmovableRodWeh
+      prob: 0.0075
+      orGroup: rodProto
+    - id: ImmovableRodDildo # Floofstation - didlo rod
       prob: 0.0075
       orGroup: rodProto
 

--- a/Resources/Prototypes/_Floof/Entities/Objects/Magic/immovable_rods.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Magic/immovable_rods.yml
@@ -1,0 +1,12 @@
+﻿- type: entity
+  parent: ImmovableRodKeepTiles
+  id: ImmovableRodDildo
+  name: immovable rod dildo
+  description: Who thought it would be a good idea to fire a didlo out of a PTL!?
+  components:
+  - type: Sprite
+    sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_canine_red.rsi
+    state: icon
+    scale: 2.5 , 2.5
+    rotation: 90
+    noRot: false

--- a/Resources/Prototypes/_Floof/Entities/Objects/Magic/immovable_rods.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Magic/immovable_rods.yml
@@ -2,7 +2,7 @@
   parent: ImmovableRodKeepTiles
   id: ImmovableRodDildo
   name: immovable rod dildo
-  description: Who thought it would be a good idea to fire a didlo out of a PTL!?
+  description: Who thought it would be a good idea to fire a dildo out of a PTL!?
   components:
   - type: Sprite
     sprite: _Floof/Objects/Fun/Lewd/Toys/Dildos/dildo_canine_red.rsi


### PR DESCRIPTION
## About the PR
Add rods back to the event scheduler.

## Why / Balance
Uh i got bored and wanted rods back so here we are.

## Technical details
Modified base rod to prevent gibing an reduced the damage specifier so it crits most species but dose not gib them. I also got distracted and made a dildo rod. Fear my creation.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Rods are back on the menu hitting stations near you.