### PR TITLE
Fun Time Regents Evaporate Slower

### DIFF
--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -64,7 +64,7 @@ public abstract partial class SharedPuddleSystem
             foreach (var (reagent, factor) in reagentProportions)
             {
                 // Floofstation - ensure evaporation is at least 0.05x fast since the above expression can evaluate to 0
-                var reagentTick = FixedPoint2.Max(evaporation.EvaporationAmount * EvaporationCooldown.TotalSeconds * evaporationSpeed * factor, 0.1f);
+                var reagentTick = FixedPoint2.Max(evaporation.EvaporationAmount * EvaporationCooldown.TotalSeconds * evaporationSpeed * factor, 0.01f); // Floofstation - changed from 0.1 to 0.01
                 puddleSolution.SplitSolutionWithOnly(reagentTick, reagent);
             }
 

--- a/Resources/Prototypes/_Floof/Reagents/biological.yml
+++ b/Resources/Prototypes/_Floof/Reagents/biological.yml
@@ -65,7 +65,7 @@
     collection: FootstepSticky
     params:
       volume: 6
-  evaporationSpeed: 0.1 # evaporates on its own in time
+  evaporationSpeed: 0.01 # evaporates on its own in time, this is the limit of how slowly we can evaporate
 
 - type: reagent
   id: NaturalLubricant
@@ -91,6 +91,6 @@
   tileReactions:
   - !type:SpillTileReaction
   friction: 0.05
-  evaporationSpeed: 0.1 # evaporates on its own in time
+  evaporationSpeed: 0.01 # evaporates on its own in time, this is the limit of how slowly we can evaporate
 
 


### PR DESCRIPTION
## About the PR
they were evaporating to fast for puddles to even form

## Technical details
adjusted evaporation speed

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->