### PR TITLE
Give captain loadouts to captain instead of generic command loadouts

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -15,9 +15,9 @@
   - Survival
   - CaptainJobTrinkets
   - GroupSpeciesBreathTool
-  - FloofUndergarmentTopCommand # Floof
-  - FloofUndergarmentBottomCommand # Floof
-  - FloofSocksCommand # Floof
+  - FloofUndergarmentTopCaptain # Floof
+  - FloofUndergarmentBottomCaptain # Floof
+  - FloofSocksCaptain # Floof
 
 - type: roleLoadout
   id: JobHeadOfPersonnel


### PR DESCRIPTION
## About the PR
Replaces generic command loadout groups with captain loadout groups for:
- Top undergarments
- Bottom undergarments
- Socks

This PR does not affect the contents of those loadout groups, but in practice this adds the following loadouts for captains:
- Captain's thigh-high socks
- Captain's thong

## Why / Balance
The recent dedicated underwear slot PR removed these captain-specific loadouts from the captain.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="603" height="183" alt="loadout-gloves" src="https://github.com/user-attachments/assets/69a3a651-e2bf-49b0-96e7-87012ee468b7" />
<img width="603" height="183" alt="loadout-socks" src="https://github.com/user-attachments/assets/32ae3680-952d-467f-9829-8a88128bfa91" />
<img width="603" height="183" alt="loadout-underwear" src="https://github.com/user-attachments/assets/1fcc4e77-1810-4a4f-9079-8662e5412330" />
<img width="148" height="147" alt="equipped" src="https://github.com/user-attachments/assets/934e485b-92fd-4efa-b831-6c6543264d6e" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- fix: Captains can start with their thigh-highs and thongs again.
