### PR TITLE
Health Analyzer - Allergies

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
@@ -74,9 +74,6 @@
 
     </BoxContainer>
 
-    <PanelContainer Name="AllergiesDivider" Visible="False" StyleClasses="LowDivider" /> <!-- Euphoria - Allergies -->
-    <BoxContainer Name="AllergiesContainer" Visible="False" Orientation="Vertical" Margin="0 5" /> <!-- Euphoria - Allergies -->
-
     <PanelContainer StyleClasses="LowDivider" />
 
     <BoxContainer
@@ -85,4 +82,6 @@
         Orientation="Vertical">
     </BoxContainer>
 
+    <PanelContainer Name="AllergiesDivider" Visible="False" StyleClasses="LowDivider" /> <!-- Euphoria - Allergies -->
+    <BoxContainer Name="AllergiesContainer" Visible="False" Orientation="Vertical" Margin="0 5" /> <!-- Euphoria - Allergies -->
 </BoxContainer>

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml
@@ -74,6 +74,9 @@
 
     </BoxContainer>
 
+    <PanelContainer Name="AllergiesDivider" Visible="False" StyleClasses="LowDivider" /> <!-- Euphoria - Allergies -->
+    <BoxContainer Name="AllergiesContainer" Visible="False" Orientation="Vertical" Margin="0 5" /> <!-- Euphoria - Allergies -->
+
     <PanelContainer StyleClasses="LowDivider" />
 
     <BoxContainer

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
@@ -24,6 +24,7 @@ using Content.Client._DV.Traits.Assorted; // DeltaV
 using Content.Shared._DV.Traits.Assorted; // DeltaV
 using Content.Shared._DV.Medical; // DeltaV - Uncloneable
 using Content.Shared._DV.MedicalRecords; // DeltaV - Medical Records
+using Content.Shared.Chemistry.Reagent; // Euphoria - Allergies
 
 // Health analyzer UI is split from its window because it's used by both the
 // health analyzer item and the cryo pod UI.
@@ -201,6 +202,51 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
                 Margin = new Thickness(0, 4),
                 MaxWidth = 300
             });
+
+        // Euphoria - Allergies
+        var hasAllergies = state.Allergies.Count > 0;
+        if (hasAllergies)
+        {
+            // Would be nice not to re-draw this each time, but if the UI doesn't close and the scan target switches,
+            // the allergies would not be redrawn. Plus, maybe an admeme adds an allergy or something. Oh well, at
+            // least its client-side.
+            AllergiesContainer.RemoveAllChildren();
+            var headerContainer = new BoxContainer
+            {
+                Align = AlignMode.Begin,
+                Orientation = LayoutOrientation.Vertical
+            };
+
+            headerContainer.AddChild(new RichTextLabel
+            {
+                Text = Loc.GetString("health-analyzer-window-entity-header-allergy-text")
+            });
+            AllergiesContainer.AddChild(headerContainer);
+
+            foreach (var allergy in state.Allergies)
+            {
+                var reagentPrototype = _prototypes.Index<ReagentPrototype>(allergy);
+                var reagentContainer = new BoxContainer
+                {
+                    Align = AlignMode.Begin,
+                    Orientation = LayoutOrientation.Vertical
+                };
+
+                reagentContainer.AddChild(new RichTextLabel
+                {
+                    Text = Loc.GetString("health-analyzer-window-entity-reagent-allergy-text",
+                        ("reagentColor", reagentPrototype.SubstanceColor),
+                        ("reagentName", reagentPrototype.LocalizedName)
+                    ),
+                    Margin = new Thickness(15f, 0f) // Small horizontal indentation
+                });
+
+                AllergiesContainer.AddChild(reagentContainer);
+            }
+        }
+        AllergiesDivider.Visible = hasAllergies;
+        AllergiesContainer.Visible = hasAllergies;
+        // END Euphoria
 
         // Damage Groups
 

--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerControl.xaml.cs
@@ -203,6 +203,37 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
                 MaxWidth = 300
             });
 
+        // Damage Groups
+
+        var damageSortedGroups =
+            damageable.DamagePerGroup.OrderByDescending(damage => damage.Value)
+                .ToDictionary(x => x.Key, x => x.Value);
+
+        IReadOnlyDictionary<string, FixedPoint2> damagePerType = damageable.Damage.DamageDict;
+
+        DrawDiagnosticGroups(damageSortedGroups, damagePerType);
+
+        // Begin DeltaV - Medical Records
+        if (state.MedicalRecord is not { } records)
+        {
+            TriageControls.Visible = false;
+            return;
+        }
+
+        TriageControls.Visible = true;
+        _triageControls[records.Status].Pressed = true;
+
+        // Update claim button based on claimed status
+        if (records.ClaimedName != null)
+        {
+            ClaimButton.Text = Loc.GetString("health-analyzer-window-triage-unclaim", ("claimedBy", records.ClaimedName));
+        }
+        else
+        {
+            ClaimButton.Text = Loc.GetString("health-analyzer-window-triage-claim");
+        }
+        // End DeltaV - Medical Records
+
         // Euphoria - Allergies
         var hasAllergies = state.Allergies.Count > 0;
         if (hasAllergies)
@@ -244,40 +275,9 @@ public sealed partial class HealthAnalyzerControl : BoxContainer
                 AllergiesContainer.AddChild(reagentContainer);
             }
         }
-        AllergiesDivider.Visible = hasAllergies;
+        AllergiesDivider.Visible = hasAllergies && GroupsContainer.ChildCount > 0; // Don't show two dividers if there is no damage.
         AllergiesContainer.Visible = hasAllergies;
         // END Euphoria
-
-        // Damage Groups
-
-        var damageSortedGroups =
-            damageable.DamagePerGroup.OrderByDescending(damage => damage.Value)
-                .ToDictionary(x => x.Key, x => x.Value);
-
-        IReadOnlyDictionary<string, FixedPoint2> damagePerType = damageable.Damage.DamageDict;
-
-        DrawDiagnosticGroups(damageSortedGroups, damagePerType);
-
-        // Begin DeltaV - Medical Records
-        if (state.MedicalRecord is not { } records)
-        {
-            TriageControls.Visible = false;
-            return;
-        }
-
-        TriageControls.Visible = true;
-        _triageControls[records.Status].Pressed = true;
-
-        // Update claim button based on claimed status
-        if (records.ClaimedName != null)
-        {
-            ClaimButton.Text = Loc.GetString("health-analyzer-window-triage-unclaim", ("claimedBy", records.ClaimedName));
-        }
-        else
-        {
-            ClaimButton.Text = Loc.GetString("health-analyzer-window-triage-claim");
-        }
-        // End DeltaV - Medical Records
     }
 
     private static string GetStatus(MobState mobState)

--- a/Content.Server/Medical/HealthAnalyzerSystem.cs
+++ b/Content.Server/Medical/HealthAnalyzerSystem.cs
@@ -25,6 +25,8 @@ using Content.Server._NF.Medical;
 using Content.Server._DV.MedicalRecords;
 using Content.Shared._DV.MedicalRecords;
 // End DeltaV
+using Content.Server._CD.Body.Components; // Euphoria
+using System.Linq; // Euphoria
 
 namespace Content.Server.Medical;
 
@@ -281,6 +283,14 @@ public sealed class HealthAnalyzerSystem : EntitySystem
         if (TryComp<UnrevivableComponent>(entity, out var unrevivableComp) && unrevivableComp.Analyzable)
             unrevivable = true;
 
+        // BEGIN Euphoria 
+        List<string> allergies = []; // Assume no allergies unless they have the comp.
+        if (TryComp<AllergyComponent>(entity, out var allergy))
+        {
+            allergies = [.. allergy.Reagents.Select(a => a.Key)];
+        }
+        // END Euphoria
+
         var printable = HasComp<HealthAnalyzerPrinterComponent>(healthAnalyzer); // Frontier
         return new HealthAnalyzerUiState(
             GetNetEntity(entity),
@@ -290,7 +300,8 @@ public sealed class HealthAnalyzerSystem : EntitySystem
             bleeding,
             unrevivable,
             _medicalRecords.GetMedicalRecords(entity), // DeltaV - Medical Records
-            printable // Frontier
+            printable, // Frontier
+            allergies // Euphoria - allergies
         );
     }
 }

--- a/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/MedicalScanner/HealthAnalyzerScannedUserMessage.cs
@@ -31,10 +31,11 @@ public struct HealthAnalyzerUiState
     public bool? Unrevivable;
     public MedicalRecord? MedicalRecord; // DeltaV - Medical Records
     public bool Printable; // Frontier
+    public List<string> Allergies = []; // Euphoria - Allergies
 
     public HealthAnalyzerUiState() {}
 
-    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, MedicalRecord? medicalRecord = null, bool printable = false) // DeltaV - Medical Records // Floof - printing port from frontier
+    public HealthAnalyzerUiState(NetEntity? targetEntity, float temperature, float bloodLevel, bool? scanMode, bool? bleeding, bool? unrevivable, MedicalRecord? medicalRecord = null, bool printable = false, List<string>? allergies = null) // DeltaV - Medical Records // Floof - printing port from frontier // Euphoria - Allergies
     {
         TargetEntity = targetEntity;
         Temperature = temperature;
@@ -44,6 +45,11 @@ public struct HealthAnalyzerUiState
         Unrevivable = unrevivable;
         MedicalRecord = medicalRecord; // DeltaV - Medical Records
         Printable = printable; // Frontier
+
+        if (allergies != null)  // Euphoria - Allergies
+        {
+            Allergies = allergies;
+        }
     }
 }
 

--- a/Resources/Locale/en-US/_Euphoria/medical/components/health-analyzer-component.ftl
+++ b/Resources/Locale/en-US/_Euphoria/medical/components/health-analyzer-component.ftl
@@ -3,6 +3,8 @@ health-analyzer-window-entity-bleeding-text-short = [color=red]Has open wounds![
 health-analyzer-window-entity-unborgable-text-short = [color=red]Incompatible with MMI technology![/color]
 health-analyzer-window-entity-redshirt-text-short = [color=red]Lacks recoverable critical state.[/color]
 health-analyzer-window-entity-uncloneable-text-short = [color=orange]Cloning is impossible.[/color]
+health-analyzer-window-entity-header-allergy-text = [bold]Allergies[/bold]
+health-analyzer-window-entity-reagent-allergy-text = [color={$reagentColor}]█[/color] {$reagentName}
 
 rotting-rotting-short = [color=orange]Corpse is rotting![/color]
 rotting-bloated-short = [color=orangered]Corpse is bloated![/color]


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Adds a list of allergies to the health scanner.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Feels like something that should be available on scan. It does not tell you how severe the allergies are though. You still still have to look that up.

~~Depending on how many allergies one has, this could be a long list, so we could possibly limit it to like 5 or 10 if needed.~~ Fixed by just putting it after damage mostly.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Allergies are a server-side component only, so a serialized list has to be in the payload sent from server to client. I resisted moving that all to shared though because scope creep. That looks like it could be done pretty easily to be honest.

If the health analyzer ever becomes [predicted](https://github.com/space-wizards/space-station-14/pull/42773), allergies should be moved to shared and become networked. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->

### With Allergies (1)
<img width="456" height="495" alt="image" src="https://github.com/user-attachments/assets/ccc3168a-1804-40a3-92f7-03838844a768" />

### With Allergies (way too many)
<img width="457" height="525" alt="image" src="https://github.com/user-attachments/assets/64d9752d-dca9-45d4-92ca-339d1ff23627" />


### Without Allergies
<img width="381" height="226" alt="image" src="https://github.com/user-attachments/assets/33d0ad1a-8d90-4fc7-adc8-13dd50df64c0" />

</details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: The health scanner now shows allergies!