### PR TITLE
Traits For Further Reducing Crit And Dead Thresholds

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
@@ -99,3 +99,13 @@ trait-brittlebone-name = Brittle Bones
 trait-brittlebone-desc = 
     People with this genetic disorder have bones that are easily broken, often simply by moving. 
     This trait reduces your threshold for critical injury by 50%.
+
+trait-frail-name = Frail
+trait-frail-desc = 
+    Your body is unfortunately quite frail, resulting in a greater susceptibility to critical injuries
+    Your damage threshold for becoming Critical is decreased by 25%.
+
+trait-illfated-name = Ill-Fated
+trait-illfated-desc = 
+    Bad things tend to happen to you, and you'll likely die sooner than others.
+    Your damage threshold for becoming Dead is decreased by 25%.

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -561,6 +561,7 @@
   conflicts:
     - GlassJaw
     - BrittleBones
+    - Tenacity
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -582,6 +583,7 @@
   conflicts:
     - WillToDie
     - Redshirt
+    - IllFated
   effects:
   - !type:ModifyCritDeadThresholdEffect
     deadModifier: 1.05 #+5%
@@ -605,4 +607,36 @@
   effects:
   - !type:ModifyCritDeadThresholdEffect
     critModifier: 0.5 #-50%
+
+- type: trait
+  id: Frail
+  name: trait-frail-name
+  description: trait-frail-desc
+  category: Skills
+  cost: -5
+  conflicts:
+    - Tenacity
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - IPC
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    critModifier: 0.75 #-25%
+
+- type: trait
+  id: IllFated
+  name: trait-illfated-name
+  description: trait-illfated-desc
+  category: Skills
+  cost: -3
+  conflicts:
+    - WillToLive
+  effects:
+  - !type:ModifyCritDeadThresholdEffect
+    deadModifier: 0.75 #-25%
 # =================================================== #


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Created 2 new traits for reducing thresholds. These do stack with others. 
Frail: Reduces Crit threshold by 25%, gives you 5 trait points. 
Ill-fated: Reduces Dead threshold by 25%, gives you 3 trait points. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Some people really want their characters to die to a stiff breeze. So why not? Gives Medical more stuff to do. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just traits on a yml page. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
A person who would normally have the baseline thresholds, but now has both of the new traits:
<img width="657" height="363" alt="image" src="https://github.com/user-attachments/assets/7e0d15c3-ff66-481e-b27f-e6461c769770" />

A person with all of the traits that reduce Dead, but not Crit (they've hit my safeguard and had their Dead set to Crit + 0.1):
<img width="643" height="291" alt="image" src="https://github.com/user-attachments/assets/0fcc6836-c1ae-4858-a0eb-8def0f34cb38" />

A paper-thin Shadekin (all negative threshold traits on a Shadekin, so the theoretical lowest these numbers can go):
<img width="643" height="257" alt="image" src="https://github.com/user-attachments/assets/c6a30ce0-ce11-4974-a3f7-90ec087d2c13" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Two new traits for further reducing your Critical and Dead thresholds. Be even more paper-thin! Die fast!
