### PR TITLE
Hide tinyfan from the spawn menu

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -3,7 +3,7 @@
   id: AtmosDeviceFanTiny
   name: tiny fan
   description: A tiny fan, releasing a thin gust of air.
-  categories: [ HideSpawnMenu ]
+  categories: [ HideSpawnMenu ] # Euph - deprecated
   placement:
     mode: SnapgridCenter
   components:

--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/special.yml
@@ -3,6 +3,7 @@
   id: AtmosDeviceFanTiny
   name: tiny fan
   description: A tiny fan, releasing a thin gust of air.
+  categories: [ HideSpawnMenu ]
   placement:
     mode: SnapgridCenter
   components:


### PR DESCRIPTION
## About the PR
The tiny fan is a buggy piece of shit that should be deprecated and never be mapped. Mappers and admins should use directional tiny fans instead.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
ADMIN:
- tweak: Full-tile tiny fans are now hidden from the spawn menu. Use directional ones instead.