### PR TITLE
Some prediction fixes

### DIFF
--- a/Content.Shared/Bed/Sleep/SleepingSystem.cs
+++ b/Content.Shared/Bed/Sleep/SleepingSystem.cs
@@ -203,6 +203,7 @@ public sealed partial class SleepingSystem : EntitySystem
     {
         // Shh the Urist McHands is sleeping...
         args.Cancelled = true;
+        args.Autostand = false; // Floof - why wasnt this set?!
     }
 
     private void OnExamined(Entity<SleepingComponent> ent, ref ExaminedEvent args)

--- a/Content.Shared/Rotation/RotationVisualsComponent.cs
+++ b/Content.Shared/Rotation/RotationVisualsComponent.cs
@@ -9,7 +9,7 @@ public sealed partial class RotationVisualsComponent : Component
     /// <summary>
     /// Default value of <see cref="HorizontalRotation"/>
     /// </summary>
-    [DataField]
+    [DataField, AutoNetworkedField] // Floof - make auto-networked
     public Angle DefaultRotation = Angle.FromDegrees(90);
 
     [DataField]

--- a/Content.Shared/Traits/Assorted/NarcolepsySystem.cs
+++ b/Content.Shared/Traits/Assorted/NarcolepsySystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Bed.Sleep;
 using Content.Shared.Random.Helpers;
 using Content.Shared.StatusEffectNew;
+using Robust.Shared.Network;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
@@ -14,6 +15,7 @@ public sealed class NarcolepsySystem : EntitySystem
     [Dependency] private readonly StatusEffectsSystem _statusEffects = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly INetManager _net = default!; // Floof
 
     /// <inheritdoc/>
     public override void Initialize()
@@ -63,7 +65,9 @@ public sealed class NarcolepsySystem : EntitySystem
                 narcolepsy.MinTimeBetweenIncidents + (narcolepsy.MaxTimeBetweenIncidents - narcolepsy.MinTimeBetweenIncidents) * rand.NextDouble() + duration;
             DirtyField(uid, narcolepsy, nameof(narcolepsy.NextIncidentTime));
 
-            _statusEffects.TryAddStatusEffectDuration(uid, SleepingSystem.StatusEffectForcedSleeping, duration);
+            // Floof - do not try to predict the unpredictable you -
+            if (_net.IsServer)
+                _statusEffects.TryAddStatusEffectDuration(uid, SleepingSystem.StatusEffectForcedSleeping, duration);
         }
     }
 }

--- a/Content.Shared/_Floof/Standing/SharedCrawlingExtensionsSystem.cs
+++ b/Content.Shared/_Floof/Standing/SharedCrawlingExtensionsSystem.cs
@@ -68,6 +68,7 @@ public sealed class SharedCrawlingExtensionsSystem : EntitySystem
             || !TryComp<StandingStateComponent>(uid, out var standingState)
             || !TryComp<CrawlingExtensionsComponent>(uid, out var ext)
             || !TryComp<AppearanceComponent>(uid, out var appearance)
+            || !TryComp<RotationVisualsComponent>(uid, out var rotVisuals)
             || !_actionBlocker.CanConsciouslyPerformAction(uid)
             || !_timing.IsFirstTimePredicted
             || !ext.CanChangeDirections
@@ -78,8 +79,9 @@ public sealed class SharedCrawlingExtensionsSystem : EntitySystem
         Dirty(uid, ext);
 
         // +90deg = default horizontal rotation, -90deg = opposite
-        var rotVisuals = EnsureComp<RotationVisualsComponent>(uid);
-        _rotVisuals.SetHorizontalAngle((uid, rotVisuals), rotVisuals.DefaultRotation + (!ext.InvertedCrawlingDirection ? 0 : Angle.FromDegrees(180)));
+        // We have to change the default rotation because the BuckleSystem and other systems may attempt to reset it later
+        rotVisuals.DefaultRotation = Angle.FromDegrees(90) + (!ext.InvertedCrawlingDirection ? 0 : Angle.FromDegrees(180));
+        _rotVisuals.SetHorizontalAngle((uid, rotVisuals), rotVisuals.DefaultRotation);
         // Have to queue an appearance update so the RotationVisualizerSystem can play an animation if the entity is already laying
         Dirty(uid, appearance);
     }


### PR DESCRIPTION
## About the PR
Fixes do-after spam of narcolepsy and crawling direction inversion (used to only break on every second login)
- The former was caused by the client trying to predict narcolepsy episodes, applying the sleeping state, then reversing and re-applying it multiple times during prediction, which would somehow leave the mob in a broken client-side state, without the sleeping component (or it somehow malfunctioning?), trying to start a get-up do-after each tick but failing to complete any. I dont even know. Did you know there are FIVE different systems managing the way mobs lay down and get up? StandingStateSystem, KnockedDownSystem, StunSystem, SleepingSystem, BuckleSystem. Each one of them controls standing in its own way, and they are all utter shitcode from 5+ years ago.

- The latter was caused by the BuckleSystem resetting HorizontalRotation after getting a new buckle component state. It's kinda on me for not changing DefaultRotation, but WHY it consistently only happened every second login is still a massive mystery to me.

## Media
<img width="370" height="146" alt="image" src="https://github.com/user-attachments/assets/95d6c8ca-1f53-4cc0-b4ea-c0e8b1ff137c" />

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Fixed several prediction bugs in regards to narcolepsy and crawling direction toggle.
