### PR TITLE
Increased tritium exothermia AKA TritFix

### DIFF
--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -217,7 +217,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     Amount of heat released per mole of burnt hydrogen or tritium (hydrogen isotope)
         /// </summary>
-        public const float FireHydrogenEnergyReleased = 284e3f; // hydrogen is 284 kJ/mol
+        public const float FireHydrogenEnergyReleased = 284e4f; // hydrogen is 284 kJ/mol // Floofstation - TritFix
         public const float FireMinimumTemperatureToExist = T0C + 100f;
         public const float FireMinimumTemperatureToSpread = T0C + 150f;
         public const float FireSpreadRadiosityScale = 0.85f;


### PR DESCRIPTION
## **Some Men Just Want to Watch the World Burn**
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Fixes/Buffs tritium burns back to what it was.
Thats about it.
**Lets bring back existencial sense to delta pressure!**

## Why
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
### **WHY?**
Cease the torture.
Undesireable gameplay as atmos and cargo in TEG only maps.
_12 plasma cans from cargo, **RIGHT NOW!!** Lone CE doing TEG math while being bombarded by meteors._

In short: It was EXTREMELY "nerfed" in an upstream fix that made a leftover bug.

What started it: https://github.com/space-wizards/space-station-14/pull/41870
What fixed it: https://github.com/space-wizards/space-station-14/pull/42641
_Maxcaps are disabled in here AFAIK, so only the trit buff will take immediate effect._

DeltaV merged fixes, we have not: https://github.com/DeltaV-Station/Delta-v/pull/5894

## Balance
Re-introduction of various true atmos threats regarding trit fires.
Affects everything that could make a tritium burn.
Nuclear Reactors, Gas Leaks, TEG and **possibly future SM**. https://github.com/Floof-Station/Panta-Rhei/pull/761
Fire alarms being interactable again counters. https://github.com/Floof-Station/Panta-Rhei/pull/799

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Changed one C# file.
The `FireHydrogenEnergyReleased` exponential from `3` to `4`. Totalling `1.136 kJ/mol` burnt. A `~33%` buff.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [x] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Re-Buffed tritium burns.
