### PR TITLE
hotfix for small reactor variant

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
@@ -83,6 +83,7 @@
         sound:
           collection: MetalBreak
   - type: InteractionOutline
+  - type: Rotatable
 
 - type: entity
   parent: HeavyFlatpackBase
@@ -91,7 +92,7 @@
   description: A flatpack used for constructing a small nuclear reactor. Parts sold separately.
   components:
   - type: Flatpack
-    entity: NuclearReactorSmall
+    entity: NuclearReactorSmallEmpty
 
 - type: entity
   parent: HeavyFlatpackBase

--- a/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Devices/flatpack.yml
@@ -83,7 +83,7 @@
         sound:
           collection: MetalBreak
   - type: InteractionOutline
-  - type: Rotatable
+  - type: Rotatable # Floof
 
 - type: entity
   parent: HeavyFlatpackBase
@@ -92,7 +92,7 @@
   description: A flatpack used for constructing a small nuclear reactor. Parts sold separately.
   components:
   - type: Flatpack
-    entity: NuclearReactorSmallEmpty
+    entity: NuclearReactorSmallEmpty # Floof | Was: NuclearReactorSmall
 
 - type: entity
   parent: HeavyFlatpackBase

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
@@ -270,6 +270,14 @@
           collection: MetalBreak
 
 - type: entity
+  id: NuclearReactorSmallEmpty
+  parent: NuclearReactorSmall
+  suffix: Empty
+  components:
+  - type: NuclearReactor
+    prefab: ReactorPrefab5x5Empty
+
+- type: entity
   id: NuclearReactorSmallRandom
   parent: NuclearReactorSmall
   suffix: Random

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
@@ -268,7 +268,7 @@
       - !type:PlaySoundBehavior
         sound:
           collection: MetalBreak
-
+# Floof start
 - type: entity
   id: NuclearReactorSmallEmpty
   parent: NuclearReactorSmall
@@ -276,7 +276,7 @@
   components:
   - type: NuclearReactor
     prefab: ReactorPrefabEmpty
-
+# Floof end
 - type: entity
   id: NuclearReactorSmallRandom
   parent: NuclearReactorSmall

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor.yml
@@ -275,7 +275,7 @@
   suffix: Empty
   components:
   - type: NuclearReactor
-    prefab: ReactorPrefab5x5Empty
+    prefab: ReactorPrefabEmpty
 
 - type: entity
   id: NuclearReactorSmallRandom

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor_prefabs.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor_prefabs.yml
@@ -227,6 +227,11 @@
     5,5: CerenkiteReactorFuelRod
 
 - type: nuclearReactorPrefab
+  id: ReactorPrefab5x5Empty
+  parts:
+   -1,-1: BaseReactorPart # Can't be empty, so I'll put this nothing part in an inaccessible spot
+
+- type: nuclearReactorPrefab
   id: ReactorPrefab5x5Normal
   parts:
     0,0: SteelReactorGasChannel

--- a/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor_prefabs.yml
+++ b/Resources/Prototypes/_FarHorizons/Entities/Structures/Power/Generation/FissionGenerator/nuclear_reactor_prefabs.yml
@@ -227,11 +227,6 @@
     5,5: CerenkiteReactorFuelRod
 
 - type: nuclearReactorPrefab
-  id: ReactorPrefab5x5Empty
-  parts:
-   -1,-1: BaseReactorPart # Can't be empty, so I'll put this nothing part in an inaccessible spot
-
-- type: nuclearReactorPrefab
   id: ReactorPrefab5x5Normal
   parts:
     0,0: SteelReactorGasChannel


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Makes it so the small reactor doesnt come with components inside anymore from the flatpack.
Also adding the ability to rotate the heavy flatpacks to unstuck them through doorways.
## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
A bug. Not supposed to come with ANY components inside. Just the reactor frame.
## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
YAML only. Added 2 things and modified 1.
## Media
<details><summary><h3>Click to show</h3></summary><p>
<img width="726" height="792" alt="image" src="https://github.com/user-attachments/assets/a6a87fc8-baa3-46c0-94e5-3bbbb929321b" />
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Removed components from the small reactor flatpack
