### PR TITLE
Unlocks Freezer

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -202,7 +202,7 @@
   suffix: Kitchen, Locked
   components:
   - type: AccessReader
-    access: [ [ "Kitchen" ] ]
+    access: [ [ "Maintenance" ] ] # Euphoria - This allows people to actually open the pathfinder freezer.
 
 # Botanist
 - type: entity


### PR DESCRIPTION
## About the PR
Sets the access of locked fridges to Maintenance access. 

## Why / Balance
We changed it before the rebase, it was just forgotten till now.
Salvage can't open the pathfinder fridge, and honestly why does a freezer need a lock.

**Changelog**
:cl:
- tweak: Changes freezers to no longer lock. (This means you can actually use the Pathfinder freezer.)