### PR TITLE
Apply more displacement maps to resomi.

### DIFF
--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
@@ -114,6 +114,26 @@
           32:
             sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
             state: belt
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: jumpsuit
+      undergarmentTop:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: jumpsuit
+      undergarmentBottom:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: jumpsuit
+      undergarmentSock:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: feet
     femaleDisplacements: # Goobstation - splitting up the genders broke displacements, apparently it won't just apply the same displacement to both genders :|
       jumpsuit:
         sizeMaps:
@@ -170,6 +190,26 @@
           32:
             sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
             state: belt
+      outerClothing:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: jumpsuit
+      undergarmentTop:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: jumpsuit
+      undergarmentBottom:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: jumpsuit
+      undergarmentSock:
+        sizeMaps:
+          32:
+            sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
+            state: feet
   - type: FootPrints # Goobstation - resomi footprints
     leftBarePrint: "footprint-left-bare-lizard"
     rightBarePrint: "footprint-right-bare-lizard"

--- a/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
+++ b/Resources/Prototypes/_Floof/Entities/Mobs/Species/resomi.yml
@@ -129,7 +129,7 @@
           32:
             sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
             state: jumpsuit
-      undergarmentSock:
+      undergarmentSocks:
         sizeMaps:
           32:
             sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
@@ -205,7 +205,7 @@
           32:
             sprite: _Floof/Mobs/Species/Resomi/displacement.rsi
             state: jumpsuit
-      undergarmentSock:
+      undergarmentSocks:
         sizeMaps:
           32:
             sprite: _Floof/Mobs/Species/Resomi/displacement.rsi


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Apply existing displacement maps to resomi when wearing underwear/outerwear

## Why / Balance
Resomi looked like they were wearing jackets that were way too big for them.

## Technical details
I just used the existing maps to try and get a better fit to the sprite

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="382" height="391" alt="image" src="https://github.com/user-attachments/assets/72e122a0-99c6-4258-8209-ab922f1973e6" />
<img width="202" height="276" alt="image" src="https://github.com/user-attachments/assets/43e4bd73-755b-4e0e-a5db-9bb5e7100e1c" />
<img width="183" height="284" alt="image" src="https://github.com/user-attachments/assets/dc9babb5-7966-4131-a344-ef0a948b14cd" />
<img width="162" height="271" alt="image" src="https://github.com/user-attachments/assets/ffb01dad-d20a-4dc5-a919-26e86923a11e" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
Sprites are gonna change on characters now. We should try to get displacement maps that indicate the regions that underwear should be. Right now they stretch quite strangely.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Resomi now explicitly use displacement maps for underwear and outerclothing. This means that most items will hug resomi bodies more closely.
