### PR TITLE
Improve handling of non-ID entities in the ID slot and fix error caused by #792

### DIFF
--- a/Content.Shared/Access/Systems/IdExaminableSystem.cs
+++ b/Content.Shared/Access/Systems/IdExaminableSystem.cs
@@ -46,25 +46,40 @@ public sealed class IdExaminableSystem : EntitySystem
         return GetInfo(uid) ?? Loc.GetString("id-examinable-component-verb-no-id");
     }
 
+    // Start Floofstation
     public string? GetInfo(EntityUid uid)
     {
-        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid) || _inventorySystem.TryGetSlotEntity(uid, "neck", out idUid)) // Floofstation Pet IDs to check neck slot
+        // Check ID slot
+        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid))
         {
-            // PDA
-            if (TryComp(idUid, out PdaComponent? pda) &&
-                TryComp<IdCardComponent>(pda.ContainedId, out var id))
-            {
-                return GetNameAndJob(id);
-            }
-            // ID Card
-            if (TryComp(idUid, out id))
-            {
-                return GetNameAndJob(id);
-            }
+            var idInfo = GetIdInfo((EntityUid)idUid);
+            if (idInfo != null) return idInfo;
+        }
+        // Check neck slot
+        if (_inventorySystem.TryGetSlotEntity(uid, "neck", out idUid))
+        {
+            var idInfo = GetIdInfo((EntityUid)idUid);
+            if (idInfo != null) return idInfo;
         }
         return null;
     }
 
+    private string? GetIdInfo(EntityUid uid)
+    {
+        // PDA
+        if (TryComp(uid, out PdaComponent? pda) &&
+            TryComp<IdCardComponent>(pda.ContainedId, out var id))
+        {
+            return GetNameAndJob(id);
+        }
+        // ID Card
+        if (TryComp(uid, out id))
+        {
+            return GetNameAndJob(id);
+        }
+        return null;
+    }
+    // End Floofstation
     private string GetNameAndJob(IdCardComponent id)
     {
         var jobSuffix = string.IsNullOrWhiteSpace(id.LocalizedJobTitle) ? string.Empty : $" ({id.LocalizedJobTitle})";


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Fixes error caused by oversight in testing of #792 and allows the `IdExaminableSystem` to attempt checking the neck slot for ID if the ID slot contains an invalid ID.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
While testing #792 I failed to catch an error when wearing a translator in the ID slot that would prevent your collar ID card from being examined due to the ID card slot being read first, even if the contained entity wasn't a valid ID.

These changes allow the `IdExaminableSystem` to check the ID slot, determine if it contains a valid ID and if not then attempt to check the neck slot, allowing for arbitrary items in the ID slot to not prevent examining a collar ID.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Changes to shared `IdExaminableSystem`.
Moves some logic from the `GetInfo` function into a helper `GetIdInfo` function.

Previous `GetInfo` function:
```C#
    public string? GetInfo(EntityUid uid)
    {
        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid) || _inventorySystem.TryGetSlotEntity(uid, "neck", out idUid)) // Floofstation Pet IDs to check neck slot
        {
            // PDA
            if (TryComp(idUid, out PdaComponent? pda) &&
                TryComp<IdCardComponent>(pda.ContainedId, out var id))
            {
                return GetNameAndJob(id);
            }
            // ID Card
            if (TryComp(idUid, out id))
            {
                return GetNameAndJob(id);
            }
        }
        return null;
    }
```

Updated `GetInfo` function:
```C#
    public string? GetInfo(EntityUid uid)
    {
        // Check ID slot
        if (_inventorySystem.TryGetSlotEntity(uid, "id", out var idUid))
        {
            var idInfo = GetIdInfo((EntityUid)idUid);
            if (idInfo != null) return idInfo;
        }
        // Check neck slot
        if (_inventorySystem.TryGetSlotEntity(uid, "neck", out idUid))
        {
            var idInfo = GetIdInfo((EntityUid)idUid);
            if (idInfo != null) return idInfo;
        }
        return null;
    }
```

New `GetIdInfo` helper function:
```C#
    private string? GetIdInfo(EntityUid uid)
    {
        // PDA
        if (TryComp(uid, out PdaComponent? pda) &&
            TryComp<IdCardComponent>(pda.ContainedId, out var id))
        {
            return GetNameAndJob(id);
        }
        // ID Card
        if (TryComp(uid, out id))
        {
            return GetNameAndJob(id);
        }
        return null;
    }
```

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
### Before:
Translator blocks collar ID:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/6ea10b45-1d4c-492a-b737-e331770bd4cf" />

### After:
Translator does not block collar ID:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/11e005b6-27c2-4353-8f4d-5cbacae30293" />

Clown ID takes priority as it is in the ID slot:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/9458f559-8b9e-4d8e-86f5-f31de63833f6" />

Clown ID functions normally when neck slot contains non-ID:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/01ba76a4-8547-4e1a-b2ee-2f3a4e8ab7b5" />

Functions fine with nothing in ID slot:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/ccc90ace-6bd0-41ab-9f0f-f845b8cdcc66" />

Functions fine with nothing in neck slot:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/2a69809d-061c-41d2-b230-ae709a9f58a2" />

Collar ID remains visible with Throngler in ID slot:
<img width="1394" height="834" alt="image" src="https://github.com/user-attachments/assets/4b1c1ebd-348f-476d-9121-8dd1183f7bf6" />
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Fixed error that made it impossible to examine the collar ID of someone wearing a translator in their ID slot.
