### PR TITLE
ConditionalHealing: fix wrong order of arguments and virtitem renaming

### DIFF
--- a/Content.Shared/_FarHorizons/Medical/ConditionalHealing/ConditionalHealingSystem.cs
+++ b/Content.Shared/_FarHorizons/Medical/ConditionalHealing/ConditionalHealingSystem.cs
@@ -83,7 +83,7 @@ public sealed class ConditionalHealingSystem : EntitySystem
             return false;
         }
 
-        _meta.SetEntityName(ent, MetaData(ent).EntityName);
+        _meta.SetEntityName(virtItem.Value, MetaData(ent).EntityName);
         EnsureComp<TimedDespawnComponent>(virtItem.Value).Lifetime = 10; // Just in case.
 
         var marker = EnsureComp<ConditionalHealingVirtualItemComponent>(virtItem.Value);
@@ -92,7 +92,7 @@ public sealed class ConditionalHealingSystem : EntitySystem
         var healingComp = healing.MakeComponent();
         AddComp(virtItem.Value, healingComp, overwrite: true);
 
-        if (!_healing.TryHeal((virtItem.Value, healingComp), user, target))
+        if (!_healing.TryHeal((virtItem.Value, healingComp), target, user))
         {
             PredictedQueueDel(virtItem);
             return false;


### PR DESCRIPTION
## About the PR
I'm fucking stupid. I was testing this with two damaged IPCs and didn't notice it was always trying to heal the user.

<details> <summary><h2>Media</h2></summary> <p>
<img width="911" height="462" alt="image" src="https://github.com/user-attachments/assets/0c04189c-59f2-435d-a5fc-fe769f633058" />

<img width="911" height="462" alt="image" src="https://github.com/user-attachments/assets/205cbc59-b989-452d-94ca-b71878bb3cb3" />

</p></details>

No cl.