### PR TITLE
Move large objects out of the atlas

### DIFF
--- a/Resources/Textures/_DV/CosmicCult/Mobs/cosmicgod.rsi/meta.json
+++ b/Resources/Textures/_DV/CosmicCult/Mobs/cosmicgod.rsi/meta.json
@@ -6,6 +6,7 @@
     },
     "license": "CC-BY-SA-3.0",
     "copyright": "A custom item by AftrLite (Github).",
+    "metaAtlas": false,
     "states": [
         {
             "name": "god",

--- a/Resources/Textures/_DV/CosmicCult/Tileset/monument.rsi/meta.json
+++ b/Resources/Textures/_DV/CosmicCult/Tileset/monument.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 96,
         "y": 96
     },
+    "metaAtlas": false,
     "states": [
         {
             "name": "stage1-spawnin",

--- a/Resources/Textures/_FarHorizons/Structures/Power/Generation/FissionGenerator/nuclear_reactor.rsi/meta.json
+++ b/Resources/Textures/_FarHorizons/Structures/Power/Generation/FissionGenerator/nuclear_reactor.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 160,
         "y": 160
     },
+    "metaAtlas": false,
     "states": [
         {
             "name": "reactor",

--- a/Resources/Textures/_FarHorizons/Structures/Power/Generation/FissionGenerator/turbine.rsi/meta.json
+++ b/Resources/Textures/_FarHorizons/Structures/Power/Generation/FissionGenerator/turbine.rsi/meta.json
@@ -6,6 +6,7 @@
         "x": 96,
         "y": 160
     },
+    "metaAtlas": false,
     "states": [
         {
             "name": "static",


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Moves the Cosmic God, Cosmic Monument, and Reactor/Turbine out of the atlas.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
These are walrii and take up huge amounts of space on the atlas for no reason. Similarly large sprites (Ratvar, Nar'sie, the Singularity etc) are `"metaAtlas": false` in their RSI meta. This PR adds said field to the aforementioned walrii.

I would have shrunk the Cosmic God (because it's the biggest of the four) but the sprite is 255x260 so the smallest clean divisor is 5, which is far too small and would lose significant detail.
## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: DoubleHypercube
- tweak: Dewalrussed the sprite atlas.