### PR TITLE
Fix innerclothing loadout grouping

### DIFF
--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Civilian/passenger.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Civilian/passenger.yml
@@ -292,13 +292,13 @@
   id: ClothingUniformLoinClothWhite
   equipment:
     jumpsuit: ClothingUniformLoinClothWhite
-  groupBy: "lewdsuit"
+  groupBy: "loincloth"
 
 - type: loadout
   id: ClothingUniformLoinClothBlack
   equipment:
     jumpsuit: ClothingUniformLoinClothBlack
-  groupBy: "lewdsuit"
+  groupBy: "loincloth"
 
 - type: loadout
   id: ClothingUniformJumpsuitLostTourist
@@ -436,7 +436,6 @@
   id: ClothingCostumeBunnySuit
   equipment:
     jumpsuit: ClothingCostumeBunnySuit
-  groupBy: "lewdsuit"
 
 - type: loadout
   id: UniformGeisha
@@ -568,7 +567,7 @@
   id: UniformNudityPermit
   equipment:
     jumpsuit: ClothingUniformNudityPermit
-  groupBy: "lewdsuit"
+  groupBy: "nuditypermit"
 
 - type: loadout
   id:   ClothingUniformBandedDancersGarb


### PR DESCRIPTION
## About the PR
Who even thought it's a good idea to group nudity permits, loincloths, bunnysuits, and latex catsuits together? This is hell to navigate especially now that we have no search function.


**Changelog**
:cl:
- fix: In the loadouts menu, nudity permits and other utility inner clothing items are no longer grouped together with latex catsuits.