### PR TITLE
Loko 14 Glow-down

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/soda.yml
@@ -280,6 +280,43 @@
         damage:
           types:
             Poison: 1
+      - !type:GenericStatusEffect # Euphoria - Making it do what the can says it does
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [Slime]
+          inverted: true
+        key: TemporaryBlindness
+        component: TemporaryBlindness # Here's the blindness
+        probability: 0.1
+      - !type:Electrocute # Euphoria - close enough to a seizure
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [Slime]
+          inverted: true
+        probability: 0.1
+      - !type:HealthChange
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [Slime]
+          inverted: true
+        damage:
+          groups:
+            Airloss: 125 # Here's the heart attack
+        probability: 0.001
+      - !type:Drunk # Euphoria - Here's the Drunk-ness
+        conditions:
+        - !type:MetabolizerTypeCondition
+          type: [Slime]
+          inverted: true
+        boozePower: 10
+        probability: 0.2
+    Narcotic:
+      effects:
+      - !type:GenericStatusEffect # Euphoria - This gives the heart on the side of the screen
+        key: Adrenaline
+        component: IgnoreSlowOnDamage
+        time: 5
+      - !type:Jitter
 
 - type: reagent
   id: ShamblersJuice


### PR DESCRIPTION
## About the PR
Makes Loko 14 do what it says on the can. 
"The MBO has advised crew members that consumption of Fourteen Loko may result in seizures, blindness, drunkeness, or even death. Please Drink Responsibly."

I'll probably have to test it later, 15 minutes to open dev is hot ass.

## Why / Balance
The can was falsely advertising that you would suffer. I have fixed that, you will actually suffer now. 

**Changelog**
:cl:
- tweak: Loko 14 now does what it says on the can.