### PR TITLE
Allow undergarment bottoms to be accessed while wearing open-bottomed clothing

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
+++ b/Resources/Prototypes/Entities/Clothing/Uniforms/base_clothinguniforms.yml
@@ -86,3 +86,4 @@
     - Skirt # Delta-V : Harpies can wear this
     - ClothMade # Delta-V : Moths can eat this
     - WhitelistChameleon # Delta-V : You can set Chameleon clothes to this.
+    - BottomAccessibleClothing # Euphoria: Does not block underwear bottoms.

--- a/Resources/Prototypes/_Euphoria/Entities/Clothing/Uniforms/jumpsuits.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Clothing/Uniforms/jumpsuits.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformLustroEcclesiaInfernus
   name: lustro ecclesia ceremonial dress
   description: Ceremonial garbs of the Lustro Ecclesia faith. Typically worn by their devotees upon completion of the Fire Rite.
@@ -9,14 +9,9 @@
   - type: Clothing
     slots: [innerclothing]
     sprite: _Euphoria/Clothing/Uniforms/Jumpskirt/infernus.rsi
-  - type: Tag
-    tags:
-    - ClothMade
-    - WhitelistChameleon
-    - Skirt
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformShirtlessBase
   id: ClothingUniformLustroEcclesiaInfernusAlt
   name: lustro ecclesia ceremonial trousers
   description: Ceremonial garbs of the Lustro Ecclesia faith. Typically worn by their devotees upon completion of the Fire Rite.
@@ -26,10 +21,6 @@
   - type: Clothing
     slots: [innerclothing]
     sprite: _Euphoria/Clothing/Uniforms/Jumpsuit/infernus.rsi
-  - type: Tag
-    tags:
-    - ClothMade
-    - WhitelistChameleon
 
 - type: entity
   parent: ClothingUniformBase
@@ -48,7 +39,7 @@
     - WhitelistChameleon
 
 - type: entity
-  parent: ClothingUniformBase
+  parent: ClothingUniformSkirtBase
   id: ClothingUniformLustroEcclesiaAlt
   name: lustro ecclesia gown
   description: Garbs worn by devotees of the Lustro Ecclesia faith.
@@ -58,11 +49,6 @@
   - type: Clothing
     slots: [innerclothing]
     sprite: _Euphoria/Clothing/Uniforms/Jumpskirt/lustromonk.rsi
-  - type: Tag
-    tags:
-    - ClothMade
-    - WhitelistChameleon
-    - Skirt
 
 - type: entity
   parent: ClothingUniformJumpskirtClown

--- a/Resources/Prototypes/_Floof/Entities/Clothing/Uniforms/misc.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/Uniforms/misc.yml
@@ -1,5 +1,5 @@
 - type: entity
-  parent: [ClothingUniformShirtlessBase, ClothingUniformBase]
+  parent: [ClothingUniformNakedBase, ClothingUniformBase]
   id: ClothingUniformNudityPermit
   name: public nudity permit
   description: This permit entitles the bearer to conduct their duties without a uniform. Normally issued to furred crewmembers or those with nothing to hide.
@@ -12,9 +12,10 @@
     sprite: _Floof/Clothing/Uniforms/nuditypermit.rsi
     equipDelay: 0
     unequipDelay: 0
+  
 
 - type: entity
-  parent: [ClothingUniformShirtlessBase, ClothingUniformBaseSwitch]
+  parent: [ClothingUniformShirtlessAccessibleBase, ClothingUniformBaseSwitch]
   id: ClothingUniformLoinClothBlack
   name: black loin-cloth
   description: A piece of cloth wrapped around the waist.

--- a/Resources/Prototypes/_Floof/Entities/Clothing/base.yml
+++ b/Resources/Prototypes/_Floof/Entities/Clothing/base.yml
@@ -3,12 +3,37 @@
   id: ClothingUniformShirtlessBase
   abstract: true
   components:
-  - type: Tag #DeltaV, needed for species with nonhuman legs/can only wear skirts
+  - type: Tag
     tags:
     - ClothMade
     - WhitelistChameleon
-    - Skirt
     - ShirtlessClothing # to allow equipping/unequipping under coats and the like
+
+# Base clothing that does not block undergarment slots
+- type: entity
+  id: ClothingUniformShirtlessAccessibleBase
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - Skirt #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    - ShirtlessClothing
+    - BottomAccessibleClothing
+    
+# Base clothing that does not block undergarment slots
+- type: entity
+  id: ClothingUniformNakedBase
+  abstract: true
+  components:
+  - type: Tag
+    tags:
+    - ClothMade
+    - WhitelistChameleon
+    - Skirt #DeltaV, needed for species with nonhuman legs/can only wear skirts
+    - ShirtlessClothing
+    - BottomlessClothing
 
 # Base undergarment. Do not inherit from this directly.
 - type: entity
@@ -79,6 +104,10 @@
       slots:
       - INNERCLOTHING
       - OUTERCLOTHING
+      blacklist:
+        tags:
+        - BottomlessClothing
+        - BottomAccessibleClothing
 
 # Base for top undergarment
 - type: entity
@@ -135,3 +164,6 @@
     blockedBy:
       slots:
       - OUTERCLOTHING
+      blacklist:
+        tags:
+        - ShirtlessClothing

--- a/Resources/Prototypes/_Floof/Tags/assorted.yml
+++ b/Resources/Prototypes/_Floof/Tags/assorted.yml
@@ -14,6 +14,12 @@
   id: ShirtlessClothing
 
 - type: Tag
+  id: BottomlessClothing # Different from BottomAccessible which is for slot blocking only; BottomlessClothing allows genitals to be theoretically visible
+
+- type: Tag
+  id: BottomAccessibleClothing # Different purpose than skirt: Skirt allows harpies to wear it, accessible allows underwear slots to be accessed.
+
+- type: Tag
   id: Sterilebag
 
 - type: Tag


### PR DESCRIPTION
## About the PR
Added tags and clothing bases to skirts and loincloths, and blacklisted those tags from blocking undergarment bottoms. Similar change for undergarment tops (not used at current moment since all undergarment tops are not blocked by inner clothing).

## Why / Balance
Allows someone wearing skirts or nudity permits to take off their undergarment bottoms or put them back on without first un-equipping said item. It doesn't make physical sense that they block this action.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Skirts and nudity permits no longer block underwear bottom slots
