### PR TITLE
Re-Implementation of Stealth Channels

### DIFF
--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -216,6 +216,9 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         {
             proto = _protoManager.Index<RadioChannelPrototype>(id);
 
+            if (!HasComp<EncryptionKeyComponent>(examineEvent.Examined) && proto.Stealth)
+                continue;
+
             var key = id == SharedChatSystem.CommonChannel
                 ? SharedChatSystem.RadioCommonPrefix.ToString()
                 : $"{SharedChatSystem.RadioChannelPrefix}{proto.KeyCode}";

--- a/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
+++ b/Content.Shared/Radio/EntitySystems/EncryptionKeySystem.cs
@@ -216,6 +216,7 @@ public sealed partial class EncryptionKeySystem : EntitySystem
         {
             proto = _protoManager.Index<RadioChannelPrototype>(id);
 
+			// Euphoria | Stealth channels
             if (!HasComp<EncryptionKeyComponent>(examineEvent.Examined) && proto.Stealth)
                 continue;
 

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -42,4 +42,11 @@ public sealed partial class RadioChannelPrototype : IPrototype
     [DataField, ViewVariables]
     public bool ShowFrequency = false;
     // End Frontier
+
+    //Euphoria
+    /// <summary>
+    /// If true, the channel will attempt to hide itself from examine events.
+    /// </summary>
+    [DataField("stealth"), ViewVariables]
+    public bool Stealth = false;
 }

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -69,7 +69,7 @@
   frequency: 1213
   color: "#8f4a4b"
   longRange: true
-  stealth: true
+  stealth: true # Euphoria | stealth channels
 
 - type: radioChannel
   id: Handheld

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -69,6 +69,7 @@
   frequency: 1213
   color: "#8f4a4b"
   longRange: true
+  stealth: true
 
 - type: radioChannel
   id: Handheld


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Brings back the pre-rebase feature where the syndicate channel was hidden from examines. This new implementation has feature parity.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Pre-rebase parity. Syndicate are encouraged to communicate and plan together here and are given a free key to do so. This key should not give them away on shift click.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Adds a 'stealth' field to the RadioChannelPrototype so that channels can be marked as stealth. I believe this to be an upgrade over the old method as it integrate more easily with the actual way the EncryptionKeySystem handles populating examines.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="692" height="423" alt="stealthkey" src="https://github.com/user-attachments/assets/31f3080e-f7dd-4931-b2b7-12d738b6cbd6" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- tweak: The Syndicate channel will no longer show up in examines.
