### PR TITLE
Fix Station Goals

### DIFF
--- a/Content.Server/_EE/StationGoal/StationGoalPaperSystem.cs
+++ b/Content.Server/_EE/StationGoal/StationGoalPaperSystem.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
-using Content.Server.GameTicking;
-using Content.Server.GameTicking.Events;
 using Content.Server.Fax;
+using Content.Server.GameTicking;
 using Content.Server.Station.Systems;
 using Content.Shared._EE.CCVars;
 using Content.Shared._DV.CCVars;
@@ -38,15 +37,24 @@ public sealed class StationGoalPaperSystem : EntitySystem
     {
         base.Initialize();
 
-        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStarted);
+        // Was: SubscribeLocalEvent<RoundStartingEvent>(OnRoundStarted);
+        // Changed to GameRunLevelChangedEvent so we can check if the round is running
+        // our event needs to happen AFTER the round has started so we know the fax machines
+        // have finished initializing, and we don't have the fax que cleared.
+        SubscribeLocalEvent<GameRunLevelChangedEvent>(OnRunLevelChanged);
     }
 
-
-    private void OnRoundStarted(RoundStartingEvent ev)
+    private void OnRunLevelChanged(GameRunLevelChangedEvent ev)
     {
+        // if we are not in round return (other otions are in lobby or post round
+        if (ev.New != GameRunLevel.InRound)
+            return;
+
         if (_config.GetCVar(EECVars.StationGoalsEnabled)
-        	&& _random.Prob(_config.GetCVar(EECVars.StationGoalsChance))) // changed this to be in the _EE namespace
+            && _random.Prob(_config.GetCVar(EECVars.StationGoalsChance))) // changed this to be in the _EE namespace
+        {
             SendRandomGoal();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## About the PR
So fun fact, this was indeed bugged so heres a fix.

## Why / Balance
Uh it was broken so this would never actually fire.

## Technical details
Previously used <RoundStartingEvent>(OnRoundStarted); which its when the round is _starting_, This leads to a few issues, the fax que getting cleared or the fax machine isn't ready to receive faxes yet. I swapped it to <GameRunLevelChangedEvent>(OnRunLevelChanged); so we can simply check what "state" the round is in. It can return three things the only time this event will now fire is if it returns its in round.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Station Goals should now be actually sent to the station.
