### PR TITLE
New Blood Reagent Traits + Shadekin Blood Tweak

### DIFF
--- a/Resources/Locale/en-US/_Euphoria/reagents/meta/biological.ftl
+++ b/Resources/Locale/en-US/_Euphoria/reagents/meta/biological.ftl
@@ -1,2 +1,8 @@
 reagent-name-yellow-blood = yellow blood
 reagent-desc-yellow-blood = But why is it yellow?
+
+reagent-name-black-blood = black blood
+reagent-desc-black-blood = This definitely isn't ketchup.
+
+reagent-name-white-blood = white blood
+reagent-desc-white-blood = You might be able to pretend it's milk as long as you don't look at it too hard.

--- a/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
+++ b/Resources/Locale/en-US/_Euphoria/traits/physical.ftl
@@ -5,6 +5,8 @@ trait-replace-blood-insect-name = Blood: Insect
 trait-replace-blood-sap-name = Blood: Sap
 trait-replace-blood-slime-name = Blood: Slime
 trait-replace-blood-yellow-name = Blood: Yellow
+trait-replace-blood-black-name = Blood: Black
+trait-replace-blood-white-name = Blood: White
 trait-blood-desc = Your blood is unusual for your species. This doesn't affect what medicines work on you.
 
 trait-healing-minus-name = Regeneration: Compromised

--- a/Resources/Prototypes/GameRules/variation.yml
+++ b/Resources/Prototypes/GameRules/variation.yml
@@ -120,6 +120,8 @@
     - AmmoniaBlood
     - Sap
     - YellowBlood
+    - BlackBlood
+    - WhiteBlood
     # Euphoria end
   - quantity: 25
     weight: 1

--- a/Resources/Prototypes/XenoArch/triggers.yml
+++ b/Resources/Prototypes/XenoArch/triggers.yml
@@ -259,7 +259,11 @@
     - AmmoniaBlood
     - ZombieBlood
     - Sap
-    - YellowBlood # Euphoria: Add yellow blood.
+# Euphoria Start: Adds new blood types to triggers.
+    - YellowBlood
+    - BlackBlood
+    - WhiteBlood
+# Euphoria End
 
 - type: xenoArchTrigger
   id: TriggerThrow

--- a/Resources/Prototypes/_DV/Entities/Effects/puddles.yml
+++ b/Resources/Prototypes/_DV/Entities/Effects/puddles.yml
@@ -22,7 +22,11 @@
     - AmmoniaBlood
     - Ichor
     - SynthBlood
-    - YellowBlood # Euphoria: Add more blood variants to random tables
+    # Euphoria start: Add more blood variants to random tables
+    - YellowBlood
+    - BlackBlood
+    - WhiteBlood
+    #Euphoria end
 
 - type: entity
   id: PuddleRandomDrinks

--- a/Resources/Prototypes/_Euphoria/Reagents/biological.yml
+++ b/Resources/Prototypes/_Euphoria/Reagents/biological.yml
@@ -6,4 +6,44 @@
   group: Biological
   desc: reagent-desc-yellow-blood
   color: "#ffc900"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/bloodglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
   recognizable: true
+
+- type: reagent
+  parent: Blood
+  id: BlackBlood
+  name: reagent-name-black-blood
+  group: Biological
+  desc: reagent-desc-black-blood
+  flavor: bitter
+  color: "#1c1624"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/bloodglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
+  recognizable: true
+  physicalDesc: reagent-physical-desc-inky
+
+- type: reagent
+  parent: Blood
+  id: WhiteBlood
+  name: reagent-name-white-blood
+  group: Biological
+  desc: reagent-desc-white-blood
+  flavor: strange
+  color: "#EFEFEF"
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/bloodglass.rsi
+    state: icon_empty
+  metamorphicMaxFillLevels: 5
+  metamorphicFillBaseName: fill-
+  metamorphicChangeColor: true
+  recognizable: true
+  physicalDesc: reagent-physical-desc-milky

--- a/Resources/Prototypes/_Euphoria/Reagents/biological.yml
+++ b/Resources/Prototypes/_Euphoria/Reagents/biological.yml
@@ -21,7 +21,7 @@
   group: Biological
   desc: reagent-desc-black-blood
   flavor: bitter
-  color: "#1c1624"
+  color: "#161624"
   metamorphicSprite:
     sprite: Objects/Consumable/Drinks/bloodglass.rsi
     state: icon_empty

--- a/Resources/Prototypes/_Euphoria/Recipes/Reactions/biological.yml
+++ b/Resources/Prototypes/_Euphoria/Recipes/Reactions/biological.yml
@@ -12,3 +12,31 @@
     Sugar: 2
     CarbonDioxide: 3
     Protein: 4
+
+- type: reaction
+  id: BlackBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    BlackBlood:
+      amount: 30
+  products:
+    Water: 17
+    Nitrogen: 4.5
+    Chlorine: 2.5
+    Protein: 6
+
+- type: reaction
+  id: WhiteBloodBreakdown
+  source: true
+  requiredMixerCategories:
+  - Centrifuge
+  reactants:
+    WhiteBlood:
+      amount: 30
+  products:
+    Water: 17
+    Nitrogen: 4.5
+    Chlorine: 2.5
+    Protein: 6

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -13,6 +13,8 @@
   - ReplaceBloodSap
   - ReplaceBloodSlime
   - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -27,6 +29,7 @@
     - Resomi #AmmoniaBlood
     - SlimePerson #Slime
     - Vox #AmmoniaBlood
+    - Shadowkin #BlackBlood
   effects:
   - !type:ReplaceBloodReagentTraitEffect
     reagent: Blood
@@ -45,6 +48,8 @@
   - ReplaceBloodSap
   - ReplaceBloodSlime
   - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -73,6 +78,8 @@
   - ReplaceBloodSap
   - ReplaceBloodSlime
   - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -99,6 +106,8 @@
   - ReplaceBloodSap
   - ReplaceBloodSlime
   - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -126,6 +135,8 @@
   - ReplaceBloodInsect
   - ReplaceBloodSlime
   - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -152,6 +163,8 @@
   - ReplaceBloodInsect
   - ReplaceBloodSap
   - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -178,6 +191,8 @@
   - ReplaceBloodInsect
   - ReplaceBloodSap
   - ReplaceBloodSlime
+  - ReplaceBloodBlack
+  - ReplaceBloodWhite
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -185,6 +200,58 @@
   effects:
   - !type:ReplaceBloodReagentTraitEffect
     reagent: YellowBlood
+
+- type: trait
+  id: ReplaceBloodBlack
+  name: trait-replace-blood-black-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  - ReplaceBloodWhite
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+    - Shadowkin
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: BlackBlood
+
+- type: trait
+  id: ReplaceBloodWhite
+  name: trait-replace-blood-white-name
+  description: trait-blood-desc
+  category: BonusPhysical
+  cost: 0 # Almost entirely cosmetic
+  usesSlots: false
+  conflicts:
+  - ReplaceBloodRed
+  - ReplaceBloodAmmonia
+  - ReplaceBloodCopper
+  - ReplaceBloodInsect
+  - ReplaceBloodSap
+  - ReplaceBloodSlime
+  - ReplaceBloodYellow
+  - ReplaceBloodBlack
+  conditions:
+  - !type:HasCompCondition
+    component: BorgChassis
+    invert: true
+  effects:
+  - !type:ReplaceBloodReagentTraitEffect
+    reagent: WhiteBlood
 
 # Regeneration
 - type: trait

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadowkin.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/shadowkin.yml
@@ -53,6 +53,10 @@
       48: 0.85
       64: 0.65
   - type: Bloodstream
+    bloodReferenceSolution:
+      reagents:
+      - ReagentId: BlackBlood #Pretty sure this is intended. All their organs are black.
+        Quantity: 300
     bloodlossDamage:
       types:
         Bloodloss: 1


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Added white blood, black blood, and their associated traits.
Changed Shadekin's default blood reagent to black blood
Added centrifuge recipes, artifact triggers, and randomly generated puddles for the new blood types.
## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was requested! More player customization is good, and Shadekin are AFAIK supposed to have black blood (all of their organs are black anyways.)
## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Assorted yml and ftl tweaks.
## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)
<img width="1321" height="579" alt="image" src="https://github.com/user-attachments/assets/6db05233-d9d9-4206-b571-e161fc457531" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Added white and black blood traits.
- tweak: Shadekin now have black blood by default.
