### PR TITLE
Curve Research Scaling and increase Weight of Glimmer Research Theft

### DIFF
--- a/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
+++ b/Content.Server/Xenoarchaeology/Equipment/ArtifactAnalyzerSystem.cs
@@ -66,7 +66,7 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
         if (sumResearch <= 0)
             return;
 
-        _glimmerSystem.Glimmer += sumGlimmer; // DeltaV - Add glimmer based on extracted points.    
+        _glimmerSystem.Glimmer += sumGlimmer; // DeltaV - Add glimmer based on extracted points.
         _research.ModifyServerPoints(server.Value, sumResearch, serverComponent);
         _audio.PlayPvs(ent.Comp.ExtractSound, artifact.Value);
         _popup.PopupEntity(Loc.GetString("analyzer-artifact-extract-popup"), artifact.Value, PopupType.Large);
@@ -86,7 +86,8 @@ public sealed class ArtifactAnalyzerSystem : SharedArtifactAnalyzerSystem
     {
         float normalizedGlimmer = Math.Clamp(_glimmerSystem.Glimmer / 1000f, 0, 1);
         //DeltaV - Prevents extreme glimmer multipliers
-        return (float)(.5f + Math.Clamp(Math.Pow(normalizedGlimmer, 0.5f) + 1.5f * Math.Pow(normalizedGlimmer, 10f), 0f, 2.5f));
+        //Euphoria - changed formula to cap glimmer mult at 1.5 if there is 1000 glimmer. Formula makes it harder to get to max mult, but makes it reasonable to get some mult
+        return (float)((Math.Log(normalizedGlimmer + 3)/Math.Log(1.6*normalizedGlimmer+4))+((0.975*Math.Pow(normalizedGlimmer,2))/(1+normalizedGlimmer))*(1+Math.Pow(normalizedGlimmer,3))+0.20751875);
 
     }
 }

--- a/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
+++ b/Content.Server/_Floof/StationEvents/Components/GlimmerResearchStealerRuleComponent.cs
@@ -15,5 +15,5 @@ public sealed partial class GlimmerResearchStealerRuleComponent : Component
     [DataField]
     public SoundSpecifier GlimmerStealSound = new SoundPathSpecifier("/Audio/_DV/CosmicCult/ability_siphon.ogg");
     [DataField]
-    public ProtoId<RadioChannelPrototype> AnnouncementChannel = "Science";
+    public ProtoId<RadioChannelPrototype> AnnouncementChannel = "Common";
 }

--- a/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
+++ b/Resources/Prototypes/_DV/GameRules/glimmer_events.yml
@@ -240,6 +240,8 @@
   parent: BaseGlimmerEvent
   id: GlimmerResearchStealer
   components:
+  - type: StationEvent
+    weight: 17
   - type: GlimmerEvent
     minimumGlimmer: 600
     glimmerBurnLower: 25


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Science points from artifacts now scale from 1 to 1.5 using the following curve/formula.
<img width="1152" height="743" alt="EpiScaling" src="https://github.com/user-attachments/assets/3512a996-d90c-48c8-a6f9-1d8e667f87cf" />

Increased the weight for the Glimmer Research Stealer event. Made its message be broadcast through common rather than science

## Why / Balance
Epi has been using super high glimmer as a reason to speed through research as fast as possible without regard to the dangers of high glimmer. Now, if the scaling at high glimmer is much worse, and, in theory, the events should be more devastating.

## Technical details
I implemented the above equation for scaling. I also changed the weight of GlimmerResearchStealer to be 17 rather than the usual 12.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Glimmer scaling for points is now capped at 1.5, down from 2.
- tweak: Glimmer scaling gives reduced returns when approaching 1000 glimmer.
- tweak: Glimmer Research Stealer event should appear more often, and broadcast on common rather than science.
- fix: Glimmer Research Stealer event should trigger now (hopefully).
