### PR TITLE
Global Ghost Hearing Removal and Subtle Protection Fix

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Floofstation.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Floofstation.cs
@@ -79,6 +79,10 @@ public sealed partial class ChatSystem
     {
         foreach (var (session, data) in GetRecipients(source, WhisperClearRange))
         {
+            //Blocks non-admin ghosts from seeing subtle
+            if (!data.Subtle)
+                continue;
+
             if (session.AttachedEntity is not { Valid: true } listener)
                 continue;
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -970,12 +970,10 @@ public sealed partial class ChatSystem : SharedChatSystem
             // Floofstation edit end
 
             // even if they are a ghost hearer, in some situations we still need the range
-            if (distance < voiceGetRange)
+            if (distance < voiceGetRange && !observer)
             {
-                if (isDead && !observer)
-                    recipients.Add(player, new ICChatRecipientData(distance, observer, Subtle: false, InLOS: isVisible));
-                else
-                    recipients.Add(player, new ICChatRecipientData(distance, observer, InLOS: isVisible));
+                // Euphoria | Hide Subtle from Non-Admin Ghosts
+                recipients.Add(player, new ICChatRecipientData(distance, observer, Subtle: !isDead, InLOS: isVisible));
                 continue;
             }
 

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -961,6 +961,7 @@ public sealed partial class ChatSystem : SharedChatSystem
                 continue;
 
             var observer = ghostHearing.HasComponent(playerEntity);
+            var isDead = HasComp<GhostComponent>(playerEntity);
 
             // Floofstation edit - check LOS
             sourceCoords.TryDistance(EntityManager, transformEntity.Coordinates, out var distance);
@@ -971,7 +972,10 @@ public sealed partial class ChatSystem : SharedChatSystem
             // even if they are a ghost hearer, in some situations we still need the range
             if (distance < voiceGetRange)
             {
-                recipients.Add(player, new ICChatRecipientData(distance, observer, InLOS: isVisible));
+                if (isDead && !observer)
+                    recipients.Add(player, new ICChatRecipientData(distance, observer, Subtle: false, InLOS: isVisible));
+                else
+                    recipients.Add(player, new ICChatRecipientData(distance, observer, InLOS: isVisible));
                 continue;
             }
 
@@ -984,7 +988,7 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // Floofstation: add inLOS
-    public readonly record struct ICChatRecipientData(float Range, bool Observer, bool? HideChatOverride = null, bool InLOS = true)
+    public readonly record struct ICChatRecipientData(float Range, bool Observer, bool? HideChatOverride = null, bool Subtle = true, bool InLOS = true)
     {
     }
 

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -240,7 +240,9 @@ namespace Content.Server.Ghost
         private void OnMapInit(EntityUid uid, GhostComponent component, MapInitEvent args)
         {
             _actions.AddAction(uid, ref component.BooActionEntity, component.BooAction);
-            //_actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
+            //Euphoria | Ghost hearing toggle action for admins only
+            if (HasComp<GhostHearingComponent>(uid))
+                _actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
             _actions.AddAction(uid, ref component.ToggleLightingActionEntity, component.ToggleLightingAction);
             _actions.AddAction(uid, ref component.ToggleFoVActionEntity, component.ToggleFoVAction);
             _actions.AddAction(uid, ref component.ToggleGhostsActionEntity, component.ToggleGhostsAction);

--- a/Content.Server/Ghost/GhostSystem.cs
+++ b/Content.Server/Ghost/GhostSystem.cs
@@ -240,7 +240,7 @@ namespace Content.Server.Ghost
         private void OnMapInit(EntityUid uid, GhostComponent component, MapInitEvent args)
         {
             _actions.AddAction(uid, ref component.BooActionEntity, component.BooAction);
-            _actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
+            //_actions.AddAction(uid, ref component.ToggleGhostHearingActionEntity, component.ToggleGhostHearingAction);
             _actions.AddAction(uid, ref component.ToggleLightingActionEntity, component.ToggleLightingAction);
             _actions.AddAction(uid, ref component.ToggleFoVActionEntity, component.ToggleFoVAction);
             _actions.AddAction(uid, ref component.ToggleGhostsActionEntity, component.ToggleGhostsAction);

--- a/Resources/Prototypes/Entities/Mobs/Player/observer.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/observer.yml
@@ -98,7 +98,7 @@
       Poison: 1
       Asphyxiation: 1
     prefix: "ghost_"
-  - type: GhostHearing
+  # - type: GhostHearing # Euphoria | Global hearing off by default
   - type: ShowElectrocutionHUD
   - type: IntrinsicRadioReceiver
   - type: ActiveRadio


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->

- Removes global hearing from non-admin observers. Their hearing now follows line of sight and range rules.
- Prevents non-admin observers from seeing subtle at all.

This change protects subtle messages they way they were intended to be, and also allows for the establishing of public ERP zones without blasting every ghost with raunchy messages.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

https://github.com/user-attachments/assets/e736cc08-ef20-4017-b3a4-abeca2e810bc

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- remove: Non-admin observers no longer have global hearing.
- fix: Non-admin observers can no longer see subtle messages at any range.
