### PR TITLE
Major Histamine Adjustments

### DIFF
--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -388,6 +388,7 @@
   color: "#FA6464"
   metabolisms:
     Poison:
+      metabolismRate: 0.05 # Euphoria - Dramatically reduced metabolism rate to allow non-extreme allergies to build up histamine. Anti-histamine chems will also be more useful. 
       effects:
       - !type:HealthChange
         probability: 0.1
@@ -395,7 +396,14 @@
           groups:
             #Brute: 1 #Euphoria - remove brute damage to stop allergies causing limb loss
           types:
-            Poison: 1
+            Poison: 0.75 #Euphoria - Reduced damage to compensate for slower metabolism.
+      - !type:AdjustReagent
+        reagent: Histamine
+        amount: -20
+        conditions:
+        - !type:ReagentCondition
+          reagent: Histamine # Purges Histamine if dosage is too high. Should "soft cap" at 100u. 80u is definitely enough to kill somebody without help.
+          min: 100
       # todo: cough, sneeze
       - !type:HealthChange
         conditions:
@@ -405,9 +413,9 @@
         damage:
           groups:
             #Brute: 1 #Euphoria - remove brute damage to stop allergies causing limb loss
-            Airloss: 2
+            Airloss: 1 #Euphoria - Reduced damage to compensate for slower metabolism. Patient and Doctors have more time to react.
           types:
-            Poison: 2
+            Poison: 1 #Euphoria - Reduced damage to compensate for slower metabolism. Patient and Doctors have more time to react.
       - !type:Emote
         conditions:
         - !type:ReagentCondition # Start Change


### PR DESCRIPTION
## About the PR
Changed Histamine to metabolize DRAMATICLALY slower, and reduced its damage per second when being metabolized to compensate. Histamine now also removes 20u of itself when there's more than 100u of Histamine in the body.

## Why / Balance
Allergies are a point of contention by some people in Medical; Mild, Moderate and Severe allergies can practically be ignored while Extreme allergies would effectively round remove the patient. Anti-Histamine chemicals (such as Diphenhydramine) weren't needed  for anything other than the most extreme cases, because Histamine would disappear quickly - and in the most extreme cases, there was too mush Histamine to properly negate anyways (usually 200-300 units in testing). 

Making Histamine metabolize much slower allows for more mild allergies to "build up" if the person is exposed to them multiple times, while also encouraging the usage of anti-histamine chemicals to remove Histamine from the body more quickly. Histamine removing itself from the body at over 100u means that, after an initial "spike", the amount of histamine in a body will decline quickly to a level Medical can actually treat. 

Reducing the damage form Histamine just makes it less extreme when accounting for the new metabolism rate, but it also allows people more time to react and treat the issue. 

## Technical details
Histamine metabolism is now 0.05, down from 0.5
Histamine damage at less than 45u is now 0.75 Poison, down from 1.0 (still deals damage at a 10% chance each metabolism tick)
Histamine damage above 45u is now 1.0 Airloss and 1.0 Poison, down from 2.0 Airloss and 2.0 Poison. 
Histamine reduces its amount by 20u when the total amount is above 100u.
## Media
<details> <summary><h3>A Severe-Intensity Allergic Reaction with zero treatment whatsoever</h3></summary> <p>
<img width="742" height="212" alt="image" src="https://github.com/user-attachments/assets/b988cf78-559b-47db-90c0-b0a3aef2ca7b" />

<!-- This is default collapsed, readers click to expand it and see all your media -->

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Histamine deals less damage per second and metabolizes much more slowly.
