### PR TITLE
One Click ERT for Admins

### DIFF
--- a/Resources/Locale/en-US/_Floof/shipyard/shipyard-console.ftl
+++ b/Resources/Locale/en-US/_Floof/shipyard/shipyard-console.ftl
@@ -1,0 +1,1 @@
+﻿vessel-category-ert-filled = ERT Ghost Ready

--- a/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-cargo.yml
+++ b/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-cargo.yml
@@ -1,0 +1,2179 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 270.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 07/31/2026 15:38:33
+  entityCount: 338
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  63: FloorGreenCircuit
+  66: FloorHullReinforced
+  126: FloorMetalDiamond
+  167: FloorShuttleBlue
+  168: FloorShuttleGrey
+  169: FloorShuttleOrange
+  193: FloorTechMaint3
+  215: Lattice
+  253: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: ERT - Pelican
+    - type: Transform
+      pos: -0.484375,-0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: pwAAAAAAAKcAAAAAAACnAAAAAAAAqAAAAAAAAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKcAAAAAAACnAAAAAAAApwAAAAAAAKgAAAAAAADBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACnAAAAAAAA/QAAAAAAAP0AAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApwAAAAAAAP0AAAAAAAD9AAAAAAAAQgAAAAAAANcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKcAAAAAAAD9AAAAAAAA/QAAAAAAAEIAAAAAAADXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACnAAAAAAAA/QAAAAAAAP0AAAAAAABCAAAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAAP0AAAAAAAD9AAAAAAAAQgAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAAAAAACoAAAAAAAAfgAAAAAAAEIAAAAAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACoAAAAAAAAqAAAAAAAAH4AAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPwAAAAAAAH4AAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAAKgAAAAAAACnAAAAAAAApwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMEAAAAAAACoAAAAAAAApwAAAAAAAKcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANcAAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADXAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAEIAAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAABCAAAAAAAAfgAAAAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAQgAAAAAAAH4AAAAAAACoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAABCAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAEIAAAAAAABCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEIAAAAAAABCAAAAAAAAQgAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB+AAAAAAAAfgAAAAAAAH4AAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAqQAAAAAAAKkAAAAAAAB+AAAAAAAAQgAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKkAAAAAAACpAAAAAAAAfgAAAAAAAEIAAAAAAADXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACnAAAAAAAA/QAAAAAAAP0AAAAAAABCAAAAAAAA1wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApwAAAAAAAP0AAAAAAAD9AAAAAAAAQgAAAAAAANcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKcAAAAAAAD9AAAAAAAA/QAAAAAAAEIAAAAAAADXAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACnAAAAAAAA/QAAAAAAAP0AAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAApwAAAAAAAKcAAAAAAACnAAAAAAAAqAAAAAAAAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAQgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAQgAAAAAAAEIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAQgAAAAAAAH4AAAAAAAB+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQgAAAAAAAEIAAAAAAAB+AAAAAAAAqQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANcAAAAAAABCAAAAAAAAfgAAAAAAAKkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADXAAAAAAAAQgAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAAAEIAAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANcAAAAAAABCAAAAAAAA/QAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABCAAAAAAAAQgAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAwQAAAAAAAKgAAAAAAACnAAAAAAAApwAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileDarkLineN
+          decals:
+            0: 1,-6
+            1: -1,-6
+            2: 0,-6
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineN
+          decals:
+            4: 0,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileSteelLineS
+          decals:
+            3: 0,2
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 30719
+          0,-1:
+            0: 63351
+          -1,0:
+            0: 52479
+            1: 4096
+          0,1:
+            0: 29047
+          -1,1:
+            0: 49356
+            1: 17
+            2: 256
+          0,2:
+            0: 55
+          -1,2:
+            0: 140
+            2: 1
+          1,0:
+            0: 17
+            1: 4096
+          1,1:
+            1: 17
+            2: 256
+          1,2:
+            2: 1
+          1,-1:
+            0: 4096
+            1: 17
+          -1,-1:
+            0: 64716
+            1: 17
+          0,-3:
+            2: 768
+          -1,-3:
+            2: 2048
+          0,-2:
+            0: 30583
+          -1,-2:
+            0: 52428
+            2: 16
+            1: 4352
+          1,-2:
+            2: 16
+            1: 4352
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          immutable: True
+          moles: {}
+        - volume: 2500
+          temperature: 293.15
+          moles: {}
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: IFF
+      color: '#0000FFFF'
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ImplicitRoof
+    - type: ExplosionAirtightGrid
+- proto: AirAlarm
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-1.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 321
+      - 320
+      - 295
+      - 174
+      - 162
+      - 296
+      - 188
+      - 269
+      - 165
+      - 164
+      - 163
+      - 172
+      - 166
+      - 167
+      - 168
+      - 173
+      - 297
+      - 319
+      - 294
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+- proto: AirlockExternalShuttleLocked
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 294
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+- proto: APCBasic
+  entities:
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 63
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 113
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 119
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+- proto: CargoPallet
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+- proto: CrateFoodDonkpocketSweet
+  entities:
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+- proto: CrateMaterialBasicResource
+  entities:
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+- proto: CrateMaterialPlasma
+  entities:
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+- proto: CrateMaterialPlasteel
+  entities:
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+- proto: CrateMaterialRandom
+  entities:
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+- proto: Firelock
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+- proto: FirelockEdge
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 164
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 166
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 168
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+- proto: GasOutletInjector
+  entities:
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+- proto: GasPipeBendAlt1
+  entities:
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: GasPipeFourway
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+- proto: GasPipeManifold
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: GasPipeStraight
+  entities:
+  - uid: 177
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+- proto: GasPipeTJunction
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+- proto: GasPort
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-6.5
+      parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+- proto: GasVentPump
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 173
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+- proto: GasVentScrubber
+  entities:
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 293
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-7.5
+      parent: 1
+- proto: GeneratorRTG
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 1
+- proto: KitchenMicrowave
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+- proto: MechEquipmentGrabber
+  entities:
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 1.474462,-6.350186
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: -0.49220473,-6.425238
+      parent: 1
+- proto: PhoneInstrument
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -1.662117,8.702438
+      parent: 1
+- proto: PoweredlightLED
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-7.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-6.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTLeaderRed
+  entities:
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 0.48277646,8.578763
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityRed
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -1.4755569,5.5850167
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 1.5577765,5.518304
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+- proto: SpawnMechRipley
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-9.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-8.5
+      parent: 1
+- proto: WallWeaponCapacitorRecharger
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,6.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 159
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+- proto: WeaponCapacitorRecharger
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,9.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-5.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+...

--- a/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-engi.yml
+++ b/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-engi.yml
@@ -1,0 +1,8937 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 270.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 07/31/2026 14:55:33
+  entityCount: 1281
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  1: Space
+  2: FloorCosmicVoid
+  8: FloorDarkMono
+  4: FloorGreenCircuit
+  9: FloorHullReinforcedDestructible
+  5: FloorReinforced
+  6: FloorSteel
+  7: FloorSteelMono
+  3: FloorTechMaint
+  0: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NTCC Sovereign Paragon
+    - type: Transform
+      pos: -0.46875,-0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: BAAAAAAAAAQAAAAAAAAAAAAAAAAABwAAAAAAAAYAAAAAAAAGAAAAAAEABwAAAAACAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAcAAAAAAAAGAAAAAAAABgAAAAAAAAcAAAAAAQAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAMABwAAAAAAAAYAAAAAAAAGAAAAAAIABgAAAAACAAYAAAAAAAAHAAAAAAMAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAADAAYAAAAAAwAGAAAAAAIABgAAAAAAAAYAAAAAAQAGAAAAAAMABgAAAAACAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAwAGAAAAAAEABgAAAAADAAYAAAAAAwAGAAAAAAEABgAAAAABAAYAAAAAAQADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAGAAAAAAEABgAAAAAAAAYAAAAAAwAGAAAAAAEAAwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAABAAcAAAAAAwAAAAAAAAAABgAAAAAAAAYAAAAAAgAGAAAAAAAABgAAAAADAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAcAAAAAAwAHAAAAAAIAAAAAAAAAAAYAAAAAAAAGAAAAAAMABgAAAAACAAYAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAHAAAAAAIABwAAAAAAAAAAAAAAAAAGAAAAAAEABgAAAAABAAYAAAAAAwAHAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAwAGAAAAAAIABQAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAEABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAADAAYAAAAAAwAFAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAQAHAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAMABgAAAAADAAUAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAcAAAAAAwAGAAAAAAIABgAAAAACAAcAAAAAAQAAAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAHAAAAAAAABgAAAAADAAYAAAAAAgAHAAAAAAAAAAAAAAAAAAUAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAABwAAAAADAAYAAAAAAQAGAAAAAAIABgAAAAADAAYAAAAAAwAHAAAAAAMAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAYAAAAAAgAGAAAAAAIABgAAAAADAAYAAAAAAwAGAAAAAAIABgAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAAGAAAAAAAABgAAAAADAAYAAAAAAAAGAAAAAAMABgAAAAAAAAYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAABgAAAAACAAYAAAAAAgAGAAAAAAAABgAAAAABAAAAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAYAAAAAAQAGAAAAAAAABgAAAAADAAYAAAAAAgAAAAAAAAAABwAAAAACAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAAGAAAAAAMABgAAAAADAAYAAAAAAQAGAAAAAAIAAAAAAAAAAAcAAAAAAwABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAABwAAAAACAAYAAAAAAwAGAAAAAAMABgAAAAACAAAAAAAAAAAHAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAABwAAAAAAAAYAAAAAAQAGAAAAAAMABwAAAAAAAAYAAAAAAgABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAYAAAAAAgAGAAAAAAIABgAAAAADAAYAAAAAAAAGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAgAGAAAAAAAABgAAAAABAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAADAAAAAAAABgAAAAAAAAYAAAAAAwAGAAAAAAMABgAAAAABAAYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAcAAAAAAAAGAAAAAAMABgAAAAADAAYAAAAAAgAGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAUAAAAAAAAFAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABgAAAAABAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAYAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAAGAAAAAAEAAAAAAAAAAAUAAAAAAAAFAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAgAAAAAAgAGAAAAAAIABgAAAAACAAYAAAAAAQAGAAAAAAAABgAAAAADAAAAAAAAAAAFAAAAAAAABQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAIABgAAAAACAAYAAAAAAQAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAwAHAAAAAAEAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAwAGAAAAAAMABgAAAAADAAAAAAAAAAAGAAAAAAMABgAAAAADAAMAAAAAAAAGAAAAAAAABgAAAAAAAAYAAAAAAAADAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAIAAAAAAEABgAAAAACAAYAAAAAAAADAAAAAAAABgAAAAACAAgAAAAAAQAAAAAAAAAABwAAAAAAAAcAAAAAAQAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAACAAYAAAAAAAAGAAAAAAAAAAAAAAAAAAYAAAAAAwAGAAAAAAMAAwAAAAAAAAYAAAAAAAAGAAAAAAEABgAAAAAAAAMAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAQAGAAAAAAIABAAAAAAAAAAAAAAAAAAGAAAAAAMABgAAAAADAAAAAAAAAAAHAAAAAAMABwAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAAABgAAAAABAAQAAAAAAAAAAAAAAAAAAwAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAgAGAAAAAAAABwAAAAACAAcAAAAAAQAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAQAGAAAAAAIABAAAAAAAAAUAAAAAAAAGAAAAAAEABgAAAAAAAAcAAAAAAwAHAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAIAAAAAAMABgAAAAAAAAcAAAAAAAAFAAAAAAAABgAAAAACAAYAAAAAAwAHAAAAAAEABwAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAADAAYAAAAAAQAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAFAAAAAAAABQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAABQAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAGAAAAAAMAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAFAAAAAAAABQAAAAAAAAAAAAAAAAAHAAAAAAAABwAAAAABAAcAAAAAAgAHAAAAAAMABgAAAAADAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABQAAAAAAAAUAAAAAAAAAAAAAAAAABwAAAAACAAcAAAAAAwAHAAAAAAEABwAAAAAAAAYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAgAHAAAAAAMABwAAAAABAAcAAAAAAAAGAAAAAAMAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAHAAAAAAMABwAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAMAAAAAAAAGAAAAAAAABgAAAAADAAYAAAAAAwADAAAAAAAABgAAAAAAAAYAAAAAAQAAAAAAAAAABgAAAAACAAYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAcAAAAAAQAHAAAAAAEAAAAAAAAAAAgAAAAAAwAGAAAAAAAAAwAAAAAAAAYAAAAAAwAGAAAAAAMAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAYAAAAAAgAGAAAAAAMABgAAAAADAAMAAAAAAAAGAAAAAAEABgAAAAABAAAAAAAAAAAGAAAAAAIABgAAAAACAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAAAAAAAAAABwAAAAADAAcAAAAAAwAAAAAAAAAABgAAAAACAAYAAAAAAgAAAAAAAAAABAAAAAAAAAYAAAAAAgABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAADAAAAAAAAAAAAAAAAAAQAAAAAAAAGAAAAAAMAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAABwAAAAABAAcAAAAAAgAGAAAAAAAABgAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAYAAAAAAgAGAAAAAAIABgAAAAACAAYAAAAAAwAFAAAAAAAABAAAAAAAAAYAAAAAAQABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAHAAAAAAIABwAAAAABAAYAAAAAAwAGAAAAAAAABQAAAAAAAAcAAAAAAwAGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAAAAAAAAAADAAAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAABAA==
+          version: 7
+        -1,1:
+          ind: -1,1
+          tiles: AQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAHAAAAAAIABwAAAAACAAcAAAAAAQAAAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAAAAAAAAABwAAAAABAAcAAAAAAAAHAAAAAAAAAAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAcAAAAAAwAHAAAAAAAABwAAAAAAAAAAAAAAAAAEAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAFAAAAAAAABQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+        0,1:
+          ind: 0,1
+          tiles: BgAAAAACAAYAAAAAAQAGAAAAAAMABgAAAAABAAYAAAAAAAAHAAAAAAIAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAQAGAAAAAAMABgAAAAACAAYAAAAAAQAGAAAAAAIABwAAAAACAAAAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAEABgAAAAADAAYAAAAAAgAGAAAAAAIABgAAAAABAAcAAAAAAgAAAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAACAAYAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAFAAAAAAAAAAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAFAAAAAAAABQAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            1: -5,-11
+            2: -5,-12
+            3: -5,-13
+            4: -4,-13
+            5: -4,-12
+            6: -4,-11
+            7: -3,-11
+            8: -3,-12
+            9: -3,-13
+            10: -2,-13
+            11: -2,-12
+            12: -2,-11
+            86: -5,-8
+            87: 0,-8
+            88: 0,-12
+            89: 5,-8
+            90: 0,-2
+            140: -5,18
+            141: -5,17
+            142: -5,16
+            143: -4,16
+            144: -4,17
+            145: -4,18
+            146: -3,18
+            147: -3,17
+            148: -3,16
+            149: -1,6
+            150: -1,7
+            151: -1,8
+            152: 0,8
+            153: 0,7
+            154: 0,6
+            155: 1,6
+            156: 1,7
+            157: 1,8
+            184: -5,10
+            185: -2,10
+            186: 1,11
+            187: 1,13
+            188: -5,14
+            189: -3,1
+            190: -3,0
+            191: -6,0
+            192: -6,1
+            193: -6,2
+            194: 6,1
+            195: 6,2
+            196: 6,-4
+            197: 6,-3
+            198: 6,-2
+            199: 7,-2
+            200: 7,-3
+            201: 7,-4
+            271: 6,0
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            31: -4,-6
+            32: 1,-5
+            33: 5,-6
+            45: 2,-7
+            78: 1,-1
+            123: 2,-11
+            124: 5,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNe
+          decals:
+            207: -3,8
+            224: 5,8
+            259: 5,-2
+            260: -4,-2
+            281: 1,14
+            289: 1,19
+            293: 4,18
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            29: -5,-6
+            30: -1,-5
+            34: 4,-6
+            44: -2,-7
+            77: -1,-1
+            122: -1,-11
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerNw
+          decals:
+            206: -5,8
+            223: 3,8
+            257: -5,-2
+            258: 4,-2
+            286: -4,14
+            290: 0,19
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            37: -4,-9
+            38: 5,-9
+            51: 2,-9
+            79: 1,-3
+            125: 5,-13
+            126: 2,-14
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSe
+          decals:
+            234: -4,0
+            236: -2,2
+            245: 5,0
+            261: -4,-4
+            262: 5,-4
+            279: 1,10
+            292: 4,16
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            35: -5,-9
+            36: 4,-9
+            52: -2,-9
+            80: -1,-3
+            127: 1,-14
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteCornerSw
+          decals:
+            233: -5,0
+            244: 4,0
+            249: 2,2
+            263: -5,-4
+            264: 4,-4
+            273: -4,10
+            291: 0,16
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteEndE
+          decals:
+            63: 9,-7
+            64: 9,-9
+            75: -7,-9
+            76: -7,-7
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteEndS
+          decals:
+            85: -1,-14
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteEndW
+          decals:
+            61: 7,-7
+            62: 7,-9
+            73: -9,-7
+            74: -9,-9
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteEndW
+          decals:
+            255: -7,-3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            59: 1,-7
+            138: 2,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerNe
+          decals:
+            225: 5,7
+            229: -3,4
+            294: 1,18
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            58: -1,-7
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerNw
+          decals:
+            208: -5,7
+            228: 3,4
+            266: -5,-3
+            288: -4,13
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            139: 2,-13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerSe
+          decals:
+            239: -4,2
+            240: -2,3
+            243: 5,3
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteInnerSw
+          decals:
+            238: -5,3
+            241: 2,3
+            242: 4,2
+            267: -5,-3
+            274: -4,11
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineE
+          decals:
+            46: 1,-6
+            47: 5,-7
+            49: -4,-7
+            50: -4,-8
+            54: 2,-8
+            82: 1,-2
+            129: -1,-13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineE
+          decals:
+            211: -3,7
+            212: -3,6
+            213: -3,5
+            235: -4,1
+            246: 5,1
+            247: 5,2
+            256: -4,-3
+            265: 5,-3
+            280: 1,12
+            297: 4,17
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineN
+          decals:
+            60: 0,-5
+            65: 8,-7
+            66: 8,-9
+            71: -8,-7
+            72: -8,-9
+            83: 0,-1
+            130: 0,-11
+            131: 1,-11
+            132: 3,-12
+            133: 4,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineN
+          decals:
+            209: -4,8
+            210: -6,7
+            214: -2,4
+            215: -1,4
+            216: 0,4
+            217: 1,4
+            218: 2,4
+            226: 4,8
+            227: 6,7
+            268: -6,-3
+            282: 0,14
+            283: -1,14
+            284: -2,14
+            285: -3,14
+            287: -5,13
+            295: 2,18
+            296: 3,18
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineS
+          decals:
+            55: -1,-9
+            56: 0,-9
+            57: 1,-9
+            67: 8,-9
+            68: 8,-7
+            69: -8,-9
+            70: -8,-7
+            84: 0,-3
+            134: 3,-13
+            135: 4,-13
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineS
+          decals:
+            230: -6,3
+            237: -3,2
+            250: 3,2
+            251: 1,3
+            252: 0,3
+            253: -1,3
+            254: 6,3
+            269: -6,-3
+            272: -5,11
+            276: -3,10
+            277: -1,10
+            278: 0,10
+            298: 3,16
+            299: 2,16
+            300: 1,16
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineW
+          decals:
+            40: -5,-7
+            41: 4,-8
+            42: 4,-7
+            43: -1,-6
+            53: -2,-8
+            81: -1,-2
+            128: 1,-13
+            136: -1,-13
+            137: -1,-12
+        - node:
+            color: '#EFB34196'
+            id: BrickTileWhiteLineW
+          decals:
+            219: 3,5
+            220: 3,6
+            221: 3,7
+            231: -5,2
+            232: -5,1
+            248: 4,1
+            270: 4,-3
+            301: 0,17
+            302: 0,18
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            319: 6,4
+            320: 6,6
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            316: -6,4
+            317: -6,6
+            318: -5,12
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            13: -10,-9
+            14: -10,-7
+            15: -6,-7
+            16: -6,-9
+            17: -5,-5
+            18: -4,-5
+            19: -3,-8
+            20: 0,-10
+            21: 3,-8
+            22: 6,-7
+            23: 6,-9
+            24: 10,-9
+            25: 10,-7
+            26: 5,-5
+            27: 4,-5
+            28: 0,-4
+            158: -7,3
+            159: -7,4
+            160: -7,5
+            161: -7,6
+            162: -7,7
+            163: -4,9
+            164: -3,9
+            165: -6,11
+            166: -6,12
+            167: -6,13
+            168: -5,15
+            169: -4,15
+            170: -3,15
+            171: 0,15
+            172: 7,7
+            173: 7,6
+            174: 7,5
+            175: 7,4
+            176: 7,3
+            177: 4,-1
+            178: 5,-1
+            179: -5,-1
+            180: -4,-1
+            181: -1,5
+            182: 0,5
+            183: 1,5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNE
+          decals:
+            108: -1,-9
+            109: 4,-9
+            110: -1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallNW
+          decals:
+            111: 1,-9
+            112: 1,-3
+            113: -4,-9
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSE
+          decals:
+            114: -1,-7
+            115: 4,-7
+            116: -1,-1
+            117: -1,-11
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallSW
+          decals:
+            118: 1,-7
+            119: 1,-11
+            120: 1,-1
+            121: -4,-7
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnFull
+          decals:
+            202: 5,18
+            203: 5,17
+            204: 5,16
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            100: -1,-2
+            101: 4,-8
+            102: -1,-8
+            103: -1,-12
+            311: 6,3
+            312: 6,4
+            313: 6,5
+            314: 6,6
+            315: 6,7
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            91: 0,-7
+            92: -5,-7
+            93: 5,-7
+            94: 0,-11
+            95: 0,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            96: 1,-2
+            97: 1,-8
+            98: 1,-12
+            99: -4,-8
+            303: -6,3
+            304: -6,4
+            305: -6,5
+            306: -6,6
+            307: -6,7
+            308: -5,11
+            309: -5,12
+            310: -5,13
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            104: -5,-9
+            105: 0,-9
+            106: 5,-9
+            107: 0,-3
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 65419
+          0,-1:
+            0: 14192
+          -1,0:
+            0: 65339
+          0,1:
+            0: 48015
+          -1,1:
+            0: 47935
+          0,2:
+            0: 13067
+            1: 2048
+          -1,2:
+            0: 65339
+          0,3:
+            0: 4915
+            2: 8
+            3: 2048
+          -1,3:
+            0: 4095
+          0,4:
+            0: 16383
+          1,0:
+            0: 30583
+          1,1:
+            0: 30583
+          1,2:
+            0: 135
+            1: 768
+          1,3:
+            2: 3
+            3: 768
+          1,-1:
+            0: 16383
+          1,4:
+            0: 819
+          -2,0:
+            0: 52428
+          -2,1:
+            0: 52428
+          -2,2:
+            0: 34860
+          -2,3:
+            0: 2184
+          -2,-1:
+            0: 40686
+          -2,4:
+            0: 2184
+          -1,-1:
+            0: 40401
+          -1,4:
+            0: 35771
+          0,-4:
+            0: 63240
+          -1,-4:
+            0: 64531
+          0,-3:
+            0: 29183
+          -1,-3:
+            0: 53503
+          0,-2:
+            0: 30591
+          -1,-2:
+            0: 56799
+          1,-4:
+            0: 45239
+          1,-3:
+            0: 63547
+          1,-2:
+            0: 15355
+          2,-4:
+            0: 4352
+          2,-3:
+            0: 29985
+          2,-2:
+            0: 9585
+          2,-1:
+            0: 4096
+          -3,-3:
+            0: 50304
+          -3,-2:
+            0: 33984
+          -2,-3:
+            0: 62347
+          -2,-2:
+            0: 35835
+          -2,-4:
+            0: 45484
+          -2,5:
+            0: 132
+          -1,5:
+            0: 115
+          0,5:
+            0: 200
+          1,5:
+            0: 53
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Plasma: 6666.982
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 6666.982
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Nitrogen: 6666.982
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
+- proto: AirAlarm
+  entities:
+  - uid: 539
+    components:
+    - type: MetaData
+      name: 'Air Alarm: Sovereign Aft'
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 433
+      - 439
+      - 434
+      - 438
+      - 435
+      - 430
+      - 474
+      - 475
+      - 411
+      - 410
+      - 432
+      - 436
+      - 437
+      - 431
+      - 592
+      - 593
+      - 536
+      - 591
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1047
+    components:
+    - type: MetaData
+      name: 'Air Alarm: Engineering'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 592
+      - 593
+      - 536
+      - 591
+      - 673
+      - 676
+      - 674
+      - 675
+      - 672
+      - 677
+      - 678
+      - 671
+      - 668
+      - 775
+      - 1234
+      - 1235
+      - 679
+      - 670
+      - 667
+      - 680
+      - 1236
+      - 669
+      - 681
+    - type: Fixtures
+      fixtures: {}
+- proto: AirAlarmElectronics
+  entities:
+  - uid: 1231
+    components:
+    - type: Transform
+      pos: 1.6705844,19.418194
+      parent: 1
+- proto: AirCanister
+  entities:
+  - uid: 533
+    components:
+    - type: Transform
+      anchored: True
+      pos: 5.5,-12.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+  - uid: 534
+    components:
+    - type: Transform
+      anchored: True
+      pos: 4.5,-12.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+  - uid: 535
+    components:
+    - type: Transform
+      anchored: True
+      pos: 3.5,-12.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+  - uid: 896
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 899
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 900
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+- proto: AirGrenade
+  entities:
+  - uid: 1126
+    components:
+    - type: Transform
+      pos: -0.6565584,2.8016944
+      parent: 1
+  - uid: 1127
+    components:
+    - type: Transform
+      pos: -0.4221834,2.8016944
+      parent: 1
+  - uid: 1128
+    components:
+    - type: Transform
+      pos: -0.2503084,2.8016944
+      parent: 1
+  - uid: 1129
+    components:
+    - type: Transform
+      pos: -0.6409334,2.4579444
+      parent: 1
+  - uid: 1130
+    components:
+    - type: Transform
+      pos: -0.4378084,2.4579444
+      parent: 1
+  - uid: 1131
+    components:
+    - type: Transform
+      pos: -0.2346834,2.4579444
+      parent: 1
+- proto: AirlockERTLocked
+  entities:
+  - uid: 497
+    components:
+    - type: MetaData
+      name: Sovereign Interior Airlock
+    - type: Transform
+      pos: -5.5,-8.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: MetaData
+      name: Sovereign Interior Airlock
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: MetaData
+      name: Sovereign Hallway
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: MetaData
+      name: Sovereign Hallway
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: MetaData
+      name: Sovereign Interior Airlock
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: MetaData
+      name: Sovereign Interior Airlock
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: MetaData
+      name: Engineering
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: MetaData
+      name: Storage
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: MetaData
+      name: Storage
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 559
+    components:
+    - type: MetaData
+      name: Storage
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: MetaData
+      name: Storage
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: MetaData
+      name: Engineering
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: MetaData
+      name: Engineering
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: MetaData
+      name: Engineering
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: MetaData
+      name: Engineering
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: MetaData
+      name: Atmospheric
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: MetaData
+      name: Atmospheric
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: MetaData
+      name: Fabrication
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+- proto: AirlockExternalGlassShuttleLocked
+  entities:
+  - uid: 564
+    components:
+    - type: MetaData
+      name: Sovereign Docking Port
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: MetaData
+      name: Sovereign Docking Port
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: MetaData
+      name: Sovereign Docking Port
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 567
+    components:
+    - type: MetaData
+      name: Sovereign Docking Port
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 1
+- proto: AntiMeteorZone
+  entities:
+  - uid: 1237
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AntiMeteorZone
+      avoidanceRate: 0.33
+      zoneRadius: 14
+  - uid: 1238
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: AntiMeteorZone
+      avoidanceRate: 0.33
+      zoneRadius: 14
+- proto: APCBasic
+  entities:
+  - uid: 134
+    components:
+    - type: MetaData
+      name: 'APC: Port Aft Engine'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-14.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 176
+    components:
+    - type: MetaData
+      name: 'APC: Port For Engine'
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 179
+    components:
+    - type: MetaData
+      name: 'APC: Starboard For Engine'
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 199
+    components:
+    - type: MetaData
+      name: 'APC: Helm & Engineering'
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 203
+    components:
+    - type: MetaData
+      name: 'APC: Starboard Aft Engine'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-14.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 352
+    components:
+    - type: MetaData
+      name: 'APC: Starboard Airlock'
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 353
+    components:
+    - type: MetaData
+      name: 'APC: Port Airlock'
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: APCElectronics
+  entities:
+  - uid: 1228
+    components:
+    - type: Transform
+      pos: 1.3580844,19.480694
+      parent: 1
+  - uid: 1229
+    components:
+    - type: Transform
+      pos: 1.5299594,19.715069
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-8.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-6.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-6.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,-8.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 683
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 684
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 685
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 687
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,3.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,12.5
+      parent: 1
+- proto: AtmosFixNitrogenMarker
+  entities:
+  - uid: 958
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 959
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 960
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+- proto: AtmosFixOxygenMarker
+  entities:
+  - uid: 864
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 956
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 957
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+- proto: AtmosFixPlasmaMarker
+  entities:
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 955
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+- proto: BlastDoorUnlinkedERT
+  entities:
+  - uid: 946
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 947
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 948
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 1026
+    components:
+    - type: Transform
+      pos: 7.5,5.5
+      parent: 1
+  - uid: 1027
+    components:
+    - type: Transform
+      pos: 7.5,6.5
+      parent: 1
+  - uid: 1028
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 1029
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 1030
+    components:
+    - type: Transform
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 1031
+    components:
+    - type: Transform
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 1032
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 1034
+    components:
+    - type: Transform
+      pos: 7.5,7.5
+      parent: 1
+  - uid: 1035
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 1036
+    components:
+    - type: Transform
+      pos: 7.5,3.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - ERT
+- proto: BlastDoorUnlinkedERTOpen
+  entities:
+  - uid: 576
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 949
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 1024
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 1025
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 1037
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+- proto: BorgCharger
+  entities:
+  - uid: 509
+    components:
+    - type: Transform
+      pos: 0.5,-13.5
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 556
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 950
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 951
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 952
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 953
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 954
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+- proto: ButtonFrameGrey
+  entities:
+  - uid: 1022
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,15.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: -6.5,-8.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 7.5,-11.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -6.5,-12.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -6.5,-11.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -3.5,20.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 5.5,-14.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: -3.5,-14.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: -4.5,-14.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 4.5,-14.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -7.5,-8.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -8.5,-8.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: -7.5,-6.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      pos: -8.5,-6.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 7.5,-8.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: 8.5,-8.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 9.5,-8.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: 7.5,-6.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 9.5,-6.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 391
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -3.5,17.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -3.5,15.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 712
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 713
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 715
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 716
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 717
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 719
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 721
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 722
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 724
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 726
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 732
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 751
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 756
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 760
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+  - uid: 762
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      pos: 3.5,12.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 766
+    components:
+    - type: Transform
+      pos: 1.5,14.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      pos: 3.5,14.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 770
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+- proto: CableApcStack
+  entities:
+  - uid: 1077
+    components:
+    - type: Transform
+      pos: -5.7811327,-1.5813615
+      parent: 1
+  - uid: 1078
+    components:
+    - type: Transform
+      pos: -5.5311327,-1.5501115
+      parent: 1
+  - uid: 1079
+    components:
+    - type: Transform
+      pos: -5.2186327,-1.5344865
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 3.5,-12.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 4.5,-12.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 395
+    components:
+    - type: Transform
+      pos: 0.5,-12.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+- proto: CableHVStack
+  entities:
+  - uid: 1071
+    components:
+    - type: Transform
+      pos: -5.7498827,-1.3001115
+      parent: 1
+  - uid: 1072
+    components:
+    - type: Transform
+      pos: -5.4998827,-1.2844865
+      parent: 1
+  - uid: 1073
+    components:
+    - type: Transform
+      pos: -5.2498827,-1.2688615
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: 2.5,-11.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -0.5,-12.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: -0.5,-11.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      pos: -0.5,-13.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 1.5,-13.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 906
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 907
+    components:
+    - type: Transform
+      pos: -3.5,17.5
+      parent: 1
+  - uid: 908
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 909
+    components:
+    - type: Transform
+      pos: -3.5,15.5
+      parent: 1
+  - uid: 910
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 911
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 912
+    components:
+    - type: Transform
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 913
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 914
+    components:
+    - type: Transform
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 915
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 916
+    components:
+    - type: Transform
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 917
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 918
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 919
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 920
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 921
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 922
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 923
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 924
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 925
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 926
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 927
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+  - uid: 928
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 929
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 930
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 931
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 932
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 933
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 934
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 935
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 1
+- proto: CableMVStack
+  entities:
+  - uid: 1074
+    components:
+    - type: Transform
+      pos: -5.7655077,-1.4407365
+      parent: 1
+  - uid: 1075
+    components:
+    - type: Transform
+      pos: -5.5155077,-1.4094865
+      parent: 1
+  - uid: 1076
+    components:
+    - type: Transform
+      pos: -5.2811327,-1.3938615
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-11.5
+      parent: 1
+- proto: CentcommComputerComms
+  entities:
+  - uid: 520
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 1093
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5998583,7.671031
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-8.5
+      parent: 1
+- proto: CircuitImprinter
+  entities:
+  - uid: 942
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+- proto: ClosetToolFilled
+  entities:
+  - uid: 537
+    components:
+    - type: Transform
+      pos: 2.5,-13.5
+      parent: 1
+- proto: ClothingShoesBootsMagAdv
+  entities:
+  - uid: 1087
+    components:
+    - type: Transform
+      pos: -6.7083955,-3.625938
+      parent: 1
+  - uid: 1088
+    components:
+    - type: Transform
+      pos: -6.5990205,-3.375938
+      parent: 1
+  - uid: 1089
+    components:
+    - type: Transform
+      pos: -6.4115205,-3.610313
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 552
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+- proto: ComputerRadar
+  entities:
+  - uid: 222
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+- proto: ConveyorBelt
+  entities:
+  - uid: 1019
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 1020
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 1021
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,18.5
+      parent: 1
+- proto: CrateEngineeringAMEControl
+  entities:
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+- proto: CrateEngineeringAMEJar
+  entities:
+  - uid: 617
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+  - uid: 618
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+- proto: CrateEngineeringAMEShielding
+  entities:
+  - uid: 624
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+  - uid: 625
+    components:
+    - type: Transform
+      pos: -3.5,17.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+  - uid: 626
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Engineering
+- proto: CrateEngineeringSecure
+  entities:
+  - uid: 1144
+    components:
+    - type: MetaData
+      name: Material Crate
+    - type: Transform
+      pos: 2.5,16.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1146
+          - 1147
+          - 1148
+          - 1149
+          - 1150
+          - 1151
+          - 1152
+          - 1153
+          - 1154
+          - 1155
+          - 1156
+          - 1157
+          - 1158
+          - 1159
+          - 1160
+          - 1161
+          - 1162
+          - 1163
+          - 1164
+          - 1165
+          - 1166
+          - 1167
+          - 1168
+          - 1169
+          - 1170
+          - 1171
+          - 1172
+          - 1173
+          - 1174
+          - 1145
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+  - uid: 1175
+    components:
+    - type: MetaData
+      name: Material Crate
+    - type: Transform
+      pos: -6.5,-2.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14673
+        moles:
+          Oxygen: 1.7459903
+          Nitrogen: 6.568249
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 1176
+          - 1177
+          - 1178
+          - 1179
+          - 1180
+          - 1181
+          - 1182
+          - 1183
+          - 1184
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+- proto: DecalSpawnerDirtWide
+  entities:
+  - uid: 600
+    components:
+    - type: Transform
+      pos: -8.5,-8.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 603
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 604
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 1.5,-12.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 8.5,-6.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 1188
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 1190
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 1191
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 1192
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 1194
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 1196
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 1197
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 1198
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 1200
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 1201
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 1203
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 1204
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 1205
+    components:
+    - type: Transform
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 1209
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 1210
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 1211
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 1212
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 1215
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 1216
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 1217
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 1218
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 1219
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 545
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-8.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+  - uid: 972
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 973
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 975
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 976
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 983
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 1011
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 1012
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 1016
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 1017
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+  - uid: 1018
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+- proto: DisposalJunctionFlipped
+  entities:
+  - uid: 1013
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 517
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 961
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 962
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 963
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 964
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 965
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 966
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 967
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 968
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 969
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 977
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 978
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 979
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 980
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 981
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 982
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 984
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 985
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 986
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 987
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 988
+    components:
+    - type: Transform
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 989
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 990
+    components:
+    - type: Transform
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 991
+    components:
+    - type: Transform
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 992
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 993
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+  - uid: 994
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 995
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 996
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 997
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 998
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 999
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 1000
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 1001
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 1002
+    components:
+    - type: Transform
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 1003
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 1004
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 1005
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 1006
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 1007
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 1008
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 1009
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 1010
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,16.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 970
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 1
+  - uid: 971
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 974
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 1014
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 1015
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,16.5
+      parent: 1
+- proto: DisposalUnit
+  entities:
+  - uid: 628
+    components:
+    - type: Transform
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      pos: 7.5,-7.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 901
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+- proto: DisposalYJunction
+  entities:
+  - uid: 546
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
+      parent: 1
+- proto: DoorElectronics
+  entities:
+  - uid: 1232
+    components:
+    - type: Transform
+      pos: 1.3580844,19.386944
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal: []
+  - uid: 1233
+    components:
+    - type: Transform
+      pos: 1.5299594,19.480694
+      parent: 1
+- proto: EngineeringTechFab
+  entities:
+  - uid: 865
+    components:
+    - type: Transform
+      pos: -0.5,18.5
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+    - type: FaxMachine
+      name: NTCC Sovereign Paragon
+- proto: FirelockGlass
+  entities:
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+      - 539
+  - uid: 591
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+      - 539
+  - uid: 592
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+      - 539
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+      - 539
+  - uid: 1234
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+  - uid: 1235
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+  - uid: 1236
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+- proto: FrezonCanister
+  entities:
+  - uid: 656
+    components:
+    - type: Transform
+      pos: -2.5,18.5
+      parent: 1
+- proto: FuelDispenser
+  entities:
+  - uid: 1142
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1143
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasMinerNitrogenStation
+  entities:
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 4.5,14.5
+      parent: 1
+- proto: GasMinerOxygenStation
+  entities:
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 4.5,12.5
+      parent: 1
+- proto: GasMinerPlasma
+  entities:
+  - uid: 90
+    components:
+    - type: Transform
+      pos: 4.5,10.5
+      parent: 1
+- proto: GasMixer
+  entities:
+  - uid: 774
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+- proto: GasMixerFlipped
+  entities:
+  - uid: 880
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#B67900FF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#F400FFFF'
+  - uid: 278
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00F7FFFF'
+  - uid: 418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-11.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FC1212FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 877
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 878
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 889
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#B67900FF'
+  - uid: 890
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,12.5
+      parent: 1
+- proto: GasPipeBendAlt1
+  entities:
+  - uid: 225
+    components:
+    - type: Transform
+      pos: 5.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 495
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 794
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 796
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 820
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 821
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 856
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 857
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 412
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 448
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 449
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 494
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 793
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 797
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 812
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 819
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 822
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 843
+    components:
+    - type: Transform
+      pos: -2.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 850
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 855
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 858
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeFourwayAlt1
+  entities:
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeFourwayAlt2
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 876
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#F400FFFF'
+  - uid: 879
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 883
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 884
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 885
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 886
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#B67900FF'
+  - uid: 887
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#B67900FF'
+  - uid: 888
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#B67900FF'
+  - uid: 891
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 892
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 893
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00F7FFFF'
+  - uid: 894
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#F400FFFF'
+- proto: GasPipeStraightAlt1
+  entities:
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 452
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 453
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 454
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 460
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 479
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 480
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 485
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 486
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 489
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 490
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 787
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 788
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 789
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 799
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 805
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 806
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 807
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 808
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 815
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 816
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 817
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 818
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 826
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 833
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 834
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 835
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 836
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 837
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 838
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 845
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 846
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 847
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 853
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 854
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 859
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 860
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 866
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 867
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 868
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 869
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 870
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 871
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 370
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 414
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FC1212FF'
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FC1212FF'
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FC1212FF'
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FC1212FF'
+  - uid: 450
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 455
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 456
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 457
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 461
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 462
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 463
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 464
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 465
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 473
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 477
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 491
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 492
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 493
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 779
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 782
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 783
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 784
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 785
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 786
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 798
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 800
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 801
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 802
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 803
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 804
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 810
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 811
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 813
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 814
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 825
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 827
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 828
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 829
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 830
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 831
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 832
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 844
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 848
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 849
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 851
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 852
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 862
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 863
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 872
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 873
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00F7FFFF'
+  - uid: 874
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00F7FFFF'
+  - uid: 875
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#F400FFFF'
+- proto: GasPipeTJunctionAlt1
+  entities:
+  - uid: 226
+    components:
+    - type: Transform
+      pos: 4.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 3.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 442
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 443
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 471
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 781
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 792
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 824
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 839
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 841
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 1.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 440
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 444
+    components:
+    - type: Transform
+      pos: -3.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 4.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 446
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 780
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 795
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 823
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 840
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 842
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 940
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 941
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPort
+  entities:
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-12.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-12.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-12.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 771
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#F400FFFF'
+  - uid: 772
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 773
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00F7FFFF'
+  - uid: 881
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#B67900FF'
+  - uid: 882
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 938
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 939
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+- proto: GasPressurePump
+  entities:
+  - uid: 542
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#950000FF'
+  - uid: 543
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#F400FFFF'
+  - uid: 544
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#00F7FFFF'
+- proto: GasPressurePumpEnabledAlt1
+  entities:
+  - uid: 406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 411
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 436
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 439
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 474
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 675
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 676
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 677
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 678
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 679
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 680
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 681
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,17.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+  - uid: 775
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+- proto: GasVentScrubber
+  entities:
+  - uid: 410
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 434
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 435
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 475
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 539
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 667
+    components:
+    - type: Transform
+      pos: -4.5,16.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 668
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 669
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,17.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 670
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 671
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 672
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 673
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+  - uid: 674
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 1047
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+- proto: GasVolumePumpEnabledAlt2
+  entities:
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -4.5,-10.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: -4.5,-12.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -3.5,-10.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: -4.5,-11.5
+      parent: 1
+  - uid: 1253
+    components:
+    - type: Transform
+      pos: -3.5,-11.5
+      parent: 1
+  - uid: 1277
+    components:
+    - type: Transform
+      pos: -3.5,-12.5
+      parent: 1
+  - uid: 1278
+    components:
+    - type: Transform
+      pos: -2.5,-10.5
+      parent: 1
+  - uid: 1279
+    components:
+    - type: Transform
+      pos: -2.5,-11.5
+      parent: 1
+  - uid: 1280
+    components:
+    - type: Transform
+      pos: -2.5,-12.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 1281
+    components:
+    - type: Transform
+      pos: -1.5,-13.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+- proto: HighSecDoorERTLocked
+  entities:
+  - uid: 1033
+    components:
+    - type: MetaData
+      name: Helm
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: HolopadLongRange
+  entities:
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+    - type: Label
+      currentLabel: NTCC Sovereign Paragon
+- proto: IngotGold
+  entities:
+  - uid: 1171
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1172
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: IngotSilver
+  entities:
+  - uid: 1149
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1150
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: JawsOfLife
+  entities:
+  - uid: 1053
+    components:
+    - type: Transform
+      pos: 3.4842134,7.60214
+      parent: 1
+  - uid: 1054
+    components:
+    - type: Transform
+      pos: 3.6092134,7.774015
+      parent: 1
+- proto: JetpackVoidFilled
+  entities:
+  - uid: 1090
+    components:
+    - type: Transform
+      pos: -5.6699524,-3.58504
+      parent: 1
+  - uid: 1091
+    components:
+    - type: Transform
+      pos: -5.5137024,-3.33504
+      parent: 1
+  - uid: 1092
+    components:
+    - type: Transform
+      pos: -5.3418274,-3.538165
+      parent: 1
+- proto: LiquidNitrogenCanister
+  entities:
+  - uid: 657
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+- proto: LiquidOxygenCanister
+  entities:
+  - uid: 655
+    components:
+    - type: Transform
+      pos: -2.5,17.5
+      parent: 1
+- proto: LockableButtonERT
+  entities:
+  - uid: 574
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1034:
+        - - Pressed
+          - Toggle
+        1027:
+        - - Pressed
+          - Toggle
+        1026:
+        - - Pressed
+          - Toggle
+        1035:
+        - - Pressed
+          - Toggle
+        1036:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 575
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        949:
+        - - Pressed
+          - Toggle
+        1025:
+        - - Pressed
+          - Toggle
+        576:
+        - - Pressed
+          - Toggle
+        577:
+        - - Pressed
+          - Toggle
+        578:
+        - - Pressed
+          - Toggle
+        1037:
+        - - Pressed
+          - Toggle
+        1024:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 579
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,1.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1032:
+        - - Pressed
+          - Toggle
+        1031:
+        - - Pressed
+          - Toggle
+        1028:
+        - - Pressed
+          - Toggle
+        1029:
+        - - Pressed
+          - Toggle
+        1030:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 945
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        948:
+        - - Pressed
+          - Toggle
+        947:
+        - - Pressed
+          - Toggle
+        946:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1240
+    components:
+    - type: MetaData
+      name: Toggle Shutters
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1244:
+        - - Pressed
+          - Toggle
+        1038:
+        - - Pressed
+          - Toggle
+        1039:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1241
+    components:
+    - type: MetaData
+      name: Toggle Shutters
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1243:
+        - - Pressed
+          - Toggle
+        1242:
+        - - Pressed
+          - Toggle
+        1239:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: LockerElectricalSuppliesFilled
+  entities:
+  - uid: 590
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+- proto: LockerWallEvacRepairFilled
+  entities:
+  - uid: 540
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: LockerWeldingSuppliesFilled
+  entities:
+  - uid: 538
+    components:
+    - type: Transform
+      pos: 2.5,-12.5
+      parent: 1
+- proto: MachineFlatpacker
+  entities:
+  - uid: 905
+    components:
+    - type: Transform
+      pos: -0.5,19.5
+      parent: 1
+- proto: MachineMaterialSilo
+  entities:
+  - uid: 898
+    components:
+    - type: Transform
+      pos: -0.5,17.5
+      parent: 1
+- proto: MaterialDiamond
+  entities:
+  - uid: 1145
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: MetalFoamGrenade
+  entities:
+  - uid: 1132
+    components:
+    - type: Transform
+      pos: 1.2340666,2.8173194
+      parent: 1
+  - uid: 1133
+    components:
+    - type: Transform
+      pos: 1.3746916,2.8016944
+      parent: 1
+  - uid: 1134
+    components:
+    - type: Transform
+      pos: 1.5934416,2.8329444
+      parent: 1
+  - uid: 1135
+    components:
+    - type: Transform
+      pos: 1.7496916,2.8329444
+      parent: 1
+  - uid: 1136
+    components:
+    - type: Transform
+      pos: 1.2496916,2.4891944
+      parent: 1
+  - uid: 1137
+    components:
+    - type: Transform
+      pos: 1.4059416,2.4891944
+      parent: 1
+  - uid: 1138
+    components:
+    - type: Transform
+      pos: 1.6090666,2.4891944
+      parent: 1
+  - uid: 1139
+    components:
+    - type: Transform
+      pos: 1.7809416,2.4891944
+      parent: 1
+  - uid: 1140
+    components:
+    - type: Transform
+      pos: 1.4684416,2.6610694
+      parent: 1
+  - uid: 1141
+    components:
+    - type: Transform
+      pos: 1.6715666,2.6923194
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 895
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+- proto: OxygenCanister
+  entities:
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+- proto: PaperBin10
+  entities:
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+- proto: PartRodMetal
+  entities:
+  - uid: 1066
+    components:
+    - type: Transform
+      pos: -6.7042255,-1.3313615
+      parent: 1
+  - uid: 1067
+    components:
+    - type: Transform
+      pos: -6.5636005,-1.4251115
+      parent: 1
+  - uid: 1068
+    components:
+    - type: Transform
+      pos: -6.3761005,-1.5032365
+      parent: 1
+  - uid: 1069
+    components:
+    - type: Transform
+      pos: -6.4542255,-1.2532365
+      parent: 1
+  - uid: 1070
+    components:
+    - type: Transform
+      pos: -6.3136005,-1.3626115
+      parent: 1
+- proto: PlaqueAtmos
+  entities:
+  - uid: 1080
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: PlasmaCanister
+  entities:
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 633
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 1059
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 1094
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 1095
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+- proto: PortableGeneratorSuperPacman
+  entities:
+  - uid: 1187
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+- proto: PortableScrubber
+  entities:
+  - uid: 936
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 937
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+- proto: PowerCellMicroreactor
+  entities:
+  - uid: 1056
+    components:
+    - type: Transform
+      pos: 3.9217134,8.78964
+      parent: 1
+  - uid: 1057
+    components:
+    - type: Transform
+      pos: 3.9685884,8.69589
+      parent: 1
+  - uid: 1058
+    components:
+    - type: Transform
+      pos: 4.0154634,8.53964
+      parent: 1
+- proto: PowerDrill
+  entities:
+  - uid: 1048
+    components:
+    - type: Transform
+      pos: 5.6248384,8.82089
+      parent: 1
+  - uid: 1050
+    components:
+    - type: Transform
+      pos: 5.4060884,8.69589
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-13.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-13.5
+      parent: 1
+  - uid: 584
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 588
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-7.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-7.5
+      parent: 1
+  - uid: 1100
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 1101
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-2.5
+      parent: 1
+  - uid: 1102
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 1103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 1104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 1105
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 1106
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 1107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 1108
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 1109
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 1110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 299
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,14.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 634
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -6.5,-1.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -6.5,-3.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 902
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 1118
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 1119
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 1120
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 1256
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 1257
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerArmed
+  entities:
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 1.5080487,-2.4435565
+      parent: 1
+  - uid: 1255
+    components:
+    - type: Transform
+      pos: -0.4711181,-2.433133
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerGamma
+  entities:
+  - uid: 1258
+    components:
+    - type: Transform
+      pos: 0.4976319,-0.36919928
+      parent: 1
+- proto: RandomHumanoidSpawnerERTEngineerRed
+  entities:
+  - uid: 1252
+    components:
+    - type: Transform
+      pos: 1.5080487,-8.416456
+      parent: 1
+  - uid: 1254
+    components:
+    - type: Transform
+      pos: -0.45028484,-8.416456
+      parent: 1
+- proto: RandomPosterLegit
+  entities:
+  - uid: 594
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 595
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 596
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 1220
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 1221
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 1222
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 1223
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 1224
+    components:
+    - type: Transform
+      pos: -1.5,17.5
+      parent: 1
+  - uid: 1225
+    components:
+    - type: Transform
+      pos: 2.5,19.5
+      parent: 1
+- proto: RCDAmmo
+  entities:
+  - uid: 1189
+    components:
+    - type: Transform
+      pos: 0.390625,2.431223
+      parent: 1
+  - uid: 1193
+    components:
+    - type: Transform
+      pos: 0.59375,2.384348
+      parent: 1
+  - uid: 1195
+    components:
+    - type: Transform
+      pos: 0.828125,2.399973
+      parent: 1
+  - uid: 1206
+    components:
+    - type: Transform
+      pos: 0.203125,2.728098
+      parent: 1
+  - uid: 1207
+    components:
+    - type: Transform
+      pos: 0.78125,2.743723
+      parent: 1
+  - uid: 1208
+    components:
+    - type: Transform
+      pos: 0.203125,2.399973
+      parent: 1
+  - uid: 1213
+    components:
+    - type: Transform
+      pos: 0.390625,2.728098
+      parent: 1
+  - uid: 1214
+    components:
+    - type: Transform
+      pos: 0.625,2.743723
+      parent: 1
+- proto: RCDRecharging
+  entities:
+  - uid: 1226
+    components:
+    - type: Transform
+      pos: 3.3290899,8.090826
+      parent: 1
+  - uid: 1227
+    components:
+    - type: Transform
+      pos: 3.5634649,7.981451
+      parent: 1
+- proto: Recycler
+  entities:
+  - uid: 1046
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,17.5
+      parent: 1
+- proto: SheetGlass
+  entities:
+  - uid: 1163
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1164
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1165
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1166
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1167
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1168
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1182
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1183
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1184
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetPlasma
+  entities:
+  - uid: 1146
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetPlasteel
+  entities:
+  - uid: 1161
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1162
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1169
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetPlastic
+  entities:
+  - uid: 1147
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1148
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1151
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1152
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1170
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1173
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1179
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1180
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1181
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: SheetSteel
+  entities:
+  - uid: 1153
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1154
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1155
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1156
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1157
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1158
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1176
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1177
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1178
+    components:
+    - type: Transform
+      parent: 1175
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1259
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1260
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1261
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1262
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1263
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1264
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1265
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1266
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1267
+    components:
+    - type: Transform
+      pos: -1.5495408,2.6116138
+      parent: 1
+  - uid: 1268
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1269
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1270
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1271
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1272
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1273
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1274
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1275
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+  - uid: 1276
+    components:
+    - type: Transform
+      pos: 2.6067095,2.5594943
+      parent: 1
+- proto: SheetUranium
+  entities:
+  - uid: 1159
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1160
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 1174
+    components:
+    - type: Transform
+      parent: 1144
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ShuttersWindow
+  entities:
+  - uid: 1038
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 1039
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 1239
+    components:
+    - type: Transform
+      pos: -4.5,15.5
+      parent: 1
+  - uid: 1242
+    components:
+    - type: Transform
+      pos: -3.5,15.5
+      parent: 1
+  - uid: 1243
+    components:
+    - type: Transform
+      pos: -2.5,15.5
+      parent: 1
+  - uid: 1244
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 2.5,14.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 425
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+- proto: SignalSwitchDirectional
+  entities:
+  - uid: 1023
+    components:
+    - type: MetaData
+      name: Toggle Recycler
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,15.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        1019:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        1020:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        1021:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        1046:
+        - - On
+          - Forward
+        - - Off
+          - Off
+    - type: Fixtures
+      fixtures: {}
+- proto: Sink
+  entities:
+  - uid: 1250
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 1251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 175
+    components:
+    - type: MetaData
+      name: SMES Sovereign
+    - type: Transform
+      pos: 5.5,-10.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: MetaData
+      name: SMES Sovereign
+    - type: Transform
+      pos: 4.5,-10.5
+      parent: 1
+- proto: SMESMachineCircuitboard
+  entities:
+  - uid: 1185
+    components:
+    - type: Transform
+      pos: 1.3112094,19.668194
+      parent: 1
+  - uid: 1186
+    components:
+    - type: Transform
+      pos: 1.5768344,19.621319
+      parent: 1
+- proto: SpaceHeaterAnchored
+  entities:
+  - uid: 943
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 944
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+- proto: StorageCanister
+  entities:
+  - uid: 631
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 632
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 897
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+- proto: SubstationBasic
+  entities:
+  - uid: 167
+    components:
+    - type: MetaData
+      name: Substation Sovereign
+    - type: Transform
+      pos: 3.5,-10.5
+      parent: 1
+- proto: SubstationMachineCircuitboard
+  entities:
+  - uid: 1230
+    components:
+    - type: Transform
+      pos: 1.6237094,19.511944
+      parent: 1
+- proto: SuitStorageERTEngineer
+  entities:
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -7.5,-9.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 506
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+- proto: ThrusterLarge
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-15.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-12.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-15.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-11.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -3.5,21.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 3.5,21.5
+      parent: 1
+- proto: ToolboxElectricalFilled
+  entities:
+  - uid: 549
+    components:
+    - type: Transform
+      pos: 2.4596424,-6.1599946
+      parent: 1
+  - uid: 1064
+    components:
+    - type: Transform
+      pos: -5.3441734,8.459651
+      parent: 1
+  - uid: 1199
+    components:
+    - type: Transform
+      pos: -5.5548716,8.407162
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 2.5690174,-6.5037446
+      parent: 1
+  - uid: 1063
+    components:
+    - type: Transform
+      pos: -5.5472984,8.647151
+      parent: 1
+  - uid: 1202
+    components:
+    - type: Transform
+      pos: -5.3204966,8.672787
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 1055
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+- proto: VendingMachineEngivend
+  entities:
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 2.5,18.5
+      parent: 1
+  - uid: 861
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+- proto: VendingMachineTankDispenserEngineering
+  entities:
+  - uid: 903
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 8.5,-7.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -7.5,-7.5
+      parent: 1
+  - uid: 641
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+- proto: VendingMachineVendomat
+  entities:
+  - uid: 1049
+    components:
+    - type: Transform
+      pos: 1.5,18.5
+      parent: 1
+- proto: VendingMachineYouTool
+  entities:
+  - uid: 651
+    components:
+    - type: Transform
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 904
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+- proto: WallClosetToolsFilled
+  entities:
+  - uid: 1081
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1082
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WallLockerElectricalFilled
+  entities:
+  - uid: 1085
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1086
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,15.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WallLockerWeldingFilled
+  entities:
+  - uid: 1083
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,6.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 1084
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,15.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WallShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -6.5,-13.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -5.5,-13.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -4.5,-13.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -3.5,-13.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -2.5,-13.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: -6.5,-10.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -7.5,-10.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: -5.5,-10.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: -5.5,-11.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: -5.5,-12.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: 3.5,-13.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 5.5,-13.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 6.5,-13.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      pos: 4.5,-13.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 6.5,-14.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 3.5,-14.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 2.5,-14.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      pos: -0.5,-14.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 0.5,-14.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 1.5,-14.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: -1.5,-14.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: -2.5,-14.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: -5.5,-14.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 6.5,-12.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 6.5,-11.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 6.5,-10.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 7.5,-10.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 8.5,-10.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -8.5,-9.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -8.5,-5.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -7.5,-4.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -7.5,-3.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: -7.5,-2.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: -7.5,-1.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 8.5,-2.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: 9.5,-9.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 10.5,-7.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 9.5,-7.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -3.5,-9.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -2.5,-9.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -6.5,-4.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -4.5,-9.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -5.5,-9.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -8.5,-7.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -9.5,-7.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: 7.5,2.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -6.5,0.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: -6.5,1.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      pos: -6.5,2.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      pos: 6.5,-7.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      pos: 6.5,-9.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 5.5,-9.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 7.5,-13.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -1.5,17.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      pos: -5.5,17.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      pos: -5.5,19.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      pos: -5.5,18.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -6.5,-0.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -1.5,18.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -1.5,20.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 5.5,19.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -5.5,-0.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 5.5,20.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -4.5,20.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 1.5,20.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: -0.5,20.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: -1.5,19.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      pos: -4.5,19.5
+      parent: 1
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 616
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 32
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-14.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-13.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-15.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-15.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-15.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,-14.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-13.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-15.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-10.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-10.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-5.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-9.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-9.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -9.5,-5.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: -8.5,-4.5
+      parent: 1
+  - uid: 145
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,20.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -5.5,20.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -7.5,-0.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,21.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,21.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -4.5,21.5
+      parent: 1
+- proto: WarningN2
+  entities:
+  - uid: 1043
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WarningO2
+  entities:
+  - uid: 1044
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WarningPlasma
+  entities:
+  - uid: 1045
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: WarpPointShuttle
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+    - type: WarpPoint
+      location: NTCC Sovereign Paragon
+- proto: WeaponEnergyTurretCommand
+  entities:
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 555
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 555
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -4.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 555
+  - uid: 562
+    components:
+    - type: Transform
+      pos: 0.5,-11.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 555
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 555
+- proto: WeaponEnergyTurretCommandControlPanel
+  entities:
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 562
+      - 563
+      - 554
+      - 553
+      - 551
+- proto: WeaponParticleDecelerator
+  entities:
+  - uid: 1062
+    components:
+    - type: Transform
+      pos: 3.463281,1.8021898
+      parent: 1
+  - uid: 1065
+    components:
+    - type: Transform
+      pos: 3.494531,1.5678148
+      parent: 1
+  - uid: 1247
+    components:
+    - type: Transform
+      pos: 3.3534284,1.7426553
+      parent: 1
+  - uid: 1248
+    components:
+    - type: Transform
+      pos: 3.3534284,1.3989053
+      parent: 1
+- proto: WelderExperimental
+  entities:
+  - uid: 1051
+    components:
+    - type: Transform
+      pos: 4.9685884,8.742765
+      parent: 1
+  - uid: 1052
+    components:
+    - type: Transform
+      pos: 4.7185884,8.53964
+      parent: 1
+- proto: WeldingFuelTankHighCapacity
+  entities:
+  - uid: 358
+    components:
+    - type: Transform
+      pos: -5.5,0.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 1122
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 1124
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 1125
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+- proto: WindoorSecurePlasmaERTLocked
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-12.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-11.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 1040
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,-9.5
+      parent: 1
+  - uid: 1041
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-9.5
+      parent: 1
+  - uid: 1042
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 1060
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 1061
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-6.5
+      parent: 1
+  - uid: 1096
+    components:
+    - type: Transform
+      pos: -6.5,-5.5
+      parent: 1
+  - uid: 1097
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 1098
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 1099
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-9.5
+      parent: 1
+  - uid: 1111
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,-8.5
+      parent: 1
+  - uid: 1112
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 1113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 1114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-6.5
+      parent: 1
+  - uid: 1115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 1
+  - uid: 1116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -8.5,-8.5
+      parent: 1
+  - uid: 1117
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -7.5,-9.5
+      parent: 1
+  - uid: 1245
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 1246
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 1249
+    components:
+    - type: Transform
+      pos: -7.5,-5.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 1121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 1123
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+...

--- a/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-janitor.yml
+++ b/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-janitor.yml
@@ -1,0 +1,3375 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 270.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 07/31/2026 14:59:48
+  entityCount: 469
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  4: Space
+  5: FloorCosmicVoid
+  3: FloorGreenCircuit
+  6: FloorReinforced
+  1: FloorSteel
+  0: FloorSteelMono
+  7: FloorTechMaint
+  9: FloorWhite
+  10: FloorWhiteMono
+  8: FloorWood
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NTCC Marquess Absolver
+    - type: Transform
+      pos: -0.46875,-0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: AgAAAAAAAAkAAAAAAAAJAAAAAAAACgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAJAAAAAAAACQAAAAAAAAoAAAAAAAACAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABgAAAAAAAAYAAAAAAAAFAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAABgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAACAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACQAAAAAAAAkAAAAAAAAKAAAAAAAAAgAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAkAAAAAAAAJAAAAAAAACgAAAAAAAAIAAAAAAAAGAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAJAAAAAAAACQAAAAAAAAoAAAAAAAACAAAAAAAABgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAGAAAAAAAABgAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAKAAAAAAAACQAAAAAAAAkAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAHAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAIAAAAAAAAKAAAAAAAACQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAYAAAAAAAACAAAAAAAACgAAAAAAAAkAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAAAgAAAAAAAAoAAAAAAAAJAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABgAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAABwAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAAGAAAAAAAABgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAABgAAAAAAAAYAAAAAAAACAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAcAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAkAAAAAAAAJAAAAAAAACgAAAAAAAAoAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAJAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAAHAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAHAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAACAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAKAAAAAAAACQAAAAAAAAkAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAACQAAAAAAAAkAAAAAAAAJAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAkAAAAAAAAJAAAAAAAACQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            170: 3,-3
+            171: 2,-3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            7: 1,-5
+            8: 9,-1
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteCornerNe
+          decals:
+            175: 3,4
+            176: 1,8
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            5: -1,-5
+            6: 5,-2
+            9: 8,-1
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteCornerNw
+          decals:
+            172: -3,3
+            177: -1,8
+            178: 1,4
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            10: 1,-7
+            11: 9,-3
+            12: 8,-4
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteCornerSe
+          decals:
+            179: 1,-3
+            180: 3,2
+            181: 2,0
+            182: 1,6
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            13: -1,-7
+            14: 5,-3
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteCornerSw
+          decals:
+            183: -2,-3
+            184: -3,-2
+            185: 1,0
+            186: -1,6
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteEndE
+          decals:
+            187: 3,-2
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteEndN
+          decals:
+            218: -1,4
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteEndS
+          decals:
+            15: 7,-5
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteInnerNe
+          decals:
+            214: -1,-2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            27: 8,-2
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteInnerNw
+          decals:
+            220: -1,3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            25: 7,-4
+            26: 8,-3
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteInnerSe
+          decals:
+            216: 1,-2
+            217: 2,2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            28: 7,-3
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteInnerSw
+          decals:
+            215: -2,-2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineE
+          decals:
+            18: 1,-6
+            19: 9,-2
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteLineE
+          decals:
+            200: -1,-1
+            201: -1,0
+            202: -1,1
+            203: -1,2
+            204: -1,3
+            205: 2,1
+            206: 3,3
+            212: 1,7
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineN
+          decals:
+            21: 6,-2
+            22: 7,-2
+            23: 0,-5
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteLineN
+          decals:
+            207: 2,-2
+            208: 1,-2
+            209: 0,-2
+            210: 2,4
+            211: 0,8
+            219: -2,3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineS
+          decals:
+            16: 0,-7
+            24: 6,-3
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteLineS
+          decals:
+            196: -1,-3
+            197: 0,-3
+            198: 2,-2
+            199: 0,6
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineW
+          decals:
+            17: -1,-6
+            20: 7,-4
+        - node:
+            color: '#8C347F96'
+            id: BrickTileWhiteLineW
+          decals:
+            188: -3,-1
+            189: -3,0
+            190: -3,1
+            191: -3,2
+            192: -1,7
+            193: 1,1
+            194: 1,2
+            195: 1,3
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            2: 1,-8
+            3: -1,-8
+            4: 4,-2
+            111: -1,-4
+            112: 1,-4
+            168: -1,5
+            169: 2,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnFull
+          decals:
+            221: 2,8
+            222: 2,7
+            223: 2,6
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 61166
+          -1,0:
+            0: 61166
+          0,1:
+            0: 30478
+          -1,1:
+            0: 56718
+          0,2:
+            0: 3591
+          -1,2:
+            0: 3613
+          0,-1:
+            0: 20466
+          1,1:
+            0: 4352
+          1,2:
+            0: 17
+          1,-1:
+            0: 28648
+          1,0:
+            0: 128
+          2,0:
+            0: 67
+          2,-1:
+            0: 13107
+          -1,-1:
+            0: 61160
+          0,-2:
+            0: 30646
+          -1,-2:
+            0: 52652
+          1,-2:
+            0: 45824
+          2,-2:
+            0: 20992
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
+- proto: AdvMopItem
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -2.6020052,-2.5249348
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.4301302,-2.6030598
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      pos: 2.2769198,4.615744
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      pos: 2.4644198,4.5427766
+      parent: 1
+- proto: AirAlarm
+  entities:
+  - uid: 368
+    components:
+    - type: MetaData
+      name: 'Air Alarm: Marquess'
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 270
+      - 269
+      - 150
+      - 268
+      - 390
+      - 396
+      - 391
+      - 395
+      - 392
+      - 397
+      - 394
+      - 393
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      anchored: True
+      pos: 7.5,-4.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockERTLocked
+  entities:
+  - uid: 38
+    components:
+    - type: MetaData
+      name: Janitorial Hall
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: MetaData
+      name: Janitorial Hall
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: MetaData
+      name: Helm
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: MetaData
+      name: Janitorial Closet
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: MetaData
+      name: Storage
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+- proto: AirlockExternalGlassShuttleLocked
+  entities:
+  - uid: 168
+    components:
+    - type: MetaData
+      name: Marquess Docking Port
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: MetaData
+      name: Marquess Docking Port
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+- proto: AntiMeteorZone
+  entities:
+  - uid: 453
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: AntiMeteorZone
+      avoidanceRate: 0.33
+      zoneRadius: 13
+- proto: APCHighCapacity
+  entities:
+  - uid: 119
+    components:
+    - type: MetaData
+      name: 'APC: Helm'
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 208
+    components:
+    - type: MetaData
+      name: 'APC: Marquess'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 448
+    components:
+    - type: MetaData
+      name: 'APC: Storage'
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+- proto: BlastDoorOpen
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+- proto: BoxLightMixed
+  entities:
+  - uid: 339
+    components:
+    - type: Transform
+      pos: -1.7278972,6.743449
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      pos: -1.6653972,6.477824
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -1.2903972,6.446574
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: -1.3841472,6.665324
+      parent: 1
+- proto: BoxMousetrap
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      pos: 3.3732564,0.6875
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 3.5138814,0.453125
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: 3.7326314,0.609375
+      parent: 1
+- proto: Bucket
+  entities:
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -1.6942456,4.742591
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: -1.6317456,4.601966
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: -1.2567456,4.523841
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: -1.3146777,4.822034
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+- proto: ButtonFrameGrey
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 440
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+- proto: CleanadeGrenadeBox
+  entities:
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 3.3470259,2.691005
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 3.5032759,2.472255
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 3.6282759,2.691005
+      parent: 1
+- proto: CleanerDispenser
+  entities:
+  - uid: 286
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 383
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: ClosetJanitorFilled
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+- proto: ClothingBackpackWaterTank
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -2.4799612,1.2760395
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+- proto: ConveyorBelt
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+- proto: CrateTrashCartJani
+  entities:
+  - uid: 371
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 0.5,-6.5
+      parent: 1
+- proto: DecalSpawnerDirtWide
+  entities:
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 386
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 242
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-4.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 110
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+- proto: DisposalUnit
+  entities:
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+- proto: EmergencyLight
+  entities:
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+- proto: FloorDrain
+  entities:
+  - uid: 195
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 279
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasPassiveVent
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeBendAlt1
+  entities:
+  - uid: 413
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 414
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeStraightAlt1
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 411
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 412
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 418
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 419
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 426
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 433
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 434
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 409
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 410
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 416
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 420
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 422
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 423
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 424
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 425
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeTJunctionAlt1
+  entities:
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 401
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 403
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 406
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 404
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 405
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPort
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-4.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPressurePumpEnabledStandardAlt1
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 394
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 396
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 392
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 462
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+- proto: HolopadLongRange
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Command
+    - type: Label
+      currentLabel: NTCC Marquess Absolver
+- proto: Holoprojector
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      pos: -2.5858219,0.78690684
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -2.5076969,0.61503184
+      parent: 1
+- proto: HydraLocker
+  entities:
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+- proto: JanitorialTrolley
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+- proto: Jug
+  entities:
+  - uid: 254
+    components:
+    - type: MetaData
+      name: jug (bleach)
+    - type: Transform
+      pos: 3.7016594,3.828351
+      parent: 1
+    - type: Label
+      currentLabel: bleach
+    - type: NameModifier
+      baseName: jug
+    - type: SolutionContainerManager
+      solutions:
+        beaker:
+          temperature: 293.15
+          canReact: True
+          maxVol: 200
+          name: null
+          reagents:
+          - data: []
+            ReagentId: Bleach
+            Quantity: 200
+  - uid: 384
+    components:
+    - type: MetaData
+      name: jug (bleach)
+    - type: Transform
+      pos: 3.7016594,3.484601
+      parent: 1
+    - type: Label
+      currentLabel: bleach
+    - type: NameModifier
+      baseName: jug
+    - type: SolutionContainerManager
+      solutions:
+        beaker:
+          temperature: 293.15
+          canReact: True
+          maxVol: 200
+          name: null
+          reagents:
+          - data: []
+            ReagentId: Bleach
+            Quantity: 200
+- proto: LightReplacer
+  entities:
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 3.3523307,1.549786
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 3.396759,1.6779838
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 3.63201,1.6927149
+      parent: 1
+- proto: LockableButtonERT
+  entities:
+  - uid: 112
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        201:
+        - - Pressed
+          - Toggle
+        140:
+        - - Pressed
+          - Toggle
+        199:
+        - - Pressed
+          - Toggle
+        116:
+        - - Pressed
+          - Toggle
+        252:
+        - - Pressed
+          - Toggle
+        250:
+        - - Pressed
+          - Toggle
+        117:
+        - - Pressed
+          - Toggle
+        256:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 257
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        114:
+        - - Pressed
+          - Toggle
+        111:
+        - - Pressed
+          - Toggle
+        115:
+        - - Pressed
+          - Toggle
+        273:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: LockerWallEvacRepairFilled
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 2.4147086,-5.404975
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 2.6647086,-5.6081
+      parent: 1
+- proto: MegaSprayBottle
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 2.2752378,4.7298946
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 2.4627378,4.5892696
+      parent: 1
+- proto: PlasmaReinforcedWindowDirectional
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+- proto: Plunger
+  entities:
+  - uid: 219
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5251129,3.5926642
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 1.6501129,3.4676642
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 1.3844879,3.6707892
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 1.2438629,3.4676642
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5563629,3.7176642
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTJanitorGamma
+  entities:
+  - uid: 466
+    components:
+    - type: Transform
+      pos: 2.3262382,1.5902452
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: 2.2637382,0.66251785
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      pos: 9.497535,-0.39262414
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      pos: 8.528785,-0.38220048
+      parent: 1
+- proto: RandomPosterLegit
+  entities:
+  - uid: 232
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+- proto: Recycler
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+- proto: ServiceTechFab
+  entities:
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+- proto: SheetGlass
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      pos: -1.7122722,7.665324
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: -1.6341472,7.509074
+      parent: 1
+- proto: SheetPlastic
+  entities:
+  - uid: 317
+    components:
+    - type: Transform
+      pos: -1.5247722,7.477824
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: -1.4778972,7.649699
+      parent: 1
+- proto: SheetSteel
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -1.3672556,7.7004666
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -1.3985056,7.4348416
+      parent: 1
+- proto: SheetUranium
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 9.652748,-2.505638
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 9.340248,-2.380638
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+- proto: ShuttleWindowDiagonal
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: SignalSwitchDirectional
+  entities:
+  - uid: 328
+    components:
+    - type: MetaData
+      name: Toggle Recycler
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        357:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        58:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        332:
+        - - On
+          - Forward
+        - - Off
+          - Off
+        258:
+        - - On
+          - Forward
+        - - Off
+          - Off
+    - type: Fixtures
+      fixtures: {}
+- proto: SinkWide
+  entities:
+  - uid: 306
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 107
+    components:
+    - type: MetaData
+      name: 'SMES: Marquess'
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+- proto: SoapNT
+  entities:
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 1.5094879,4.7020392
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 1.6032379,4.4676642
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 108
+    components:
+    - type: MetaData
+      name: 'Substation: Marquess'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 1
+- proto: SuitStorageEVA
+  entities:
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: ThrusterLarge
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 9.465248,-2.661888
+      parent: 1
+- proto: TrashBagOfHolding
+  entities:
+  - uid: 246
+    components:
+    - type: Transform
+      pos: -2.6311371,4.4832892
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: -2.3342621,4.5301642
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: -2.778774,4.586341
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+- proto: WarpPointShuttle
+  entities:
+  - uid: 274
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+    - type: WarpPoint
+      location: NTCC Marquess Absolver
+- proto: WaterTankHighCapacity
+  entities:
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: WeaponSprayNozzle
+  entities:
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -2.3610969,1.7227578
+      parent: 1
+- proto: WetFloorSign
+  entities:
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 3.5235531,4.7712817
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 3.6329281,4.7087817
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: 3.7110531,4.8025317
+      parent: 1
+- proto: WindoorSecurePlasma
+  entities:
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,8.5
+      parent: 1
+- proto: WindoorSecurePlasmaERTLocked
+  entities:
+  - uid: 287
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+- proto: WireBrush
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.9689713,4.71395
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.7502213,4.6202
+      parent: 1
+...

--- a/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-medical.yml
+++ b/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-medical.yml
@@ -1,0 +1,3704 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 270.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 07/31/2026 15:41:03
+  entityCount: 558
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  0: Space
+  21: FloorBlueCircuit
+  36: FloorDark
+  1: FloorFreezer
+  63: FloorGreenCircuit
+  2: FloorMS13MetalGrate
+  126: FloorMetalDiamond
+  159: FloorRGlass
+  193: FloorTechMaint3
+  196: FloorWhite
+  215: Lattice
+  253: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: ERT - Butterfly
+    - type: Transform
+      pos: -0.515625,-0.453125
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: wQAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAAH4AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAMEAAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAfgAAAAAAAH4AAAAAAADEAAAAAAAAxAAAAAAAAH4AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAAB+AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAfgAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAD9AAAAAAAAwQAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAPwAAAAAAAMQAAAAAAADEAAAAAAAAfgAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAD8AAAAAAADEAAAAAAAAxAAAAAAAAH4AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAD9AAAAAAAAPwAAAAAAAD8AAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAAEAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAMEAAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAB+AAAAAAAAfgAAAAAAAP0AAAAAAAD9AAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAD9AAAAAAAAfgAAAAAAAP0AAAAAAAB+AAAAAAAA/QAAAAAAAH4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAA/QAAAAAAAH4AAAAAAAB+AAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAB+AAAAAAAAfgAAAAAAAP0AAAAAAAAVAAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANcAAAAAAAD9AAAAAAAAfgAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADXAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1wAAAAAAANcAAAAAAADXAAAAAAAA1wAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADBAAAAAAAA/QAAAAAAAMEAAAAAAAD9AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAJAAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAACQAAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAFQAAAAAAABUAAAAAAAAVAAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAAJ8AAAAAAACfAAAAAAAAnwAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADEAAAAAAAAxAAAAAAAAMQAAAAAAAAVAAAAAAAAFQAAAAAAABUAAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAnwAAAAAAAJ8AAAAAAACfAAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAABUAAAAAAAAVAAAAAAAAFQAAAAAAAP0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAwQAAAAAAAMEAAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAMQAAAAAAADEAAAAAAAAfgAAAAAAAH4AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAB+AAAAAAAAPwAAAAAAAD8AAAAAAAA/AAAAAAAA/QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAPwAAAAAAAMQAAAAAAADEAAAAAAAAxAAAAAAAAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAH4AAAAAAADEAAAAAAAAfgAAAAAAAMQAAAAAAAB+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0AAAAAAAB+AAAAAAAAxAAAAAAAAMQAAAAAAADEAAAAAAAAfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAfgAAAAAAAD8AAAAAAADEAAAAAAAAxAAAAAAAAH4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/QAAAAAAAP0AAAAAAAD9AAAAAAAAfgAAAAAAAMEAAAAAAAD9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9AAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            66: -2,6
+            67: -4,3
+            68: 4,0
+            69: 4,-1
+            79: 3,-5
+            80: 4,-5
+            81: 5,-5
+            82: 3,-3
+            83: 4,-3
+            84: 5,-3
+            85: 3,-7
+            86: 4,-7
+            87: 5,-7
+            88: 5,4
+            89: 5,3
+            90: 5,2
+            91: 2,2
+            92: 1,2
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            63: 0,-4
+            64: 0,-3
+            70: 3,-1
+        - node:
+            color: '#3CBEFFFF'
+            id: FullTileOverlayGreyscale
+          decals:
+            0: 2,-3
+            1: 0,-3
+            2: 1,-4
+            3: 0,-5
+            4: 2,-5
+            5: 1,-6
+            6: 0,-7
+            7: 2,-7
+            8: 1,-8
+            12: -3,-3
+            13: -2,-4
+            14: -4,-4
+            15: -4,-6
+            16: -2,-6
+            20: 1,-1
+            21: 2,0
+            24: 2,3
+            25: 3,2
+            26: 4,3
+            28: 3,4
+            29: 1,4
+            30: 2,5
+            31: 1,6
+            32: 3,6
+            33: 4,5
+        - node:
+            color: '#646464FF'
+            id: MiniTileSteelInnerNe
+          decals:
+            52: -2,0
+        - node:
+            color: '#646464FF'
+            id: MiniTileSteelInnerSe
+          decals:
+            53: -2,0
+        - node:
+            color: '#646464FF'
+            id: MiniTileSteelLineE
+          decals:
+            50: -2,-1
+            51: -2,1
+            58: -1,-9
+            59: -1,-10
+        - node:
+            color: '#646464FF'
+            id: MiniTileSteelLineN
+          decals:
+            55: -1,0
+        - node:
+            color: '#646464FF'
+            id: MiniTileSteelLineS
+          decals:
+            54: -1,0
+            56: 1,-8
+            57: 0,-8
+            62: 2,-8
+        - node:
+            color: '#646464FF'
+            id: MiniTileSteelLineW
+          decals:
+            46: -3,1
+            47: -3,0
+            48: -3,-1
+            60: 3,-9
+            61: 3,-10
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 61071
+          -1,0:
+            0: 62719
+          0,1:
+            0: 20222
+          -1,1:
+            0: 65535
+          0,2:
+            0: 3310
+          -1,2:
+            1: 192
+            2: 16
+          0,-1:
+            0: 59135
+          1,0:
+            0: 13057
+          1,1:
+            0: 275
+            1: 17408
+          1,2:
+            0: 17
+          1,-1:
+            0: 4147
+          -2,1:
+            1: 34
+            2: 8192
+            0: 34952
+          -2,2:
+            2: 226
+          -2,0:
+            0: 32768
+          -1,-1:
+            0: 62719
+          0,-3:
+            0: 65360
+          -1,-3:
+            0: 34816
+            1: 12288
+          0,-2:
+            0: 65527
+          -1,-2:
+            0: 32624
+          1,-2:
+            0: 13104
+          1,-3:
+            1: 8192
+          -2,-2:
+            0: 34944
+          -2,-1:
+            0: 136
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        - volume: 2500
+          temperature: 293.15
+          moles: {}
+        - volume: 2500
+          immutable: True
+          moles: {}
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: IFF
+      color: '#0000FFFF'
+    - type: ImplicitRoof
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
+- proto: AirAlarm
+  entities:
+  - uid: 501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 507
+      - 186
+      - 219
+      - 398
+      - 399
+      - 502
+      - 503
+      - 504
+      - 400
+      - 508
+      - 218
+      - 185
+      - 401
+      - 505
+      - 510
+      - 422
+      - 404
+    - type: Fixtures
+      fixtures: {}
+  - uid: 506
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 509
+      - 401
+      - 505
+      - 422
+      - 183
+      - 402
+      - 511
+      - 184
+      - 222
+      - 403
+      - 404
+      - 513
+      - 187
+      - 220
+      - 405
+      - 512
+      - 188
+      - 223
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+- proto: AirlockCentralCommandLocked
+  entities:
+  - uid: 431
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 432
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 433
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 434
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 435
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 436
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 439
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,7.5
+      parent: 1
+- proto: AirlockExternalGlassShuttleLocked
+  entities:
+  - uid: 474
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+- proto: AirSensor
+  entities:
+  - uid: 507
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 508
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 511
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+- proto: APCBasic
+  entities:
+  - uid: 289
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanTiny
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 0.5,-10.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: 2.5,-10.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 486
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -6.5,8.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: -3.5,-8.5
+      parent: 1
+- proto: Beaker
+  entities:
+  - uid: 395
+    components:
+    - type: Transform
+      pos: -4.2174554,-3.0917096
+      parent: 1
+    - type: CollisionWake
+      enabled: False
+  - uid: 396
+    components:
+    - type: Transform
+      pos: -4.5455804,-2.9042096
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      pos: -4.8580804,-2.0917096
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 539
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+- proto: BoxBeaker
+  entities:
+  - uid: 392
+    components:
+    - type: Transform
+      pos: -4.6705804,-2.7010846
+      parent: 1
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -4.2643304,-2.7948346
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 329
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 331
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 338
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 345
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 346
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 350
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 351
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 352
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 353
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 356
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 359
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 362
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 363
+    components:
+    - type: Transform
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 364
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 365
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 366
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 367
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 368
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 369
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 371
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 372
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 373
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 376
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 377
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 379
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 380
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 381
+    components:
+    - type: Transform
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 382
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 383
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 384
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 385
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 301
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 311
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+- proto: CarpetGreen
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 443
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,8.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 163
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 165
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: 0.5,-9.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: 1.5,-8.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 2.5,-8.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 2.5,-9.5
+      parent: 1
+- proto: Chair
+  entities:
+  - uid: 532
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-6.5
+      parent: 1
+- proto: ChairFolding
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.2011676,4.635354
+      parent: 1
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5460577,3.9057546
+      parent: 1
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 2.4679327,5.4057546
+      parent: 1
+  - uid: 447
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.6866828,4.6713796
+      parent: 1
+  - uid: 449
+    components:
+    - type: Transform
+      pos: 3.4835577,5.3588796
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.4835577,3.8901296
+      parent: 1
+- proto: ChairOfficeDark
+  entities:
+  - uid: 517
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.3339574,-3.4517179
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: -2.7402074,-5.420468
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 262
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,9.5
+      parent: 1
+- proto: ChemDispenser
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -3.5,-6.5
+      parent: 1
+- proto: ChemistryHotplate
+  entities:
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -4.5,-3.5
+      parent: 1
+    - type: ItemPlacer
+      placedEntities:
+      - 395
+    - type: PlaceableSurface
+      isPlaceable: False
+- proto: ChemMaster
+  entities:
+  - uid: 270
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+- proto: ComputerCrewMonitoring
+  entities:
+  - uid: 411
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+- proto: CrateFoodDonkpocketSweet
+  entities:
+  - uid: 455
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+- proto: CrateMedicalSurgery
+  entities:
+  - uid: 387
+    components:
+    - type: Transform
+      pos: 5.5,4.5
+      parent: 1
+- proto: CryoPod
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 515
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: DeployableBarrier
+  entities:
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 3.5,-9.5
+      parent: 1
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 3.5,-8.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: -0.5,-9.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+- proto: DVSmartFridgeMedical
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+    - type: FaxMachine
+      name: ERT Medievac
+- proto: FirelockEdge
+  entities:
+  - uid: 406
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 417
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 419
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 503
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 504
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 505
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+      - 506
+- proto: FirelockGlass
+  entities:
+  - uid: 398
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 399
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 400
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+      - 506
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+      - 506
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 422
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+      - 506
+- proto: FloorDrain
+  entities:
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -4.5,-4.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasFilterFlipped
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 150
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 252
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+- proto: GasPipeBend
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,9.5
+      parent: 1
+- proto: GasPipeStraight
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 197
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+- proto: GasPipeTJunction
+  entities:
+  - uid: 149
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 208
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+- proto: GasPort
+  entities:
+  - uid: 70
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+- proto: GasPressurePump
+  entities:
+  - uid: 151
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,7.5
+      parent: 1
+- proto: GasThermoMachineFreezer
+  entities:
+  - uid: 148
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,3.5
+      parent: 1
+- proto: GasVentPump
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 185
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 187
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+- proto: GasVentScrubber
+  entities:
+  - uid: 218
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 219
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 501
+  - uid: 220
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 221
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+  - uid: 223
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 506
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 282
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 109
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 112
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,8.5
+      parent: 1
+- proto: HoloprojectorSecurity
+  entities:
+  - uid: 483
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.653673,6.5763016
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.481798,6.7638016
+      parent: 1
+- proto: KitchenMicrowave
+  entities:
+  - uid: 454
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+- proto: LargeBeaker
+  entities:
+  - uid: 394
+    components:
+    - type: Transform
+      pos: -4.7955804,-2.9042096
+      parent: 1
+- proto: LockableButtonCommand
+  entities:
+  - uid: 537
+    components:
+    - type: MetaData
+      name: Bolt Lockable Button
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        536:
+        - - Pressed
+          - DoorBolt
+        535:
+        - - Pressed
+          - DoorBolt
+    - type: Fixtures
+      fixtures: {}
+  - uid: 538
+    components:
+    - type: MetaData
+      name: Toggle Windoor Lockable
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        535:
+        - - Pressed
+          - Toggle
+        536:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: MedicalBed
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 5.5,-6.5
+      parent: 1
+- proto: MedicalTechFab
+  entities:
+  - uid: 516
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+- proto: MedkitBruteFilled
+  entities:
+  - uid: 390
+    components:
+    - type: Transform
+      pos: 2.4334984,4.5396633
+      parent: 1
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 2.2459984,4.8209133
+      parent: 1
+- proto: MedkitBurnFilled
+  entities:
+  - uid: 389
+    components:
+    - type: Transform
+      pos: 2.8709984,4.5709133
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      pos: 2.6053734,4.8834133
+      parent: 1
+- proto: MedkitOxygenFilled
+  entities:
+  - uid: 476
+    components:
+    - type: Transform
+      pos: 3.3553734,4.4615383
+      parent: 1
+- proto: MedkitRadiationFilled
+  entities:
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 3.0584984,4.8052883
+      parent: 1
+- proto: Morgue
+  entities:
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: -4.5,3.5
+      parent: 1
+- proto: OxygenCanister
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: -4.5,5.5
+      parent: 1
+- proto: PaperBin20
+  entities:
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 457
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-9.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-6.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 547
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalArmed
+  entities:
+  - uid: 555
+    components:
+    - type: Transform
+      pos: 3.4894366,9.508381
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalGamma
+  entities:
+  - uid: 554
+    components:
+    - type: Transform
+      pos: 4.2706866,4.7394433
+      parent: 1
+- proto: RandomHumanoidSpawnerERTMedicalRed
+  entities:
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -2.766367,-5.4066896
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: 2.4810286,-6.305752
+      parent: 1
+- proto: SheetGlass
+  entities:
+  - uid: 550
+    components:
+    - type: Transform
+      pos: 2.5074718,2.4974363
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: 2.5074718,2.4974363
+      parent: 1
+- proto: SheetPlasma
+  entities:
+  - uid: 391
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5143304,-6.3729596
+      parent: 1
+- proto: SheetPlastic
+  entities:
+  - uid: 548
+    components:
+    - type: Transform
+      pos: 2.3043468,2.4974363
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: 2.3043468,2.4974363
+      parent: 1
+- proto: SheetSteel
+  entities:
+  - uid: 552
+    components:
+    - type: Transform
+      pos: 2.7262218,2.4974363
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: 2.7262218,2.4974363
+      parent: 1
+- proto: SheetUranium
+  entities:
+  - uid: 424
+    components:
+    - type: Transform
+      pos: -4.4906034,-6.418018
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,11.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+- proto: SignMorgue
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: SinkWide
+  entities:
+  - uid: 413
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+- proto: StasisBed
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: Syringe
+  entities:
+  - uid: 481
+    components:
+    - type: Transform
+      pos: -4.266017,-2.857554
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 482
+    components:
+    - type: Transform
+      pos: -4.609767,-2.826304
+      parent: 1
+- proto: Table
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 426
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,6.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 130
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-8.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-8.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,5.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,4.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 108
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 480
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-3.5
+      parent: 1
+- proto: VendingMachineChemicals
+  entities:
+  - uid: 272
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+- proto: VendingMachineMedical
+  entities:
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 5.5,3.5
+      parent: 1
+  - uid: 388
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+- proto: VendingMachineRestockMedical
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 3.6991234,4.5331182
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      pos: 3.4959984,4.8143682
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-8.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,7.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,0.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-8.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-10.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-10.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-10.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-10.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,-9.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,3.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-8.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-9.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-7.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 86
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 95
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 141
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+- proto: WaterCooler
+  entities:
+  - uid: 456
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      anchored: True
+      pos: 2.5,-4.5
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      bodyType: Static
+- proto: WaterVaporCanister
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      pos: -4.5,4.5
+      parent: 1
+- proto: WeldingFuelTankHighCapacity
+  entities:
+  - uid: 279
+    components:
+    - type: Transform
+      anchored: True
+      pos: -2.5,-4.5
+      parent: 1
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      bodyType: Static
+- proto: Windoor
+  entities:
+  - uid: 477
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+- proto: WindoorSecureCentralCommandLocked
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+  - uid: 410
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 429
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-2.5
+      parent: 1
+  - uid: 430
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+...

--- a/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-security.yml
+++ b/Resources/Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-security.yml
@@ -1,0 +1,3045 @@
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 270.1.0
+  forkId: ""
+  forkVersion: ""
+  time: 07/31/2026 14:53:17
+  entityCount: 423
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  4: Space
+  5: FloorCosmicVoid
+  3: FloorGreenCircuit
+  6: FloorReinforced
+  1: FloorSteel
+  0: FloorSteelMono
+  7: FloorTechMaint
+  8: FloorWood
+  2: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: NTCC Marquess Sentinel
+    - type: Transform
+      pos: -0.46875,-0.5
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: BgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAcAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABgAAAAAAAAYAAAAAAAAFAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAYAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAgAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAGAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAABgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAGAAAAAAAABgAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        -1,0:
+          ind: -1,0
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAAHAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAYAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABQAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAFAAAAAAAABgAAAAAAAAYAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        0,-1:
+          ind: 0,-1
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAABwAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAQAAAAAAAAEAAAAAAAACAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAIAAAAAAAAGAAAAAAAABgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAUAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAAAAAAAAAACAAAAAAAABgAAAAAAAAYAAAAAAAACAAAAAAAAAQAAAAAAAAMAAAAAAAACAAAAAAAABQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAcAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAEAAAAAAAABAAAAAAAAAwAAAAAAAAIAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAEAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAACAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAGAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABwAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABgAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAAAgAAAAAAAAIAAAAAAAADAAAAAAAAAwAAAAAAAAIAAAAAAAABAAAAAAAAAQAAAAAAAAIAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAA==
+          version: 7
+        -1,-1:
+          ind: -1,-1
+          tiles: BAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAAHAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAACAAAAAAAAAQAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAUAAAAAAAACAAAAAAAAAAAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAACAAAAAAAAAgAAAAAAAAAAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAAAgAAAAAAAAIAAAAAAAACAAAAAAAABwAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAIAAAAAAAAAAAAAAAAAAQAAAAAAAAEAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAGAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAAEAAAAAAAABgAAAAAAAAEAAAAAAAABAAAAAAAAAQAAAAAAAA==
+          version: 7
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+      dampingModifier: 0.25
+    - type: ImplicitRoof
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            7: 1,-5
+            8: 9,-1
+            139: -1,4
+            157: 1,8
+        - node:
+            color: '#D58C18FF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            117: 3,1
+            118: 3,4
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            5: -1,-5
+            6: 5,-2
+            9: 8,-1
+            134: -2,4
+            135: -3,3
+            156: -1,8
+        - node:
+            color: '#D58C18FF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            119: 1,4
+            120: 1,1
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            10: 1,-7
+            11: 9,-3
+            12: 8,-4
+            136: 1,-3
+            159: 1,6
+        - node:
+            color: '#D58C18FF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            121: 3,0
+            122: 3,3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            13: -1,-7
+            14: 5,-3
+            137: -2,-3
+            138: -3,-2
+            158: -1,6
+        - node:
+            color: '#D58C18FF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            123: 1,0
+            124: 1,3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteEndE
+          decals:
+            140: 3,-2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteEndS
+          decals:
+            15: 7,-5
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            164: -1,-2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            27: 8,-2
+            167: -2,3
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            25: 7,-4
+            26: 8,-3
+            165: 1,-2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            28: 7,-3
+            166: -2,-2
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineE
+          decals:
+            18: 1,-6
+            19: 9,-2
+            144: -1,-1
+            145: -1,0
+            146: -1,1
+            147: -1,2
+            148: -1,3
+            163: 1,7
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineN
+          decals:
+            21: 6,-2
+            22: 7,-2
+            23: 0,-5
+            141: 2,-2
+            142: 1,-2
+            143: 0,-2
+            162: 0,8
+        - node:
+            color: '#D58C18FF'
+            id: BrickTileWhiteLineN
+          decals:
+            125: 2,4
+            128: 2,1
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineS
+          decals:
+            16: 0,-7
+            24: 6,-3
+            153: 2,-2
+            154: 0,-3
+            155: -1,-3
+            160: 0,6
+        - node:
+            color: '#D58C18FF'
+            id: BrickTileWhiteLineS
+          decals:
+            126: 2,3
+            127: 2,0
+        - node:
+            color: '#0E7F1BFF'
+            id: BrickTileWhiteLineW
+          decals:
+            17: -1,-6
+            20: 7,-4
+            149: -3,2
+            150: -3,1
+            151: -3,0
+            152: -3,-1
+            161: -1,7
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            2: 1,-8
+            3: -1,-8
+            4: 4,-2
+            111: -1,-4
+            112: 1,-4
+            113: 0,1
+            115: -1,5
+            116: 0,3
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 61694
+          -1,0:
+            0: 61166
+          0,1:
+            0: 30478
+          -1,1:
+            0: 56718
+          0,2:
+            0: 3591
+          -1,2:
+            0: 3613
+          1,1:
+            0: 4352
+          1,2:
+            0: 17
+          1,-1:
+            0: 28648
+          1,0:
+            0: 128
+          2,0:
+            0: 67
+          2,-1:
+            0: 13107
+          -1,-1:
+            0: 61160
+          0,-2:
+            0: 30646
+          -1,-2:
+            0: 52652
+          0,-1:
+            0: 4082
+          1,-2:
+            0: 45824
+          2,-2:
+            0: 20992
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
+- proto: AirAlarm
+  entities:
+  - uid: 368
+    components:
+    - type: MetaData
+      name: 'Air Alarm: Marquess'
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 354
+      - 355
+      - 352
+      - 357
+      - 356
+      - 353
+      - 358
+      - 351
+      - 359
+      - 350
+      - 270
+      - 269
+      - 268
+      - 150
+    - type: Fixtures
+      fixtures: {}
+- proto: AirCanister
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      anchored: True
+      pos: 7.5,-4.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: AirlockERTGlassLocked
+  entities:
+  - uid: 38
+    components:
+    - type: MetaData
+      name: Cell 2
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: MetaData
+      name: Cell 1
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+- proto: AirlockERTLocked
+  entities:
+  - uid: 86
+    components:
+    - type: MetaData
+      name: Foyer
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+  - uid: 87
+    components:
+    - type: MetaData
+      name: Foyer
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: MetaData
+      name: Helm
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 111
+    components:
+    - type: MetaData
+      name: Storage
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+- proto: AirlockExternalGlassShuttleLocked
+  entities:
+  - uid: 168
+    components:
+    - type: MetaData
+      name: Marquess Docking Port
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 169
+    components:
+    - type: MetaData
+      name: Marquess Docking Port
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+- proto: AntiMeteorZone
+  entities:
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+    - type: AntiMeteorZone
+      avoidanceRate: 0.33
+      zoneRadius: 13
+- proto: APCHighCapacity
+  entities:
+  - uid: 119
+    components:
+    - type: MetaData
+      name: 'APC: Helm'
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+  - uid: 208
+    components:
+    - type: MetaData
+      name: 'APC: Marquess'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 409
+    components:
+    - type: Transform
+      pos: 1.5,-7.5
+      parent: 1
+  - uid: 411
+    components:
+    - type: Transform
+      pos: -0.5,-7.5
+      parent: 1
+- proto: Bed
+  entities:
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+- proto: BedsheetOrange
+  entities:
+  - uid: 217
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+- proto: BlastDoorUnlinkedERTOpen
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 114
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 117
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 256
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+- proto: BoxHandcuff
+  entities:
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 2.6087122,7.537424
+      parent: 1
+- proto: BoxMRE
+  entities:
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 1.2947795,4.6980047
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: 1.3572795,0.38550448
+      parent: 1
+- proto: BoxStinger
+  entities:
+  - uid: 331
+    components:
+    - type: Transform
+      pos: 2.6727726,6.485489
+      parent: 1
+- proto: BoxTearGas
+  entities:
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 2.3915226,6.672989
+      parent: 1
+- proto: BoxZiptie
+  entities:
+  - uid: 334
+    components:
+    - type: Transform
+      pos: 2.4212122,7.662424
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 273
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 151
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 152
+    components:
+    - type: Transform
+      pos: 7.5,-3.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      pos: 1.5,-5.5
+      parent: 1
+  - uid: 162
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      pos: -0.5,-5.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 189
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -0.5,0.5
+      parent: 1
+  - uid: 276
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 290
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+  - uid: 315
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 320
+    components:
+    - type: Transform
+      pos: 3.5,3.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 129
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 134
+    components:
+    - type: Transform
+      pos: 9.5,-1.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 423
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 155
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 212
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 213
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 215
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,-3.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,3.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,-0.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-0.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+- proto: ComputerIFF
+  entities:
+  - uid: 101
+    components:
+    - type: Transform
+      pos: 9.5,0.5
+      parent: 1
+- proto: ComputerShuttle
+  entities:
+  - uid: 100
+    components:
+    - type: Transform
+      pos: 8.5,0.5
+      parent: 1
+- proto: CrateTrackingImplants
+  entities:
+  - uid: 328
+    components:
+    - type: Transform
+      pos: 0.5,6.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Armory
+- proto: DecalSpawnerDirtWide
+  entities:
+  - uid: 377
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+  - uid: 378
+    components:
+    - type: Transform
+      pos: 0.5,-5.5
+      parent: 1
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 401
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 402
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 2.5,1.5
+      parent: 1
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,5.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: DrinkWaterCup
+  entities:
+  - uid: 259
+    components:
+    - type: Transform
+      pos: 3.6017022,-2.2272058
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: 3.4454522,-2.3209558
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 3.2735772,-2.3209558
+      parent: 1
+- proto: EmergencyLight
+  entities:
+  - uid: 369
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-6.5
+      parent: 1
+- proto: FaxMachineBase
+  entities:
+  - uid: 241
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+    - type: FaxMachine
+      name: NTCC Marquess Sentinel
+- proto: FoodSnackEnergy
+  entities:
+  - uid: 243
+    components:
+    - type: Transform
+      pos: 3.4287937,-2.5491405
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: 3.7100437,-2.4710155
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: 3.6944187,-2.6272655
+      parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeBendAlt1
+  entities:
+  - uid: 385
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 393
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 394
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 395
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 396
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeBendAlt2
+  entities:
+  - uid: 288
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 300
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 311
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 397
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 398
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeFourwayAlt1
+  entities:
+  - uid: 370
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeStraightAlt1
+  entities:
+  - uid: 183
+    components:
+    - type: Transform
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 293
+    components:
+    - type: Transform
+      pos: 7.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 294
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 295
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 298
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 304
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 305
+    components:
+    - type: Transform
+      pos: 1.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 376
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 386
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 387
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 388
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 392
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 399
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeStraightAlt2
+  entities:
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 306
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 307
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 308
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 312
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 373
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 389
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 390
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 391
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPipeTJunctionAlt1
+  entities:
+  - uid: 292
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 360
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 362
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPipeTJunctionAlt2
+  entities:
+  - uid: 309
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 361
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 366
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 367
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GasPort
+  entities:
+  - uid: 120
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-4.5
+      parent: 1
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasPressurePumpEnabledStandardAlt1
+  entities:
+  - uid: 121
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,-3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasVentPump
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 269
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 356
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 357
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Secondary
+    - type: AtmosPipeColor
+      color: '#0337FCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 270
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 350
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-1.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 351
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 352
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 353
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+  - uid: 354
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 368
+    - type: AtmosPipeLayers
+      pipeLayer: Tertiary
+    - type: AtmosPipeColor
+      color: '#FF1212FF'
+- proto: GeneratorBasic15kW
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      pos: 8.5,-3.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 8.5,-4.5
+      parent: 1
+- proto: GeneratorWallmountAPU
+  entities:
+  - uid: 125
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 422
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 94
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 95
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+  - uid: 96
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+- proto: GunSafeVulcanRifle
+  entities:
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+  - uid: 420
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 105
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+- proto: HolopadLongRange
+  entities:
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+    - type: AccessReader
+      accessListsOriginal:
+      - - Command
+    - type: Label
+      currentLabel: NTCC Marquess Sentinel
+- proto: HoloprojectorSecurity
+  entities:
+  - uid: 341
+    components:
+    - type: Transform
+      pos: -2.6133366,-2.3091257
+      parent: 1
+  - uid: 342
+    components:
+    - type: Transform
+      pos: -2.4258366,-2.5122507
+      parent: 1
+- proto: JetpackSecurity
+  entities:
+  - uid: 345
+    components:
+    - type: Transform
+      pos: 0.29640877,-4.2721796
+      parent: 1
+  - uid: 347
+    components:
+    - type: Transform
+      pos: 0.6089088,-4.3034296
+      parent: 1
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 0.29640877,-4.5065546
+      parent: 1
+  - uid: 349
+    components:
+    - type: Transform
+      pos: 0.6245338,-4.4909296
+      parent: 1
+- proto: LockableButtonERT
+  entities:
+  - uid: 255
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        117:
+        - - Pressed
+          - Toggle
+        256:
+        - - Pressed
+          - Toggle
+        140:
+        - - Pressed
+          - Toggle
+        115:
+        - - Pressed
+          - Toggle
+        112:
+        - - Pressed
+          - Toggle
+        114:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+  - uid: 410
+    components:
+    - type: MetaData
+      name: Toggle Blastdoors
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,-0.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        253:
+        - - Pressed
+          - Toggle
+        254:
+        - - Pressed
+          - Toggle
+        116:
+        - - Pressed
+          - Toggle
+        246:
+        - - Pressed
+          - Toggle
+    - type: Fixtures
+      fixtures: {}
+- proto: LockerWallEvacRepairFilled
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-3.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: MedkitAdvancedFilled
+  entities:
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 2.4147086,-5.404975
+      parent: 1
+- proto: MedkitCombatFilled
+  entities:
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 2.6647086,-5.6081
+      parent: 1
+  - uid: 336
+    components:
+    - type: Transform
+      pos: 0.40155023,8.670843
+      parent: 1
+  - uid: 337
+    components:
+    - type: Transform
+      pos: 0.60467523,8.498968
+      parent: 1
+- proto: MedkitRadiationFilled
+  entities:
+  - uid: 339
+    components:
+    - type: Transform
+      pos: 0.60467523,8.623968
+      parent: 1
+- proto: MedkitToxinFilled
+  entities:
+  - uid: 338
+    components:
+    - type: Transform
+      pos: 0.40155023,8.436468
+      parent: 1
+- proto: Paper
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.6320422,1.5573795
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.4289172,3.6667545
+      parent: 1
+  - uid: 262
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5070422,1.6511295
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.4445422,3.4480045
+      parent: 1
+- proto: PaperBin10
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+- proto: Pen
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.6945422,3.6511295
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.3039172,1.4323795
+      parent: 1
+- proto: PlushieLizard
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      pos: 3.6958613,0.48077703
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,-4.5
+      parent: 1
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 173
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,0.5
+      parent: 1
+  - uid: 174
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,6.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
+      parent: 1
+  - uid: 324
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-2.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+  - uid: 344
+    components:
+    - type: Transform
+      pos: 0.5,-4.5
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityArmedGrenade
+  entities:
+  - uid: 417
+    components:
+    - type: Transform
+      pos: -0.565081,7.600194
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityArmedShotgun
+  entities:
+  - uid: 416
+    components:
+    - type: Transform
+      pos: -2.4296641,3.4827514
+      parent: 1
+- proto: RandomHumanoidSpawnerERTSecurityArmedVanguard
+  entities:
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 9.531,-0.49481022
+      parent: 1
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 8.520583,-0.44269067
+      parent: 1
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 6.510166,-2.4232333
+      parent: 1
+- proto: RandomPosterLegit
+  entities:
+  - uid: 375
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+- proto: SecBreachingHammer
+  entities:
+  - uid: 340
+    components:
+    - type: Transform
+      pos: 2.4986203,6.585873
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 40
+    components:
+    - type: Transform
+      pos: 8.5,1.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: 9.5,1.5
+      parent: 1
+  - uid: 97
+    components:
+    - type: Transform
+      pos: 10.5,-1.5
+      parent: 1
+  - uid: 98
+    components:
+    - type: Transform
+      pos: 10.5,-2.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+- proto: ShuttleWindowDiagonal
+  entities:
+  - uid: 52
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,1.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: 7.5,1.5
+      parent: 1
+- proto: SMESAdvanced
+  entities:
+  - uid: 107
+    components:
+    - type: MetaData
+      name: 'SMES: Marquess'
+    - type: Transform
+      pos: 9.5,-3.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 108
+    components:
+    - type: MetaData
+      name: 'Substation: Marquess'
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-3.5
+      parent: 1
+- proto: SuitStorageERTSecurity
+  entities:
+  - uid: 47
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 333
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 418
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+  - uid: 216
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 234
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 29
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 88
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 89
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 90
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: ThrusterLarge
+  entities:
+  - uid: 16
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-5.5
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 127
+    components:
+    - type: Transform
+      pos: 9.463572,-2.2655878
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      pos: 9.465248,-2.661888
+      parent: 1
+- proto: ToyIan
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      pos: 2.8525474,4.700506
+      parent: 1
+- proto: TurboItemRecharger
+  entities:
+  - uid: 238
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+- proto: VendingMachineSec
+  entities:
+  - uid: 237
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+- proto: VendingMachineSustenance
+  entities:
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+- proto: VendingMachineTankDispenserEVA
+  entities:
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: 0.5,-7.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 21
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 7.5,0.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 10.5,-3.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 9.5,-4.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 34
+    components:
+    - type: Transform
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 7.5,-5.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,5.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
+      pos: 10.5,-0.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: 10.5,0.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 181
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 190
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 191
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 26
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 10.5,-4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -3.5,9.5
+      parent: 1
+- proto: WarpPointShuttle
+  entities:
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+    - type: WarpPoint
+      location: NTCC Marquess Sentinel
+- proto: WaterCooler
+  entities:
+  - uid: 235
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+- proto: WeaponDisablerSMG
+  entities:
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -1.4890895,7.3835855
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      pos: -1.5359645,7.1492105
+      parent: 1
+- proto: WeaponMeleeNeedle
+  entities:
+  - uid: 343
+    components:
+    - type: Transform
+      pos: -2.4777849,-2.552956
+      parent: 1
+- proto: WeaponTaser
+  entities:
+  - uid: 247
+    components:
+    - type: Transform
+      pos: -1.4782071,8.033786
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: -1.4313321,7.783786
+      parent: 1
+- proto: WindoorSecurePlasmaERTLocked
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 258
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 271
+    components:
+    - type: Transform
+      pos: -0.5,-6.5
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 407
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-4.5
+      parent: 1
+...

--- a/Resources/Maps/Floof/centcomm.yml
+++ b/Resources/Maps/Floof/centcomm.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Grid
-  engineVersion: 267.3.0
+  engineVersion: 270.1.0
   forkId: ""
   forkVersion: ""
-  time: 02/05/2026 20:00:06
-  entityCount: 20835
+  time: 07/31/2026 15:26:05
+  entityCount: 20856
 maps: []
 grids:
 - 1668
@@ -4841,7 +4841,7 @@ entities:
           4,-7:
             0: 48127
           4,-6:
-            0: 47803
+            0: 47675
           4,-9:
             0: 65523
           5,-8:
@@ -6419,13 +6419,13 @@ entities:
         - volume: 2500
           temperature: 293.15
           moles:
-            Oxygen: 23.903439
-            Nitrogen: 80.02455
+            Oxygen: 21.824879
+            Nitrogen: 82.10312
         - volume: 2500
           temperature: 235
           moles:
-            Oxygen: 29.818268
-            Nitrogen: 99.82637
+            Oxygen: 27.225372
+            Nitrogen: 102.419266
         - volume: 2500
           immutable: True
           moles: {}
@@ -6454,6 +6454,9 @@ entities:
     - type: IFF
       color: '#32CD32FF'
     - type: ImplicitRoof
+    - type: TileHistory
+      chunkHistory: {}
+    - type: ExplosionAirtightGrid
 - proto: AirAlarm
   entities:
   - uid: 4120
@@ -8712,13 +8715,19 @@ entities:
     - type: Transform
       pos: -6.5,0.5
       parent: 1668
+    - type: Door
+      secondsUntilStateChange: -415.63455
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
   - uid: 15515
     components:
     - type: Transform
       pos: -6.5,-0.5
       parent: 1668
     - type: Door
-      secondsUntilStateChange: -46143.56
+      secondsUntilStateChange: -46574.125
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9323,24 +9332,6 @@ entities:
     - type: Transform
       pos: -39.5,-49.5
       parent: 1668
-  - uid: 12856
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,42.5
-      parent: 1668
-  - uid: 12857
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,41.5
-      parent: 1668
-  - uid: 12858
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 48.5,40.5
-      parent: 1668
   - uid: 12859
     components:
     - type: Transform
@@ -9396,21 +9387,6 @@ entities:
     components:
     - type: Transform
       pos: 10.5,-66.5
-      parent: 1668
-  - uid: 13114
-    components:
-    - type: Transform
-      pos: 17.5,-71.5
-      parent: 1668
-  - uid: 13115
-    components:
-    - type: Transform
-      pos: 18.5,-71.5
-      parent: 1668
-  - uid: 13116
-    components:
-    - type: Transform
-      pos: 19.5,-71.5
       parent: 1668
   - uid: 13118
     components:
@@ -9487,6 +9463,41 @@ entities:
       rot: 3.141592653589793 rad
       pos: -40.5,59.5
       parent: 1668
+- proto: AirlockExternalGlassShuttleShipyard
+  entities:
+  - uid: 4295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,42.5
+      parent: 1668
+  - uid: 4296
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,40.5
+      parent: 1668
+  - uid: 4297
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,41.5
+      parent: 1668
+  - uid: 4298
+    components:
+    - type: Transform
+      pos: 17.5,-71.5
+      parent: 1668
+  - uid: 4371
+    components:
+    - type: Transform
+      pos: 19.5,-71.5
+      parent: 1668
+  - uid: 4567
+    components:
+    - type: Transform
+      pos: 18.5,-71.5
+      parent: 1668
 - proto: AirlockFreezer
   entities:
   - uid: 18006
@@ -9503,7 +9514,7 @@ entities:
       pos: -19.5,-24.5
       parent: 1668
     - type: Door
-      secondsUntilStateChange: -63668.35
+      secondsUntilStateChange: -64098.918
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12772,6 +12783,22 @@ entities:
       parent: 1668
     - type: Fixtures
       fixtures: {}
+  - uid: 12837
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 36.5,-32.5
+      parent: 1668
+    - type: Fixtures
+      fixtures: {}
+  - uid: 15172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 29.5,-41.5
+      parent: 1668
+    - type: Fixtures
+      fixtures: {}
 - proto: Ashtray
   entities:
   - uid: 3204
@@ -12972,6 +12999,39 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 52.5,2.5
       parent: 1668
+  - uid: 4568
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,42.5
+      parent: 1668
+  - uid: 4569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,40.5
+      parent: 1668
+  - uid: 4640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 48.5,41.5
+      parent: 1668
+  - uid: 4641
+    components:
+    - type: Transform
+      pos: 19.5,-71.5
+      parent: 1668
+  - uid: 4661
+    components:
+    - type: Transform
+      pos: 18.5,-71.5
+      parent: 1668
+  - uid: 4698
+    components:
+    - type: Transform
+      pos: 17.5,-71.5
+      parent: 1668
 - proto: AtmosDeviceFanTiny
   entities:
   - uid: 4496
@@ -12991,24 +13051,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -70.5,19.5
-      parent: 1668
-  - uid: 4567
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 48.5,42.5
-      parent: 1668
-  - uid: 4568
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 48.5,41.5
-      parent: 1668
-  - uid: 4569
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 48.5,40.5
       parent: 1668
   - uid: 4570
     components:
@@ -13159,24 +13201,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 33.5,-66.5
-      parent: 1668
-  - uid: 12991
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 17.5,-71.5
-      parent: 1668
-  - uid: 12992
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,-71.5
-      parent: 1668
-  - uid: 12993
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 19.5,-71.5
       parent: 1668
   - uid: 12997
     components:
@@ -13673,11 +13697,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -5.5,-44.5
       parent: 1668
-  - uid: 15172
-    components:
-    - type: Transform
-      pos: -2.5,1.5
-      parent: 1668
   - uid: 15418
     components:
     - type: Transform
@@ -13711,23 +13730,6 @@ entities:
     components:
     - type: Transform
       pos: -23.5,-35.5
-      parent: 1668
-  - uid: 19645
-    components:
-    - type: Transform
-      pos: -0.5,1.5
-      parent: 1668
-  - uid: 19949
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,0.5
-      parent: 1668
-  - uid: 19953
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,0.5
       parent: 1668
   - uid: 20168
     components:
@@ -14455,49 +14457,7 @@ entities:
       rot: 3.141592653589793 rad
       pos: 7.5,-33.5
       parent: 1668
-- proto: BenchSofaCorpLeft
-  entities:
-  - uid: 2741
-    components:
-    - type: Transform
-      pos: -50.5,48.5
-      parent: 1668
-  - uid: 10140
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -42.5,-29.5
-      parent: 1668
-  - uid: 12890
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -52.5,-24.5
-      parent: 1668
-  - uid: 14609
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -44.5,-28.5
-      parent: 1668
-  - uid: 16056
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 15.5,29.5
-      parent: 1668
-  - uid: 16057
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,22.5
-      parent: 1668
-  - uid: 17136
-    components:
-    - type: Transform
-      pos: 1.5,-39.5
-      parent: 1668
-- proto: BenchSofaCorpRight
+- proto: BenchSofaCorpLeftDV
   entities:
   - uid: 1902
     components:
@@ -14538,6 +14498,48 @@ entities:
     components:
     - type: Transform
       pos: 2.5,-39.5
+      parent: 1668
+- proto: BenchSofaCorpRightDV
+  entities:
+  - uid: 2741
+    components:
+    - type: Transform
+      pos: -50.5,48.5
+      parent: 1668
+  - uid: 10140
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -42.5,-29.5
+      parent: 1668
+  - uid: 12890
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -52.5,-24.5
+      parent: 1668
+  - uid: 14609
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -44.5,-28.5
+      parent: 1668
+  - uid: 16056
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 15.5,29.5
+      parent: 1668
+  - uid: 16057
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,22.5
+      parent: 1668
+  - uid: 17136
+    components:
+    - type: Transform
+      pos: 1.5,-39.5
       parent: 1668
 - proto: BenchSteelLeft
   entities:
@@ -27217,11 +27219,6 @@ entities:
     - type: Transform
       pos: 28.5,-39.5
       parent: 1668
-  - uid: 12837
-    components:
-    - type: Transform
-      pos: 29.5,-39.5
-      parent: 1668
   - uid: 12838
     components:
     - type: Transform
@@ -27876,6 +27873,11 @@ entities:
     components:
     - type: Transform
       pos: 37.5,-5.5
+      parent: 1668
+  - uid: 13116
+    components:
+    - type: Transform
+      pos: 35.5,-32.5
       parent: 1668
   - uid: 13208
     components:
@@ -28547,6 +28549,26 @@ entities:
     - type: Transform
       pos: -67.5,-8.5
       parent: 1668
+  - uid: 14608
+    components:
+    - type: Transform
+      pos: 36.5,-32.5
+      parent: 1668
+  - uid: 15243
+    components:
+    - type: Transform
+      pos: 30.5,-40.5
+      parent: 1668
+  - uid: 15424
+    components:
+    - type: Transform
+      pos: 30.5,-41.5
+      parent: 1668
+  - uid: 16083
+    components:
+    - type: Transform
+      pos: 29.5,-41.5
+      parent: 1668
   - uid: 16170
     components:
     - type: Transform
@@ -28706,11 +28728,6 @@ entities:
     components:
     - type: Transform
       pos: -0.5,47.5
-      parent: 1668
-  - uid: 20261
-    components:
-    - type: Transform
-      pos: 29.5,-32.5
       parent: 1668
   - uid: 20262
     components:
@@ -31315,6 +31332,11 @@ entities:
     components:
     - type: Transform
       pos: -13.5,16.5
+      parent: 1668
+  - uid: 6569
+    components:
+    - type: Transform
+      pos: 28.5,-40.5
       parent: 1668
   - uid: 7493
     components:
@@ -36371,6 +36393,51 @@ entities:
     - type: Transform
       pos: -7.5,0.5
       parent: 1668
+  - uid: 12651
+    components:
+    - type: Transform
+      pos: 36.5,-32.5
+      parent: 1668
+  - uid: 12856
+    components:
+    - type: Transform
+      pos: 34.5,-32.5
+      parent: 1668
+  - uid: 12857
+    components:
+    - type: Transform
+      pos: 33.5,-32.5
+      parent: 1668
+  - uid: 12858
+    components:
+    - type: Transform
+      pos: 35.5,-32.5
+      parent: 1668
+  - uid: 12991
+    components:
+    - type: Transform
+      pos: 32.5,-32.5
+      parent: 1668
+  - uid: 12992
+    components:
+    - type: Transform
+      pos: 31.5,-32.5
+      parent: 1668
+  - uid: 12993
+    components:
+    - type: Transform
+      pos: 28.5,-32.5
+      parent: 1668
+  - uid: 13114
+    components:
+    - type: Transform
+      pos: 30.5,-32.5
+      parent: 1668
+  - uid: 13115
+    components:
+    - type: Transform
+      pos: 29.5,-32.5
+      parent: 1668
   - uid: 14715
     components:
     - type: Transform
@@ -36415,6 +36482,16 @@ entities:
     components:
     - type: Transform
       pos: -50.5,-1.5
+      parent: 1668
+  - uid: 16084
+    components:
+    - type: Transform
+      pos: 29.5,-40.5
+      parent: 1668
+  - uid: 16086
+    components:
+    - type: Transform
+      pos: 29.5,-41.5
       parent: 1668
   - uid: 19532
     components:
@@ -41807,6 +41884,17 @@ entities:
     - type: Transform
       pos: 37.5,17.5
       parent: 1668
+- proto: CentcommComputerComms
+  entities:
+  - uid: 4701
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1668
+    - type: AccessReader
+      accessListsOriginal:
+      - - CentralCommand
 - proto: Chair
   entities:
   - uid: 2195
@@ -44341,6 +44429,13 @@ entities:
     - type: Transform
       pos: -27.5,9.5
       parent: 1668
+- proto: ClosetJanitorFilled
+  entities:
+  - uid: 18695
+    components:
+    - type: Transform
+      pos: 21.5,13.5
+      parent: 1668
 - proto: ClosetMaintenanceFilledRandom
   entities:
   - uid: 17780
@@ -45420,6 +45515,14 @@ entities:
     - type: Transform
       pos: -22.5,-35.5
       parent: 1668
+- proto: ComputerRadar
+  entities:
+  - uid: 4754
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1668
 - proto: ComputerRoboticsControl
   entities:
   - uid: 4973
@@ -45439,8 +45542,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: 11.5,-56.5
       parent: 1668
+- proto: ComputerShipyardAdmin
+  entities:
+  - uid: 4699
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1668
 - proto: ComputerStationRecords
   entities:
+  - uid: 4700
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1668
   - uid: 20560
     components:
     - type: Transform
@@ -99907,13 +100022,6 @@ entities:
       angularDamping: 0
       linearDamping: 0
       bodyType: Static
-- proto: LockerJanitor
-  entities:
-  - uid: 18695
-    components:
-    - type: Transform
-      pos: 21.5,13.5
-      parent: 1668
 - proto: LockerQuarterMaster
   entities:
   - uid: 15408
@@ -114305,6 +114413,36 @@ entities:
     components:
     - type: Transform
       pos: 33.5,26.5
+      parent: 1668
+    - type: Fixtures
+      fixtures: {}
+- proto: Shower
+  entities:
+  - uid: 16092
+    components:
+    - type: Transform
+      pos: -10.5,-11.5
+      parent: 1668
+    - type: Fixtures
+      fixtures: {}
+  - uid: 16093
+    components:
+    - type: Transform
+      pos: -9.5,-11.5
+      parent: 1668
+    - type: Fixtures
+      fixtures: {}
+  - uid: 16099
+    components:
+    - type: Transform
+      pos: -8.5,-11.5
+      parent: 1668
+    - type: Fixtures
+      fixtures: {}
+  - uid: 16100
+    components:
+    - type: Transform
+      pos: -7.5,-11.5
       parent: 1668
     - type: Fixtures
       fixtures: {}

--- a/Resources/Prototypes/_DV/Entities/Structures/Machines/computers.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Machines/computers.yml
@@ -54,6 +54,7 @@
     categories:
     - CentComm
     - ERT
+    - ERTFilled # Floofstation - Our ERT Shuttles with pre-mapped ghostroles
     - Transport
     - Shipping
     - Medical
@@ -65,7 +66,7 @@
     - Small
     - Medium
     - Large
-    defaultCategory: ERT # Probably switch to CentComm once we have ships in that category
+    defaultCategory: ERTFilled #  # Floofstation - set defualt to ERTFIlled instead of the defualt ERT, Probably switch to CentComm once we have ships in that category
   - type: AccessReader
     access: [[ CentralCommand ]]
 

--- a/Resources/Prototypes/_Floof/Catalog/Shipyard/categories.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Shipyard/categories.yml
@@ -1,0 +1,3 @@
+﻿- type: vesselCategory
+  id: ERTFilled
+  name: vessel-category-ert-filled

--- a/Resources/Prototypes/_Floof/Catalog/Shipyard/ert.yml
+++ b/Resources/Prototypes/_Floof/Catalog/Shipyard/ert.yml
@@ -1,0 +1,50 @@
+﻿# floof specific ert shuttles for the centcomm shipyard
+# descriptions can be more ooc since these are only seen by admins who need to know whats spawning on the ship
+# Ships put in here still need to have a price associated with them due to the arbitrage tests.
+# The CentComm console won't charge for them so just put like a million spesos or something
+# The stations shipyard will not show these shuttles unless somoene gives the station shipyard access to see them in which case utoh.
+
+- type: vessel
+  id: FloofERTCargo
+  name: HGI ERT Cargo
+  description: ERT Cargo shuttle, 3 ghost roles will be created.
+  price: 10000000
+  path: /Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-cargo.yml
+  categories:
+  - ERTFilled
+
+- type: vessel
+  id: FloofERTMedical
+  name: HGI ERT Medical, 4 ghost roles will be created.
+  description: ERT medical ship.
+  price: 10000000
+  path: /Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-medical.yml
+  categories:
+  - ERTFilled
+
+- type: vessel
+  id: FloofERTEngineering
+  name: HGI ERT Engineering
+  description: ERT Engineering Shuttle for most repairs, 5 ghost roles will be created.
+  price: 10000000
+  path: /Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-engi.yml
+  categories:
+  - ERTFilled
+
+- type: vessel
+  id: FloofERTSecurity
+  name: HGI ERT Security
+  description: ERT Security Shuttle for station side combat, 5 ghost roles will be created may need more weapons given.
+  price: 10000000
+  path: /Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-security.yml
+  categories:
+  - ERTFilled
+
+- type: vessel
+  id: FloofERTJanitor
+  name: HGI ERT Janitor
+  description: ERT Janitor Shuttle for station mess cleanup, 4 ghost roles will be created.
+  price: 10000000
+  path: /Maps/Floof/Shuttles/CentralCommand/ERTships/Shipyard/ert-janitor.yml
+  categories:
+  - ERTFilled


### PR DESCRIPTION
## About the PR
This PR is more so for admins. I created a new catageogory for the admin shipyard that has pre-mapped ghostroles for specific Ert shuttles so its one click and they can spawn in a shuttle for very specific ERT needs.

I had to replace two docks at centcomm with Shipyard docks so these shuttles will actually spawn in at centcomm before being sent out, its not a perfect solution by any means but it will work for now. Centcomms main area for admin faxes now has the admin shipyard and it will default to our ERT shuttles. I kept the other categories for now incase they want to load in a non-ert shuttle shut as a court house shuttle with an easy click.

## Why / Balance
Admin requested.

## Technical details
more yaml and i will cry

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Added a few more pre-fabbed and pre-ghost role ready ERT Shuttles for admins to use the Centcomm shipyard to spawn in. Admins, mouse over the button that says Free to see how many roles will spawn.
- fix: Centcomms cryopod room in medical will now have proper power.
