### PR TITLE
Autolabel off by Default

### DIFF
--- a/Content.Server/_NF/Chemistry/Components/ReagentDispenserComponent.AutoLabel.cs
+++ b/Content.Server/_NF/Chemistry/Components/ReagentDispenserComponent.AutoLabel.cs
@@ -17,6 +17,6 @@ public sealed partial class ReagentDispenserComponent : Component
     /// Returns if the entity has auto-labeling toggled on.
     /// Will have no effect if <see cref="CanAutoLabel"/> is false.
     /// </summary>
-    [ViewVariables]
+    [DataField, ViewVariables] // Floofstation - make this a datafield so we can turn this off
     public bool AutoLabelToggle = true;
 }

--- a/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
+++ b/Resources/Prototypes/Entities/Structures/Dispensers/base_structuredispensers.yml
@@ -67,6 +67,7 @@
         components:
         - FitsInDispenser
       priority: 9
+    autoLabelToggle: false # Floofstation - turn this shit off by default
   - type: ItemSlots
   - type: ContainerContainer
     containers:


### PR DESCRIPTION
## About the PR
Turns auto label off by default, my branch name is not accurate just realized but don't care enough to fix the branch name.

## Why / Balance
Its annoying that its on by default, so we turn it off and allow people to turn it on as they desire.

## Technical details
Make AutoLabelToggle a datafield and add it toggled off to base dispenser.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Autolabelers will now be off by default, you can toggle them on if you wish to use them.
