### PR TITLE
Remove duplicate leash loadouts

### DIFF
--- a/Resources/Prototypes/_Floof/Loadouts/Groups/trinkets.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/trinkets.yml
@@ -74,6 +74,4 @@
   - WhipPink
   - WhipTealCrotch
   - WhipTeal
-  - LeashBasic
-  - RemoteSignaller
   - HoloprojectorNSFW # Den


### PR DESCRIPTION
## About the PR
#760 failed to resolve a merge conflict and i missed it. Now we have two of these in the loadouts.

**Changelog**
:cl:
- fix: Removed a duplicate leash & remote signaller loadouts (they are still available in the trinkets group)
