### PR TITLE
Detective Loadout fix

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -618,8 +618,8 @@
   - SurvivalSecurity
   - DetectiveJobTrinkets
   - GroupSpeciesBreathToolSecurity
-  - SecurityRevolverFirearm # DeltaV - loadouts
-  - SecurityRevolverAmmo # DeltaV - loadouts
+  - SecurityFirearm # DeltaV - loadouts # Euphoria - Detectives now have more choices
+  - SecurityFirearmAmmo # DeltaV - loadouts # Euphoria - Detectives now have more choices
   - FloofUndergarmentTopDetective # Floof
   - FloofUndergarmentBottomDetective # Floof
   - FloofSocksDetective # Floof

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/security_weapons.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/security_weapons.yml
@@ -8,6 +8,8 @@
   loadouts:
   - SecurityFirearmWeaponRevolverDeckard
   - SecurityRevolverInspector
+  - SecurityFirearmWeaponRevolverFitz
+  - SecurityRevolverWeaponRevolverLucky
   - FloofSecurityWeaponRevolverPython
   - FloofWeaponLaserSvalinn
   - FloofPlasteelArmingSword
@@ -28,6 +30,8 @@
   - FloofSecurityFirearmSpeedLoaderMagnumRubber
   - FloofSecurityFirearmSpeedLoaderMagnum
   - FloofSecurityFirearmPowerCellHigh
+  - SecurityFirearmSpeedLoaderSpecialRubber
+  - SecurityFirearmSpeedLoaderSpecial
 
 - type: loadoutGroup
   id: FloofSecurityRevolverAmmo


### PR DESCRIPTION
## About the PR
Changes the loadout so detectives may take the full security firearm list.

## Why / Balance
Was requested.

**Changelog**
:cl:
- tweak: Changed Detective loadout to have the full security firearms list

