### PR TITLE
Let Borgs Cryo

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -301,6 +301,7 @@
     requiredMobState:
     - Critical
     - Dead
+  - type: CanEnterCryostorage # Floofstation - let borgs cryo
 
 - type: entity
   abstract: true


### PR DESCRIPTION
## About the PR
Lets borgs enter cryo themselfs or allows for someone to cryo ssd borgs.

## Why / Balance
Kinda silly they need to just ghost out by cryo and it not freeing up a slot. Sure people can join round as a ghost to check for brains that may be activated ghost roles but that seems a little silly.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
A singular comp was missing.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="973" height="482" alt="image" src="https://github.com/user-attachments/assets/570482c6-2a47-493c-a85a-23a6d3e3fac6" />
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [ ] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Borgs can enter cryosleep again on their own or if a player puts them into it.
