### PR TITLE
GIVE ME MY ROBOTS BACK!!!!

### DIFF
--- a/Resources/Locale/en-US/_Euphoria/species/ipc.ftl
+++ b/Resources/Locale/en-US/_Euphoria/species/ipc.ftl
@@ -1,0 +1,11 @@
+marking-MobIPCHeadStandard = Standard Robotic Monitor
+marking-MobIPCTorsoStandard = Standard Robotic Chassis
+marking-MobIPCLArmStandard = Standard Robotic Left Arm
+marking-MobIPCLHandStandard = Standard Robotic Left Hand
+marking-MobIPCRArmStandard = Standard Robotic Right Arm
+marking-MobIPCRHandStandard = Standard Robotic Right Hand
+marking-MobIPCLLegStandard = Standard Robotic Left Leg
+marking-MobIPCLFootStandard = Standard Robotic Left Foot
+marking-MobIPCRLegStandard = Standard Robotic Right Leg
+marking-MobIPCRFootStandard = Standard Robotic Right Foot
+marking-MobIPCTorsoStandardAlt = Standard Alternate Robotic Chassis

--- a/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/zenghu_alt.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Customization/Markings/zenghu_alt.yml
@@ -1,0 +1,95 @@
+- type: marking
+  id: CyberLimbsMarkingZenghuHeadAlt
+  bodyPart: Head
+  markingCategory: Head
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_head-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_head-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuChestAlt
+  bodyPart: Chest
+  markingCategory: Chest
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_chest-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_chest-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuLArmAlt
+  bodyPart: LArm
+  markingCategory: Arms
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_arm-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_arm-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuLHandAlt
+  bodyPart: LHand
+  markingCategory: Arms
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_hand-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_hand-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuLLegAlt
+  bodyPart: LLeg
+  markingCategory: Legs
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_leg-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_leg-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuLFootAlt
+  bodyPart: LFoot
+  markingCategory: Legs
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_l_foot
+
+- type: marking
+  id: CyberLimbsMarkingZenghuRArmAlt
+  bodyPart: RArm
+  markingCategory: Arms
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_arm-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_arm-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuRHandAlt
+  bodyPart: RHand
+  markingCategory: Arms
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_hand-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_hand-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuRLegAlt
+  bodyPart: RLeg
+  markingCategory: Legs
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_leg-1
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_leg-2
+
+- type: marking
+  id: CyberLimbsMarkingZenghuRFootAlt
+  bodyPart: RFoot
+  markingCategory: Legs
+  sprites:
+  - sprite: _EE/Mobs/Species/Cybernetics/zenghu/zenghu_alt.rsi
+    state: zhpipc_r_foot

--- a/Resources/Prototypes/_FarHorizons/Species/ipc.yml
+++ b/Resources/Prototypes/_FarHorizons/Species/ipc.yml
@@ -54,25 +54,41 @@
       points: 2
       required: true
     Hair:
-      points: 2
+      points: 1 # Euphoria - Previously 2 for some reason.
       required: false
     FacialHair:
-      points: 2
+      points: 1 # Euphoria - Same problem as hair
       required: false
     Head:
-      points: 2
+      points: 6
       required: true
+      defaultMarkings: [ MobIPCHeadStandard ]
     HeadSide:
-      points: 2
-      required: true
+      points: 6
+      required: false
     Chest:
-      points: 3
-      required: false
+      points: 10
+      required: true
+      defaultMarkings: [ MobIPCTorsoStandard ]
     Legs:
-      points: 3
-      required: false
+      points: 24
+      required: true
+      defaultMarkings: [ MobIPCLLegStandard, MobIPCLFootStandard, MobIPCRLegStandard, MobIPCRFootStandard ]
     Arms:
-      points: 3
+      points: 24
+      required: false
+      defaultMarkings: [ MobIPCLArmStandard, MobIPCLHandStandard, MobIPCRArmStandard, MobIPCRHandStandard ]
+    Snout: # DeltaV - Adds ability to use more marking types
+      points: 1
+      required: false
+    SnoutCover:
+      points: 1
+      required: false
+    UndergarmentTop:
+      points: 1
+      required: false
+    Eyes: # DeltaV - Moves screen to the eyes layer
+      points: 10
       required: false
 
 - type: humanoidBaseSprite
@@ -87,87 +103,143 @@
 - type: humanoidBaseSprite
   id: MobIPCMarkingMatchSkin
   markingsMatchSkin: true
-
-- type: humanoidBaseSprite
-  id: MobIPCHead
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
-    state: head_m
+# Head
 
 - type: humanoidBaseSprite
   id: MobIPCHeadMale
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
-    state: head_m
 
 - type: humanoidBaseSprite
   id: MobIPCHeadFemale
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
-    state: head_f
+
+- type: humanoidBaseSprite
+  id: MobIPCHead
+
+- type: marking
+  id: MobIPCHeadStandard
+  bodyPart: Head
+  markingCategory: Head
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+    state: head_m
+
+# Torso
 
 - type: humanoidBaseSprite
   id: MobIPCTorso
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
-    state: torso_m
-
-- type: humanoidBaseSprite
-  id: MobIPCTorsoMale
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
-    state: torso_m
 
 - type: humanoidBaseSprite
   id: MobIPCTorsoFemale
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+  # Alt Standard Chassis Marking is here to keep it consistent with the location of the rest of them.
+
+- type: marking
+  id: MobIPCTorsoStandardAlt
+  bodyPart: Chest
+  markingCategory: Chest
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: torso_f
 
 - type: humanoidBaseSprite
+  id: MobIPCTorsoMale
+
+- type: marking
+  id: MobIPCTorsoStandard
+  bodyPart: Chest
+  markingCategory: Chest
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+    state: torso_m
+
+
+# Left Limbs
+
+- type: humanoidBaseSprite
   id: MobIPCLLeg
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCLLegStandard
+  bodyPart: LLeg
+  markingCategory: Legs
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: l_leg
 
 - type: humanoidBaseSprite
   id: MobIPCLArm
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCLArmStandard
+  bodyPart: LArm
+  markingCategory: Arms
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: l_arm
 
 - type: humanoidBaseSprite
   id: MobIPCLHand
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCLHandStandard
+  bodyPart: LHand
+  markingCategory: Arms
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: l_hand
 
 - type: humanoidBaseSprite
   id: MobIPCLFoot
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCLFootStandard
+  bodyPart: LFoot
+  markingCategory: Legs
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: l_foot
+
+# Right Limbs
 
 - type: humanoidBaseSprite
   id: MobIPCRLeg
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCRLegStandard
+  bodyPart: RLeg
+  markingCategory: Legs
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: r_leg
 
 - type: humanoidBaseSprite
   id: MobIPCRArm
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCRArmStandard
+  bodyPart: RArm
+  markingCategory: Arms
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: r_arm
 
 - type: humanoidBaseSprite
   id: MobIPCRHand
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCRHandStandard
+  bodyPart: RHand
+  markingCategory: Arms
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: r_hand
 
 - type: humanoidBaseSprite
   id: MobIPCRFoot
-  baseSprite:
-    sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
+
+- type: marking
+  id: MobIPCRFootStandard
+  bodyPart: RFoot
+  markingCategory: Legs
+  sprites:
+  - sprite: _FarHorizons/Mobs/Species/IPC/parts.rsi
     state: r_foot


### PR DESCRIPTION


## About the PR
Restored essential creativity to dressing up your IPC however you want. Enabled Zenghu Alternate options once again.

## Why / Balance
i miss liturgiya... 

## Technical details
Hair/Facial Hair marking points were set to 2, which broke hair visibility for some reason. They're back to 1. Your robots are no longer bald!
FTL has been created to name the standard chassis options + standard alternate torso for the robots that still want their curvy hips. (if this needs to be relocated, tell me please)
IPC default chassis options were not defaulted to markings and instead actual body parts, which, unfortunately, breaks how we manipulate the marking system to pick out certain chassis options.
Alternate Zenghu existed in EE folder so I revived the yml that let the parts get selected with a path change. We-- we had this before, surely we can keep it, right?
Re-added certain marking tabs to IPC selection so they can re-select them.

I also paranoia tested this in a packaged version just to make sure it WORKS. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)
## Extra monitor is no longer ghosting behind the head
<img width="713" height="333" alt="image" src="https://github.com/user-attachments/assets/c13d65a3-fb47-475e-b312-b9b6c0f04756" />

## Hair works now + zenghu alt is back
<img width="1480" height="668" alt="image" src="https://github.com/user-attachments/assets/149b4775-2a51-4c5b-8f65-639a3f30c8f3" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Zenghu finally lets their synthetics utilize the alternate chassis again.
- tweak: Reverted marking points prior to the FH IPC transition so your robots can once again be dolled up. Remember to re-import your robots!
- fix: Markings now properly replace body parts on IPCs. 
- fix: IPCs are no longer bald!