### PR TITLE
Scurret Crate Price Decrease and Animal Translator Include Scurret

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_fun.yml
@@ -234,7 +234,7 @@
     sprite: Structures/Wallmounts/posters.rsi
     state: poster55_legit
   product: CrateFunScurret
-  cost: 25000 # You will surely not regret buying this
+  cost: 10000 # Euphoria, decreased price
   category: cargoproduct-category-name-fun
   group: market
 

--- a/Resources/Prototypes/_Floof/Entities/Objects/Devices/translators.yml
+++ b/Resources/Prototypes/_Floof/Entities/Objects/Devices/translators.yml
@@ -218,7 +218,7 @@
     - Pig
     - Crab
     - Kobold
-    - ScugSign
+    - Scurret
     - Hissing
     requires:
     - TauCetiBasic


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Changed Scurret crate price from 25,000 to 10,000.
Changed Animal Translator to translate Scurret instead of ScugSign.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Players have requested these changes, and they were mentioned in the Dev meet. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just yml changes. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="642" height="631" alt="image" src="https://github.com/user-attachments/assets/b8020e97-9b40-4f96-9b21-e03ebfbfa385" />

<img width="838" height="827" alt="image" src="https://github.com/user-attachments/assets/44c07dc7-e3c4-47b2-84eb-94e8c101d872" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Changed Scurret crate from 25,000 to 10,000. Also made Animal translator translate Scurret instead of ScugSign.
