### PR TITLE
Tweaks and fixes

### DIFF
--- a/Content.Shared/_Floof/CCVar/FloofCCVars.Leash.cs
+++ b/Content.Shared/_Floof/CCVar/FloofCCVars.Leash.cs
@@ -8,5 +8,5 @@ public sealed partial class FloofCCVars
     ///     Client-only, defines whether the client should predict leash joints.
     /// </summary>
     public static readonly CVarDef<bool> PredictLeashes =
-        CVarDef.Create("leash.predict", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+        CVarDef.Create("leash.predict", true, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/_Floof/Leash/LeashSystem.ContainerWorkarounds.cs
+++ b/Content.Shared/_Floof/Leash/LeashSystem.ContainerWorkarounds.cs
@@ -7,25 +7,29 @@ public sealed partial class LeashSystem
 {
     private void InitializeContainerWorkarounds()
     {
-        SubscribeLocalEvent<LeashedComponent, EntGotInsertedIntoContainerMessage>(OnLeashedContainerChanged);
-        SubscribeLocalEvent<LeashedComponent, EntGotRemovedFromContainerMessage>(OnLeashedContainerChanged);
-
-        SubscribeLocalEvent<LeashComponent, EntGotInsertedIntoContainerMessage>(OnLeashContainerChanged);
-        SubscribeLocalEvent<LeashComponent, EntGotRemovedFromContainerMessage>(OnLeashContainerChanged);
+        // This doesn't really work because if the parent of the leash holder changes, we won't be notified
+        // I don't want to add another component just for the leash holder (lazy), so i just made these checks be performed on each tick
+        // They are pretty cheap anyway
+        //
+        // SubscribeLocalEvent<LeashedComponent, EntGotInsertedIntoContainerMessage>(OnLeashedContainerChanged);
+        // SubscribeLocalEvent<LeashedComponent, EntGotRemovedFromContainerMessage>(OnLeashedContainerChanged);
+        //
+        // SubscribeLocalEvent<LeashComponent, EntGotInsertedIntoContainerMessage>(OnLeashContainerChanged);
+        // SubscribeLocalEvent<LeashComponent, EntGotRemovedFromContainerMessage>(OnLeashContainerChanged);
     }
 
     // Note: we can't use the Entity<T> handler here because it doesn't support polymorphism
-    private void OnLeashedContainerChanged(EntityUid ent, LeashedComponent comp, ContainerModifiedMessage args)
-    {
-        // TODO: this method refreshes all leashes instead of just the one that changed.
-        // This doesn't matter much because most leashes can only create 1 joint, but look into fixing this.
-        if (!_net.IsClient && GetEntity(comp.Leash) is { } leashEnt && TryComp<LeashComponent>(leashEnt, out var leash))
-            RefreshJoints((leashEnt, leash));
-    }
-
-    private void OnLeashContainerChanged(EntityUid ent, LeashComponent comp, ContainerModifiedMessage args)
-    {
-        if (!_net.IsClient)
-            RefreshJoints((ent, comp));
-    }
+    // private void OnLeashedContainerChanged(EntityUid ent, LeashedComponent comp, ContainerModifiedMessage args)
+    // {
+    //     // TODO: this method refreshes all leashes instead of just the one that changed.
+    //     // This doesn't matter much because most leashes can only create 1 joint, but look into fixing this.
+    //     if (!_net.IsClient && GetEntity(comp.Leash) is { } leashEnt && TryComp<LeashComponent>(leashEnt, out var leash))
+    //         RefreshJoints((leashEnt, leash));
+    // }
+    //
+    // private void OnLeashContainerChanged(EntityUid ent, LeashComponent comp, ContainerModifiedMessage args)
+    // {
+    //     if (!_net.IsClient)
+    //         RefreshJoints((ent, comp));
+    // }
 }

--- a/Content.Shared/_Floof/Leash/LeashSystem.Joints.cs
+++ b/Content.Shared/_Floof/Leash/LeashSystem.Joints.cs
@@ -90,7 +90,7 @@ public sealed partial class LeashSystem
                           && leashXform.Coordinates.TryDistance(EntityManager, leashedXform.Coordinates, out var dst)
                           && dst <= leash.Comp.MaxDistance;
             // The anchor must be either the entity itself or something parented to them (clothing)
-            canRestore &= anchor.Owner == leashed.Owner || _container.ContainsEntity(leashed, anchor);
+            canRestore &= anchor.Owner == leashed.Owner || _xform.ContainsEntity(leashed, anchor.Owner);
         }
 
         RemoveLeash(leashed!, leash!, false);

--- a/Content.Shared/_Floof/Leash/LeashSystem.cs
+++ b/Content.Shared/_Floof/Leash/LeashSystem.cs
@@ -80,6 +80,8 @@ public sealed partial class LeashSystem : EntitySystem
             foreach (var data in leash.Leashed.ToList())
                 UpdateLeash(data, sourceXForm, leash, leashEnt);
 
+            // I give up. Just do the refresh on each tick and pray for the best.
+            RefreshJoints((leashEnt, leash));
             RefreshRelays((leashEnt, leash, sourceXForm));
         }
         leashQuery.Dispose();
@@ -114,13 +116,15 @@ public sealed partial class LeashSystem : EntitySystem
         {
             RemoveLeash(target.Value, (leashEnt, leash));
             _popups.PopupEntity(Loc.GetString("leash-snap-popup", ("leash", leashEnt)), target.Value);
+            return;
         }
 
         // Server: update leash lengths if necessary/possible
         // The length can be increased freely, but can only be decreased if the pulled entity is close enough
-        // TODO this never worked and probably because of joint.Length not actually containing the length between the entities
-        if (joint is not null && joint.MaxLength > leash.Length && joint.Length < joint.MaxLength)
-            joint.MaxLength = Math.Max(joint.Length, leash.Length);
+        // NOTE: joint.length is the NATURAL distance between bodies, to which they gravitate. Joint.MaxLength is the MAXIMUM distance (at which positions are clamped)
+        // We do not care about joint.length as leash joints are supposed to allow entities to freely come closer/further within the leash length.
+        if (joint is not null && joint.MaxLength > leash.Length && dst < joint.MaxLength)
+            joint.MaxLength = Math.Max(dst, leash.Length);
 
         if (joint is not null && joint.MaxLength < leash.Length)
             joint.MaxLength = leash.Length;
@@ -435,6 +439,8 @@ public sealed partial class LeashSystem : EntitySystem
     public void SetLeashLength(Entity<LeashComponent> leash, float length)
     {
         leash.Comp.Length = length;
+        Dirty(leash);
+
         RefreshJoints(leash);
         _popups.PopupPredicted(Loc.GetString("leash-set-length-popup", ("length", length)), leash.Owner, null);
 

--- a/Content.Shared/_Floof/Popup/PopUpOnUseComponent.cs
+++ b/Content.Shared/_Floof/Popup/PopUpOnUseComponent.cs
@@ -31,6 +31,12 @@ public sealed partial class PopUpOnUseComponent : Component
     [DataField, AutoNetworkedField]
     public TimeSpan PopUpDoAfterTime = TimeSpan.Zero;
 
+    /// <summary>
+    /// Whether to repeat the do-after.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Repeat = false;
+
     // Used to cancel the played sound.
     public EntityUid? AudioStream;
 

--- a/Content.Shared/_Floof/Popup/PopUpOnUseSystem.cs
+++ b/Content.Shared/_Floof/Popup/PopUpOnUseSystem.cs
@@ -44,7 +44,12 @@ public sealed class PopUpOnUseSystem : EntitySystem
             ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.PopUpDoAfterSound, ent)?.Entity;
         }
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.PopUpDoAfterTime, new PopUpOnUseDoAfterEvent(), ent, args.Target.Value, ent);
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.PopUpDoAfterTime, new PopUpOnUseDoAfterEvent(), ent, args.Target.Value, ent)
+        {
+            BreakOnDamage = true,
+            BreakOnHandChange = true,
+            NeedHand = true,
+        };
         _doAfter.TryStartDoAfter(doAfterArgs);
 
         args.Handled = true;
@@ -60,12 +65,14 @@ public sealed class PopUpOnUseSystem : EntitySystem
         if (args.Target == null)
             return;
 
+        // For some reason, no one but the user can predict the do-after. Oh well.
         var locKey = args.Target == args.User ? ent.Comp.UserPopUpMsg : ent.Comp.TargetPopUpMsg;
-        _popup.PopupClient(
+        _popup.PopupPredicted(
             Loc.GetString(locKey,
                 ("target", Identity.Entity(args.Target.Value, EntityManager)),
                 ("user", Identity.Entity(args.User, EntityManager)),
                 ("used", Identity.Entity(args.Used ?? EntityUid.Invalid, EntityManager))),
+            args.User,
             args.User);
 
         if (ent.Comp.Repeat)

--- a/Content.Shared/_Floof/Popup/PopUpOnUseSystem.cs
+++ b/Content.Shared/_Floof/Popup/PopUpOnUseSystem.cs
@@ -16,32 +16,35 @@ public sealed class PopUpOnUseSystem : EntitySystem
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelist = default!;
 
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<PopUpOnUseComponent, AfterInteractEvent>(OnAfterInteract);
+        SubscribeLocalEvent<PopUpOnUseComponent, PopUpOnUseDoAfterEvent>(OnDoAfter);
+    }
+
     // Whitelist what we can and can't use these items on (no using this stuff on a wall smh)
     // Thank you, Fox, for the help getting the whitelist working
     public bool CanUse(Entity<PopUpOnUseComponent> ent, EntityUid target) =>
         _whitelist.IsWhitelistPass(ent.Comp.Whitelist, target) &&
         !_whitelist.IsWhitelistPass(ent.Comp.Blacklist, target);
 
-    public override void Initialize()
-      {
-          SubscribeLocalEvent<PopUpOnUseComponent, AfterInteractEvent>(OnAfterInteract);
-          SubscribeLocalEvent<PopUpOnUseComponent, PopUpOnUseDoAfterEvent>(OnDoAfter);
-      }
-
     private void OnAfterInteract(Entity<PopUpOnUseComponent> ent, ref AfterInteractEvent args)
     {
         if (!args.Target.HasValue || !args.CanReach)
             return;
 
-        if (_net.IsServer) // Cannot cancel predicted audio.
-            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.PopUpDoAfterSound, ent)?.Entity;
-
-        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.PopUpDoAfterTime, new PopUpOnUseDoAfterEvent(), ent, args.Target.Value, ent);
-
         // Check if the entitiy the item will be used on is blacklisted, if it is return
         if (!CanUse(ent, args.Target.Value))
             return;
 
+        if (_net.IsServer)
+        {
+            // Cannot cancel predicted audio.
+            _audio.Stop(ent.Comp.AudioStream);
+            ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.PopUpDoAfterSound, ent)?.Entity;
+        }
+
+        var doAfterArgs = new DoAfterArgs(EntityManager, args.User, ent.Comp.PopUpDoAfterTime, new PopUpOnUseDoAfterEvent(), ent, args.Target.Value, ent);
         _doAfter.TryStartDoAfter(doAfterArgs);
 
         args.Handled = true;
@@ -57,12 +60,22 @@ public sealed class PopUpOnUseSystem : EntitySystem
         if (args.Target == null)
             return;
 
+        var locKey = args.Target == args.User ? ent.Comp.UserPopUpMsg : ent.Comp.TargetPopUpMsg;
         _popup.PopupClient(
-            Loc.GetString(args.Target == args.User ? ent.Comp.UserPopUpMsg : ent.Comp.TargetPopUpMsg,
+            Loc.GetString(locKey,
                 ("target", Identity.Entity(args.Target.Value, EntityManager)),
-                ("user", Identity.Entity(args.User, EntityManager))),
-            args.User,
+                ("user", Identity.Entity(args.User, EntityManager)),
+                ("used", Identity.Entity(args.Used ?? EntityUid.Invalid, EntityManager))),
             args.User);
+
+        if (ent.Comp.Repeat)
+        {
+            args.Repeat = true;
+            // On the server side, repeat the sound
+            if (_net.IsServer)
+                ent.Comp.AudioStream = _audio.PlayPvs(ent.Comp.PopUpDoAfterSound, ent)?.Entity;
+        }
+
         args.Handled = true;
     }
 }

--- a/Resources/Locale/en-US/_Floof/popuponuse/brush.ftl
+++ b/Resources/Locale/en-US/_Floof/popuponuse/brush.ftl
@@ -1,2 +1,2 @@
-﻿self-brushing-success = You brush your self with a comb.
-target-brushing-success = {THE($user)} brushes {THE($target)}.
+﻿self-brushing-success = You brush your self with {THE($used)}.
+target-brushing-success = {THE($user)} brushes {THE($target)} with {THE($used)}.

--- a/Resources/Prototypes/_Floof/Entities/Objects/Misc/brush.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Misc/brush.yml
@@ -12,6 +12,7 @@
     popUpDoAfterTime: 3
     userPopUpMsg: self-brushing-success
     targetPopUpMsg: target-brushing-success
+    repeat: true
     whitelist:
       components:
         - MobState

--- a/Resources/Prototypes/_Floof/Entities/Objects/Misc/brush.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Misc/brush.yml
@@ -12,6 +12,12 @@
     popUpDoAfterTime: 3
     userPopUpMsg: self-brushing-success
     targetPopUpMsg: target-brushing-success
+    popUpDoAfterSound:
+      path: /Audio/Items/wirebrushing.ogg # Same as wirebrush
+      params:
+        volume: -5
+        variation: 0.05
+        maxDistance: 4
     repeat: true
     whitelist:
       components:

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/trinkets.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/trinkets.yml
@@ -48,6 +48,7 @@
   - FlippableCoinPlasma
   - CombBrush
   - HairBrush
+  - ClothingMaskMuzzle
 
 - type: loadoutGroup
   id: SexToys

--- a/Resources/Prototypes/_Floof/Loadouts/Miscellaneous/trinkets.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Miscellaneous/trinkets.yml
@@ -132,3 +132,9 @@
     back:
     - HairBrush
   groupBy: "Brushes"
+
+- type: loadout
+  id: ClothingMaskMuzzle
+  storage:
+    back:
+    - ClothingMaskMuzzle


### PR DESCRIPTION
## About the PR
Hairbrushes:
- Now correctly display the popups
- Now have a sound (same sound as wirebrushes, but quieter and limited in distance)
- Now have a repeating do-after

Leashes:
- Changing leash length now correctly dirties the leash (used to cause bugs with leash prediction enabled)
- Fixed a bug that triggered an ancient engine bug that caused containers containing both the leash and the leashed entities to become immovable
- When the leash is made shorter, the actual joint only changes maxLength when the entities are close enough. There was a bug preventing it from working.
- Are now predicted by default (there's a command to toggle leash prediction)

Loadouts: added a muzzle to the trinkets group (requested by @Dunrab)

## Technical details

PopupOnUse:
- Added a "repeat" field to the component
- Cleaned up the code and fixed a minor bug with audio
- Changed the popup call from PopupClient to PopupPredicted ||(for some reason the do-after event is only predicted on the side of the user? why does the system even bother serializing shit then if the only client who's going to see it already predicts the StartDoAfter call??)||

Leash system:
- Now RefreshJoints() is called on every tick instead of whenever leash/leashed are moved in/out of containers. There's no way to make the old approach work other besides making a marker component for the leash holder, which i frankly don't want to bother doing. This will increase the performance cost of the system, but not by much. If the leash system becomes a performance hog however, we will have to do that (and in process change how/when the system performs joint relay refreshes)
- For years i thought that Joint.Length is the current length of the joint. I was wrong. It's the natural length which the joint tries by exerting finite force. MaxLength and MinLength are distance ranges in which entity coordinates are clamped with infinite force. T## About the PR
Hairbrushes:
- Now correctly display the popups
- Now have a sound (same sound as wirebrushes, but quieter and limited in distance)
- Now have a repeating do-after

Leashes:
- Changing leash length now correctly dirties the leash (used to cause bugs with leash prediction enabled)
- Fixed a bug that triggered an ancient engine bug that caused containers containing both the leash and the leashed entities to become immovable
- When the leash is made shorter, the actual joint only changes maxLength when the entities are close enough. There was a bug preventing it from working.
- Are now predicted by default (there's a command to toggle leash prediction)

Loadouts: added a muzzle to the trinkets group (requested by @Dunrab)

## Technical details

PopupOnUse:
- Added a "repeat" field to the component
- Cleaned up the code and fixed a minor bug with audio
- Changed the popup call from PopupClient to PopupPredicted ||(for some reason the do-after event is only predicted on the side of the user? why does the system even bother serializing shit then if the only client who's going to see it already predicts the StartDoAfter call??)||

Leash system:
- Now RefreshJoints() is called on every tick instead of whenever leash/leashed are moved in/out of containers. There's no way to make the old approach work other besides making a marker component for the leash holder, which i frankly don't want to bother doing. This will increase the performance cost of the system, but not by much. If the leash system becomes a performance hog however, we will have to do that (and in process change how/when the system performs joint relay refreshes)
- For years i thought that Joint.Length is the current length of the joint. I was wrong. It's the natural length which the joint tries by exerting finite force. MaxLength and MinLength are distance ranges in which entity coordinates are clamped with infinite force. The only reason joint.Length doesn't matter in our case is that leash joints have zero force.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

Compression go brrrrrr

https://github.com/user-attachments/assets/00a9cca3-2d33-4ef9-a492-f8b10eafc234

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Putting a leashed entity and the leash in the same container should no longer make the container immovable. This includes the space dragon which would sometimes get stuck due to this.
- fix: When the length of a leash is shortened, the "rope" will only get shorter when the leashed entity comes close enough - as opposed to changing instantly and forcing it to come closer. Also other players should now correctly see length changes.
- tweak: Leash prediction is now enabled by default. This should make leash physics visually better. You can still toggle this using the /leashpredict command.
- he only reason joint.Length doesn't matter in our case is that leash joints have zero force.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

Compression go brrrrrr

https://github.com/user-attachments/assets/00a9cca3-2d33-4ef9-a492-f8b10eafc234

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- fix: Putting a leashed entity and the leash in the same container should no longer make the container immovable. This includes the space dragon which would sometimes get stuck due to this.
- fix: When the length of a leash is shortened, the "rope" will only get shorter when the leashed entity comes close enough - as opposed to changing instantly and forcing it to come closer. Also other players should now correctly see length changes.
- tweak: Leash prediction is now enabled by default. This should make leash physics visually better. You can still toggle this using the /leashpredict command.
- tweak: Hairbrushes now make sound when used, and their do-after automatically repeats.
- fix: The popup from hairbrushes should now show correctly for other players.
- tweak: Muzzles are now available as loadout trinkets.