### PR TITLE
Adds Ion repair to cables

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -43,6 +43,7 @@
         Heat: -3.22 # DeltaV was -1.66
         Shock: -3.22 # DeltaV was -1.66
         Cold: -3.22 # DeltaV
+        Ion: -5 # Euphoria - This is mostly a fix for organics with cybernetics which don't autoheal but works as a way to get someone EMP'd up faster
   # EE Change End
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/cable_coils.yml
@@ -43,7 +43,7 @@
         Heat: -3.22 # DeltaV was -1.66
         Shock: -3.22 # DeltaV was -1.66
         Cold: -3.22 # DeltaV
-        Ion: -5 # Euphoria - This is mostly a fix for organics with cybernetics which don't autoheal but works as a way to get someone EMP'd up faster
+        Ion: -3.22 # Euphoria - This is mostly a fix for organics with cybernetics which don't autoheal but works as a way to get someone EMP'd up faster
   # EE Change End
   - type: GuideHelp
     guides:


### PR DESCRIPTION
## About the PR
This PR adds Ion Damage repair to cables.

## Why / Balance
This PR aims to fix the issue which plagues cybernetics being un-repairable and unusable as organic species don't have natural ion regeneration. Also makes it so IPCs can get up from Ion damage faster should someone recover them.


**Changelog**
:cl:
- add: Added Ion damage repair to cables, you may now fix cybernetic limbs which don't naturally regenerate instead of replacing them, IPCs may also be repaired so Ion damage goes away faster. 

