### PR TITLE
Hotfixes

### DIFF
--- a/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
+++ b/Content.Client/Weapons/Melee/MeleeWeaponSystem.cs
@@ -140,7 +140,7 @@ public sealed partial class MeleeWeaponSystem : SharedMeleeWeaponSystem
         if (altDown == BoundKeyState.Down)
         {
             // If it's an unarmed attack then do a disarm
-            if (weapon.AltDisarm && weaponUid == entity)
+            if (weapon.AltDisarm)// && weaponUid == entity) // Euph - remove the useless check preventing armed disarm
             {
                 ClientDisarm(entity, mousePos, coordinates);
                 return;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -715,8 +715,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             !TryEmoteChatInput(source, action))
             return;
 
-        // Floof - supply empty message wrap data for the third arg as emotes are never obfuscated
-        SendInVoiceRange(ChatChannel.Emotes, new MessageWrapData(action, wrappedMessage, LanguageSystem.Universal), MessageWrapData.Empty, source, range, author);
+        // Floof - supply empty message wrap data for the third arg as emotes are never obfuscated, also check LOS
+        SendInVoiceRange(ChatChannel.Emotes, new MessageWrapData(action, wrappedMessage, LanguageSystem.Universal), MessageWrapData.Empty, source, range, author, checkLOS: true);
         if (!hideLog)
             if (name != Name(source))
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {source} as {name}: {action}");

--- a/Content.Server/Wagging/WaggingSystem.cs
+++ b/Content.Server/Wagging/WaggingSystem.cs
@@ -1,7 +1,9 @@
 ﻿using Content.Server.Actions;
 using Content.Server.Humanoid;
+using Content.Shared._DV.Humanoid;
 using Content.Shared._Floof.Humanoid;
 using Content.Shared.Cloning.Events;
+using Content.Shared.GameTicking;
 using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Mobs;
@@ -25,7 +27,7 @@ public sealed class WaggingSystem : EntitySystem
         base.Initialize();
 
         SubscribeLocalEvent<WaggingComponent, MapInitEvent>(OnMapInit);
-        SubscribeLocalEvent<WaggingComponent, HumanoidProfileImportedEvent>(OnMapInit); // Floofstation - listen on profile load as well as map init
+        SubscribeLocalEvent<WaggingComponent, AppearanceLoadedEvent>(OnMapInit); // Floofstation - listen on profile load as well as map init
         SubscribeLocalEvent<WaggingComponent, ComponentShutdown>(OnWaggingShutdown);
         SubscribeLocalEvent<WaggingComponent, ToggleActionEvent>(OnWaggingToggle);
         SubscribeLocalEvent<WaggingComponent, MobStateChangedEvent>(OnMobStateChanged);
@@ -41,7 +43,7 @@ public sealed class WaggingSystem : EntitySystem
     }
 
     // Floofstation - listen on both profile load and map init
-    private void OnMapInit(EntityUid uid, WaggingComponent component, object args)
+    private void OnMapInit<T>(EntityUid uid, WaggingComponent component, T args)
     {
         // Floofstation - this event can run before CompInit, at which point AddAction would throw an exception.
         if (!Initialized(uid))

--- a/Resources/Prototypes/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/Body/Organs/Animal/animal.yml
@@ -119,7 +119,7 @@
     metabolizerTypes: [ Animal ]
     groups:
     - id: Alcohol
-      rateModifier: 0.1
+      rateModifier: 1 # Euph - this has to be set to be >=1 otherwise everything will fall apart because of wizden's FP2 shitcode
   - type: Item
     size: Small
     heldPrefix: liver

--- a/Resources/Prototypes/Body/Organs/arachnid.yml
+++ b/Resources/Prototypes/Body/Organs/arachnid.yml
@@ -124,7 +124,7 @@
     metabolizerTypes: [Animal]
     groups:
     - id: Alcohol
-      rateModifier: 0.1 # removes alcohol very slowly along with the stomach removing it as a drink
+      rateModifier: 1 # removes alcohol very slowly along with the stomach removing it as a drink # Euph - this has to be set to be >=1 otherwise everything will fall apart because of wizden's FP2 shitcode
 
 - type: entity
   id: OrganArachnidKidneys

--- a/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/regalrat.yml
@@ -104,8 +104,9 @@
   - type: RatKing
     hungerPerArmyUse: 10 # DeltaV changed from 25 to 10. Gets multiplied with a modifier to be dynamic
     hungerPerDomainUse: 50
-  - type: ReplacementAccent # DeltaV - replace mobster accent with mouse speech replacement
-    accent: mouse
+#  - type: ReplacementAccent # DeltaV - replace mobster accent with mouse speech replacement # Euph - no
+#    accent: mouse
+  - type: MobsterAccent
   - type: Speech
     speechVerb: SmallMob
     speechSounds: Squeak # DeltaV addition

--- a/Resources/Prototypes/_FarHorizons/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Species/ipc.yml
@@ -51,13 +51,13 @@
   id: MobIPCMarkingLimits
   points:
     HeadTop:
-      points: 1
+      points: 2
       required: true
     Hair:
-      points: 0
+      points: 2
       required: false
     FacialHair:
-      points: 0
+      points: 2
       required: false
     Head:
       points: 2

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Hands/mittens.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Hands/mittens.yml
@@ -9,7 +9,7 @@
     damage:
       types: {}
     animation: WeaponArcClaw
-    wideAnimationRotation: 135
+    altDisarm: true
     mustBeEquippedToUse: true
   - type: Fiber
     fiberMaterial: fibers-synthetic


### PR DESCRIPTION
## About the PR
- Increases the alcohol metabolism rate of animal livers to 1x (from 0.1x). The low rate of metabolism was causing reagents to have very minor effects, preventing drunkness buildup when consuming ethanol.
- Removes the replacement accent from ratking
- Makes emotes respect LOS (again)
- Fixes WaggingSystem action granting on species without default tail markings (it was listening on the wrong event: profile import instead of appearence load)
- Fixes mittens giving you a wide swing attack. Mittens now allow disarm just like unarmed melee.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="1173" height="552" alt="image" src="https://github.com/user-attachments/assets/69f9936a-de8b-4a89-ba65-27f54e21b10a" />

<img width="1173" height="552" alt="image" src="https://github.com/user-attachments/assets/e07a2874-31a7-4cb1-87b1-b27081a7206b" />


</p></details>

**Changelog**
- fix: Species with animal livers should now metabolize alcohol at a normal rate.
- fix: The "toggle wagging" action should now be correctly added if you have an animate-able tail.
- fix: Ratking no longer has a replacement accent.
- fix: Emotes respect LOS again.
- fix: You can disarm/shove while wearing mittens.
- fix: IPCs can have hair and have more marking points on the head.
