### PR TITLE
Juggsuit to Regular Uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1878,8 +1878,8 @@
   # Begin DeltaV additions - Jugsuit buy limit #5462
   #    - CommanderUplink
   #    - LoneOpUplink
-  #- !type:ListingLimitedStockCondition
-  #  stock: 1
+  - !type:ListingLimitedStockCondition
+    stock: 1
   # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1865,21 +1865,21 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts # DeltaV
   discountDownTo: # DeltaV
-    Telecrystal: 8 # Euphoria - was 12
+    Telecrystal: 12
   cost:
-    Telecrystal: 12 # DeltaV - was 12 / Euphoria - Was 20
+    Telecrystal: 20 # DeltaV - was 12
   categories:
   - UplinkWearables
-  #conditions: - Euphoria
-  #- !type:StoreWhitelistCondition
-  #  whitelist:
-  #    tags:
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
       # - NukeOpsUplink # DeltaV - Commented out as of #5462 (only commander and loneop can get suit)
   # Begin DeltaV additions - Jugsuit buy limit #5462
-  #    - CommanderUplink
-  #    - LoneOpUplink
-  #- !type:ListingLimitedStockCondition
-  #  stock: 1
+      - CommanderUplink
+      - LoneOpUplink
+  - !type:ListingLimitedStockCondition
+    stock: 1
   # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1870,7 +1870,7 @@
     Telecrystal: 12 # DeltaV - was 12 / Euphoria - was 20
   categories:
   - UplinkWearables
-  #conditions:
+  conditions:
   #- !type:StoreWhitelistCondition
   #  whitelist:
   #    tags:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1865,21 +1865,21 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts # DeltaV
   discountDownTo: # DeltaV
-    Telecrystal: 12
+    Telecrystal: 8 # Euphoria - was 12
   cost:
-    Telecrystal: 20 # DeltaV - was 12
+    Telecrystal: 12 # DeltaV - was 12 / Euphoria - was 20
   categories:
   - UplinkWearables
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
+  #conditions:
+  #- !type:StoreWhitelistCondition
+  #  whitelist:
+  #    tags:
       # - NukeOpsUplink # DeltaV - Commented out as of #5462 (only commander and loneop can get suit)
   # Begin DeltaV additions - Jugsuit buy limit #5462
-      - CommanderUplink
-      - LoneOpUplink
-  - !type:ListingLimitedStockCondition
-    stock: 1
+  #    - CommanderUplink
+  #    - LoneOpUplink
+  #- !type:ListingLimitedStockCondition
+  #  stock: 1
   # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1865,21 +1865,21 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts # DeltaV
   discountDownTo: # DeltaV
-    Telecrystal: 12
+    Telecrystal: 8 # Euphoria - was 12
   cost:
-    Telecrystal: 20 # DeltaV - was 12
+    Telecrystal: 12 # DeltaV - was 12 / Euphoria - Was 20
   categories:
   - UplinkWearables
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
+  #conditions: - Euphoria
+  #- !type:StoreWhitelistCondition
+  #  whitelist:
+  #    tags:
       # - NukeOpsUplink # DeltaV - Commented out as of #5462 (only commander and loneop can get suit)
   # Begin DeltaV additions - Jugsuit buy limit #5462
-      - CommanderUplink
-      - LoneOpUplink
-  - !type:ListingLimitedStockCondition
-    stock: 1
+  #    - CommanderUplink
+  #    - LoneOpUplink
+  #- !type:ListingLimitedStockCondition
+  #  stock: 1
   # End DeltaV additions
 
 - type: listing


### PR DESCRIPTION
## About the PR
This PR brings the Jugg suit back to the normal uplink at the original pre-rebase price. (the discount pre-rebase was 5 but I made it 8 so it wouldn't be too cheap)

## Why / Balance
Adds more power to syndicates and honestly, don't see the suit anymore.

**Changelog**
:cl:
- tweak: Bought Juggernaut suit back to normal syndicate uplinks and lowered to pre-rebase prices.
