### PR TITLE
Hostage Bundle to Regular Uplink

### DIFF
--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1865,21 +1865,21 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts # DeltaV
   discountDownTo: # DeltaV
-    Telecrystal: 8 # Euphoria - was 12
+    Telecrystal: 12
   cost:
-    Telecrystal: 12 # DeltaV - was 12 / Euphoria - Was 20
+    Telecrystal: 20 # DeltaV - was 12
   categories:
   - UplinkWearables
-  #conditions: - Euphoria
-  #- !type:StoreWhitelistCondition
-  #  whitelist:
-  #    tags:
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
       # - NukeOpsUplink # DeltaV - Commented out as of #5462 (only commander and loneop can get suit)
   # Begin DeltaV additions - Jugsuit buy limit #5462
-  #    - CommanderUplink
-  #    - LoneOpUplink
-  #- !type:ListingLimitedStockCondition
-  #  stock: 1
+      - CommanderUplink
+      - LoneOpUplink
+  - !type:ListingLimitedStockCondition
+    stock: 1
   # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1865,21 +1865,21 @@
   productEntity: CrateCybersunJuggernautBundle
   discountCategory: veryRareDiscounts # DeltaV
   discountDownTo: # DeltaV
-    Telecrystal: 12
+    Telecrystal: 8 # Euphoria - was 12
   cost:
-    Telecrystal: 20 # DeltaV - was 12
+    Telecrystal: 12 # DeltaV - was 12 / Euphoria - Was 20
   categories:
   - UplinkWearables
-  conditions:
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
+  #conditions: - Euphoria
+  #- !type:StoreWhitelistCondition
+  #  whitelist:
+  #    tags:
       # - NukeOpsUplink # DeltaV - Commented out as of #5462 (only commander and loneop can get suit)
   # Begin DeltaV additions - Jugsuit buy limit #5462
-      - CommanderUplink
-      - LoneOpUplink
-  - !type:ListingLimitedStockCondition
-    stock: 1
+  #    - CommanderUplink
+  #    - LoneOpUplink
+  #- !type:ListingLimitedStockCondition
+  #  stock: 1
   # End DeltaV additions
 
 - type: listing

--- a/Resources/Prototypes/_DV/Catalog/Uplink/implants.yml
+++ b/Resources/Prototypes/_DV/Catalog/Uplink/implants.yml
@@ -48,10 +48,10 @@
     blacklist:
       components:
       - SurplusBundle
-  - !type:StoreWhitelistCondition
-    whitelist:
-      tags:
-      - NukeOpsUplink
+  #- !type:StoreWhitelistCondition # Euphoria - More Hostages
+  #  whitelist:
+  #    tags:
+  #    - NukeOpsUplink
 
 - type: listing
   id: NukeopsUplinkUplinkImplanter


### PR DESCRIPTION
## About the PR
Makes the Hostage Bundle no longer Nuke Ops only.

## Why / Balance
Enables more hostage roleplay.

**Changelog**
:cl:
- tweak: Enabled hostage implanter in regular uplinks.
