### PR TITLE
Disable shooting while prone

### DIFF
--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -12,14 +12,13 @@ using Content.Shared.Gravity;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
-using Content.Shared.Item; // 🌟Starlight🌟
-using Content.Shared.Movement.Events; // 🌟Starlight🌟
+using Content.Shared.Movement.Events; // Starlight
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
-using Content.Shared.Weapons.Ranged.Events; // 🌟Starlight🌟
-using Content.Shared.Weapons.Ranged.Systems; // 🌟Starlight🌟
+using Content.Shared.Weapons.Ranged.Events; // Starlight
+using Content.Shared.Weapons.Ranged.Systems; // Starlight
 using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input.Binding;
@@ -43,7 +42,7 @@ public abstract partial class SharedStunSystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly StandingStateSystem _standingState = default!;
     [Dependency] private readonly IConfigurationManager _cfgManager = default!;
-    [Dependency] private readonly SharedGunSystem _gun = default!; // 🌟Starlight🌟
+    [Dependency] private readonly SharedGunSystem _gun = default!; // Starlight
     // Floofstation
     [Dependency] private readonly ClimbSystem _climb = default!;
 
@@ -62,7 +61,7 @@ public abstract partial class SharedStunSystem
         // Action blockers
         SubscribeLocalEvent<KnockedDownComponent, BuckleAttemptEvent>(OnBuckleAttempt);
         SubscribeLocalEvent<KnockedDownComponent, StandAttemptEvent>(OnStandAttempt);
-        SubscribeLocalEvent<KnockedDownComponent, ShotAttemptedEvent>(OnShootAttempt); // 🌟Starlight🌟
+        SubscribeLocalEvent<KnockedDownComponent, ShotAttemptedEvent>(OnShootAttempt); // Starlight
 
         // Updating movement and friction
         SubscribeLocalEvent<KnockedDownComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshKnockedSpeed);
@@ -610,7 +609,7 @@ public abstract partial class SharedStunSystem
             args.Cancelled = true;
     }
 
-    // 🌟Starlight🌟
+    // Starlight
     private void OnShootAttempt(Entity<KnockedDownComponent> entity, ref ShotAttemptedEvent args)
     {
         args.Cancel();

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -1,11 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Timers;
 using Content.Shared.Alert;
 using Content.Shared.Buckle.Components;
 using Content.Shared.CCVar;
 using Content.Shared.Climbing.Components;
 using Content.Shared.Climbing.Systems;
-using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
 using Content.Shared.Damage.Systems;
 using Content.Shared.Database;
@@ -14,11 +12,14 @@ using Content.Shared.Gravity;
 using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
-using Content.Shared.Movement.Events;
+using Content.Shared.Item; // 🌟Starlight🌟
+using Content.Shared.Movement.Events; // 🌟Starlight🌟
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
 using Content.Shared.Rejuvenate;
 using Content.Shared.Standing;
+using Content.Shared.Weapons.Ranged.Events; // 🌟Starlight🌟
+using Content.Shared.Weapons.Ranged.Systems; // 🌟Starlight🌟
 using Robust.Shared.Audio;
 using Robust.Shared.Configuration;
 using Robust.Shared.Input.Binding;
@@ -42,6 +43,7 @@ public abstract partial class SharedStunSystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly StandingStateSystem _standingState = default!;
     [Dependency] private readonly IConfigurationManager _cfgManager = default!;
+    [Dependency] private readonly SharedGunSystem _gun = default!; // 🌟Starlight🌟
     // Floofstation
     [Dependency] private readonly ClimbSystem _climb = default!;
 
@@ -60,6 +62,7 @@ public abstract partial class SharedStunSystem
         // Action blockers
         SubscribeLocalEvent<KnockedDownComponent, BuckleAttemptEvent>(OnBuckleAttempt);
         SubscribeLocalEvent<KnockedDownComponent, StandAttemptEvent>(OnStandAttempt);
+        SubscribeLocalEvent<KnockedDownComponent, ShotAttemptedEvent>(OnShootAttempt); // 🌟Starlight🌟
 
         // Updating movement and friction
         SubscribeLocalEvent<KnockedDownComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshKnockedSpeed);
@@ -605,6 +608,17 @@ public abstract partial class SharedStunSystem
     {
         if (args.User == entity && entity.Comp.NextUpdate > GameTiming.CurTime)
             args.Cancelled = true;
+    }
+
+    // 🌟Starlight🌟
+    private void OnShootAttempt(Entity<KnockedDownComponent> entity, ref ShotAttemptedEvent args)
+    {
+        args.Cancel();
+        if (args.Used.Comp.NextFire <= GameTiming.CurTime)
+        {
+            _popup.PopupClient(Loc.GetString("knockdown-component-shoot-fail"), entity, entity, PopupType.MediumCaution);
+            _gun.DelayFire(args.Used!, TimeSpan.FromSeconds(0.5f)); // Same time as a safety delay.
+        }
     }
 
     #endregion

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Interactions.cs
@@ -138,4 +138,14 @@ public abstract partial class SharedGunSystem
         component.NextFire = minimum;
         Dirty(uid, component);
     }
+
+    // Starlight start
+    public void DelayFire(Entity<GunComponent?> entity, TimeSpan delay)
+    {
+        if (!Resolve(entity, ref entity.Comp, logMissing: false))
+            return;
+
+        entity.Comp.NextFire = Timing.CurTime + delay;
+    }
+    // Starlight end
 }

--- a/Resources/Locale/en-US/stunnable/components/stunnable-component.ftl
+++ b/Resources/Locale/en-US/stunnable/components/stunnable-component.ftl
@@ -5,3 +5,5 @@ knockdown-component-pushup-failure = You're too exhausted to push yourself up!
 knockdown-component-pushup-success = With a burst of energy, you push yourself up with one of your free hands!
 knockdown-component-stand-no-room = You try to push yourself to stand up but there's not enough room!
 worm-component-stand-attempt = You try to stand up but you cannot!
+# Starlight
+knockdown-component-shoot-fail = This gun is too cumbersome to be fired while lying down!


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Ports Starlight's inability to shoot while prone.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Firstly: How do you mean to tell me that you can perfectly fire a whole rifle or shotgun while lying on the ground? It makes absolutely no sense. The recoil would break your shoulder in half.

Secondly: The ability to shoot while prone breaks stunlocking. Normally, you can stunlock someone by hitting them repeatedly before their doafter completes (the intended counter to this is right click yourself in harm mode to instantly get up). But if you can shoot while prone, you can just ignore that and shoot them anyway.

Thirdly: Going prone makes you incredibly hard to hit (people have to click directly on your sprite) while still leaving you full freedom of combat.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
New `SharedGunSystem.Interactions#DelayFire` method from Starlight; `SharedStunSystem.Knockdown#OnShootAttempt` handles the prevention itself.

## Media
<img width="465" height="387" alt="image" src="https://github.com/user-attachments/assets/57219f4e-a2ee-4ae7-b0b1-dea55e9cf43e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] AGPL (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-AGPLv3.txt) <!-- This one is required to contribute to Floofstation -->
  - [ ] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: DoubleHypercube
- remove: You can no longer shoot while prone.