### PR TITLE
Don't Load Ghostbar in Debug

### DIFF
--- a/Content.Server/_Goobstation/Ghostbar/GhostBarSystem.cs
+++ b/Content.Server/_Goobstation/Ghostbar/GhostBarSystem.cs
@@ -57,8 +57,8 @@ public sealed class GhostBarSystem : EntitySystem
         return;
         if (_mapLoader.TryLoadMap(_mapPath, out var map, out _, new DeserializationOptions { InitializeMaps = true }))
             _mapSystem.SetPaused(map.Value.Comp.MapId, false);
-    }
         #endif // we don't want to load the ghostbar in debug
+    }
 
     public void SpawnPlayer(GhostBarSpawnEvent msg, EntitySessionEventArgs args)
     {

--- a/Content.Server/_Goobstation/Ghostbar/GhostBarSystem.cs
+++ b/Content.Server/_Goobstation/Ghostbar/GhostBarSystem.cs
@@ -52,9 +52,13 @@ public sealed class GhostBarSystem : EntitySystem
 
     private void OnRoundStart(RoundStartingEvent ev)
     {
+        // we do not want to load the ghostbar in debug
+        #if DEBUG
+        return;
         if (_mapLoader.TryLoadMap(_mapPath, out var map, out _, new DeserializationOptions { InitializeMaps = true }))
             _mapSystem.SetPaused(map.Value.Comp.MapId, false);
     }
+        #endif // we don't want to load the ghostbar in debug
 
     public void SpawnPlayer(GhostBarSpawnEvent msg, EntitySessionEventArgs args)
     {

--- a/Content.Server/_Goobstation/Ghostbar/GhostBarSystem.cs
+++ b/Content.Server/_Goobstation/Ghostbar/GhostBarSystem.cs
@@ -55,9 +55,9 @@ public sealed class GhostBarSystem : EntitySystem
         // we do not want to load the ghostbar in debug
         #if DEBUG
         return;
+        #endif
         if (_mapLoader.TryLoadMap(_mapPath, out var map, out _, new DeserializationOptions { InitializeMaps = true }))
             _mapSystem.SetPaused(map.Value.Comp.MapId, false);
-        #endif // we don't want to load the ghostbar in debug
     }
 
     public void SpawnPlayer(GhostBarSpawnEvent msg, EntitySessionEventArgs args)


### PR DESCRIPTION
## About the PR
Don't load the ghostbar in debug, can manually load it if needed.

## Why / Balance
Much like lavaland, no one really needs this to load except when working with it so why make people load it in the first place?

## Technical details
Small changes to GhostBarSystem

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->