### PR TITLE
Ignore Gamble Crate in Arbitrage Tests

### DIFF
--- a/Content.IntegrationTests/Tests/CargoTest.cs
+++ b/Content.IntegrationTests/Tests/CargoTest.cs
@@ -22,7 +22,7 @@ public sealed class CargoTest
     private static readonly HashSet<ProtoId<CargoProductPrototype>> Ignored =
     [
         // This is ignored because it is explicitly intended to be able to sell for more than it costs.
-        // new("FunCrateGambling") // DeltaV - no gambling
+        new("FunCrateGambling"), // DeltaV - no gambling - Floofstation - re-enable this to be ignored because fuck this test for throwing on this every time its ran its fishy
         new("LivestockArenaMobLarge"), // Deltav - add crate to exceptions
         new("LivestockArenaMobSmall") // Deltav - add crate to exceptions
     ];


### PR DESCRIPTION
## About the PR
I'm sick of seeing this fishy thing throw every time we have tests run

## Why / Balance
Forgor to do this when i re-enabled gamble crates from being purchased

## Technical details
re-add FunCrateGambling to the ignored list of CargoTest.cs

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [ ] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
nocl