### PR TITLE
Fix N14 Cactus and Tree Fixtures

### DIFF
--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
@@ -118,7 +118,7 @@
       fix1:
         shape:
           !type:PhysShapeAabb
-          bounds: "-0.15,-0.1,0.15,0.7" # Floofstation - fix fixture
+          bounds: "-0.15,-0.1,0.15,0.4" # Floofstation - fix fixture
         density: 1000
         layer:
         - WallLayer

--- a/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
+++ b/Resources/Prototypes/_Nuclear14/Entities/Structures/Misc/floradesert.yml
@@ -7,17 +7,17 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/floradesert.rsi
     state: cactus
-    offset: 0,0
+    offset: 0.5,0.5 # Floofstation - fix this offset so it actually places at the mouse
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "-0.7,-0.3,-0.4,-1.2"
+            bounds: "-0.15,-0.2,0.15,0.2" # fix the fixture
         density: 1000
         layer:
         - WallLayer
-    
+
 - type: entity
   parent: N14FloraDesertCactus
   id: N14FloraDesertTree1
@@ -26,37 +26,41 @@
   components:
   - type: Sprite
     state: joshua_1
+    offset: 0,0.8 # Floofstation
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "0.3,-0.3,-0.2,-1.2"
+            bounds: "-0.15,-0.2,0.15,0" # Floofstation - fix fixture
         density: 1000
         layer:
         - WallLayer
-    
+
 - type: entity
   parent: N14FloraDesertTree1
   id: N14FloraDesertTree2
   components:
   - type: Sprite
     state: joshua_2
-    
+    offset: 0,0.8 # Floofstation
+
 - type: entity
   parent: N14FloraDesertTree1
   id: N14FloraDesertTree3
   components:
   - type: Sprite
     state: joshua_3
-    
+    offset: 0,0.8 # Floofstation
+
 - type: entity
   parent: N14FloraDesertTree1
   id: N14FloraDesertTree4
   components:
   - type: Sprite
     state: joshua_4
-    
+    offset: 0,0.8 # Floofstation
+
 - type: entity
   parent: N14FloraDesertCactus
   id: N14FloraTreeBald
@@ -66,16 +70,17 @@
   - type: Sprite
     sprite: _Nuclear14/Structures/Misc/trees-ms.rsi
     state: bald
+    offset: 0,1.8 # Floofstation
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeAabb
-            bounds: "0.2,-1.4,-0.2,-1.8"
+            bounds: "-0.15,-0.2,0.15,0" # Floofstation - fix fixture
         density: 1000
         layer:
         - WallLayer
-    
+
 - type: entity
   parent: N14FloraTreeBald
   id: N14FloraTreePine
@@ -91,7 +96,7 @@
       - tree:
           pine_1: ""
           pine_1_alt: ""
-          
+
 - type: entity
   parent: N14FloraTreeBald
   id: N14FloraTreeDead1
@@ -108,7 +113,17 @@
           dead_tree1: ""
           dead_tree2: ""
           dead_tree3: ""
-          
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.15,-0.1,0.15,0.7" # Floofstation - fix fixture
+        density: 1000
+        layer:
+        - WallLayer
+
+
 - type: entity
   parent: N14FloraTreeDead1
   id: N14FloraTreeDead2


### PR DESCRIPTION
## About the PR
Fix some of the n14 tree and cactus textures that are going to be used.

## Why / Balance
Fixing this for a map that's being worked on #925

## Technical details
Some yaml changes

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

NOCL