### PR TITLE
Ninja: Forbidden Target

### DIFF
--- a/Resources/Maps/Floof/pebble.yml
+++ b/Resources/Maps/Floof/pebble.yml
@@ -69963,7 +69963,7 @@ entities:
       parent: 2
     - type: Fixtures
       fixtures: {}
-- proto: WarpPoint
+- proto: WarpPointNoBomb
   entities:
   - uid: 10816
     components:

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -260,6 +260,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-medbay
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -317,6 +320,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-research-and-development
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -325,6 +331,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-research-server
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -333,6 +342,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-mystagogue  #Delta V - Renamed
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -349,6 +361,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-artifact-lab
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -357,6 +372,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-anomaly-gen
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -514,6 +532,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-anchor
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -522,6 +543,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-pa
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -546,6 +570,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-atmos
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconEngineering
@@ -647,6 +674,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-evac
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -687,6 +717,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-dorms
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -722,6 +755,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -730,6 +766,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-N
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -738,6 +777,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-NE
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -746,6 +788,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-E
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -754,6 +799,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-SE
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -762,6 +810,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-S
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -770,6 +821,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-SW
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -778,6 +832,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-W
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -786,6 +843,9 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-escape-pod-NW
+  - type: Tag # Euphoria | Parity with warp point blocklist
+    tags:
+    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon

--- a/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/station_beacon.yml
@@ -260,9 +260,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-medbay
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconMedical
@@ -320,9 +317,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-research-and-development
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -331,9 +325,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-research-server
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -342,9 +333,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-mystagogue  #Delta V - Renamed
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -361,9 +349,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-artifact-lab
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconScience
@@ -372,9 +357,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-anomaly-gen
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeacon
@@ -532,9 +514,6 @@
   components:
   - type: NavMapBeacon
     defaultText: station-beacon-anchor
-  - type: Tag # Euphoria | Parity with warp point blocklist
-    tags:
-    - NinjaBombingTargetBlocker
 
 - type: entity
   parent: DefaultStationBeaconEngineering

--- a/Resources/Prototypes/_DV/Entities/Markers/warp_point.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/warp_point.yml
@@ -378,8 +378,8 @@
     location: Cryo
 
 - type: entity
-  id: WarpPointDormsNoBomb # Euphoria | Bombing dorms is a rule break
-  parent: WarpPoint
+  id: WarpPointDorms
+  parent: WarpPointNoBomb # Euphoria | Bombing dorms is a rule break
   suffix: Dorms
   components:
   - type: WarpPoint

--- a/Resources/Prototypes/_DV/Entities/Markers/warp_point.yml
+++ b/Resources/Prototypes/_DV/Entities/Markers/warp_point.yml
@@ -378,7 +378,7 @@
     location: Cryo
 
 - type: entity
-  id: WarpPointDorms
+  id: WarpPointDormsNoBomb # Euphoria | Bombing dorms is a rule break
   parent: WarpPoint
   suffix: Dorms
   components:


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
This PR addresses the following issues:
- Pebble had a default warp point named Evac at Evac, which was a valid ninja bomb target
- The dorms warp point was a valid ninja bomb target
- Station beacons marking places we don't want bombed were valid ninja bomb targets

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ninjas should not be asked to bomb places they aren't allowed to bomb.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Touches the Pebble map file (which loaded fine in testing afterwards), reparents the default warp point for evac to the no bomb verstion, and tags several beacons that would be used in no bomb locations with the bomb blocker tag.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Pictured, a ninja not getting dorms as a target:
<img width="441" height="115" alt="image" src="https://github.com/user-attachments/assets/41850aee-e8a3-48da-8188-72a76597abfa" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
While not a breaking change, there is almost certainly more instances of improper warp point and beacon usage that will need to be noted as they are found.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- fix: Ninjas should no longer be asked to bomb places they shouldn't. (Ask in AHELP if unsure about your target!)