### PR TITLE
Fixes Head of Security's Cavalier hat's damage resistances (ATTEMPT 2)

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/hats.yml
@@ -402,7 +402,7 @@
       head:
       - state: equipped-HELMET
         offset: "0, 0.12"
-# Euphoria start: Parity with other HoS hats.
+# Euphoria start: Parity with other HoS hats. Copied armor coefficients instead of parenting from the HOS hat since the cav hat lacks the proper sprites for animals.
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_DV/Entities/Clothing/Head/hats.yml
+++ b/Resources/Prototypes/_DV/Entities/Clothing/Head/hats.yml
@@ -402,6 +402,15 @@
       head:
       - state: equipped-HELMET
         offset: "0, 0.12"
+# Euphoria start: Parity with other HoS hats.
+  - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
+# Euphoria end
 
 - type: entity
   parent: ClothingHeadBase


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Attempt 2 since I branched a branch on accident last time.

Tweaked the damage resistances of the HOS Cavalier hat so that they match the HOS hat and beret.
## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Parity. The other hats get the same resistances.
## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
A handful of lines of yml. I'd change the cavalier hat's parent to the HOS hat, but since it doesn't have sprites for animals it'd wind up floating in the air above Hamlet.
## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->

<img width="495" height="323" alt="image" src="https://github.com/user-attachments/assets/0f5384a7-7e9f-4075-b62d-c32acca57343" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: The HoS's cavalier hat now has the same armor as other HoS hats
