### PR TITLE
More Loadout Fixes

### DIFF
--- a/Resources/Prototypes/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Loadouts/role_loadouts.yml
@@ -267,6 +267,7 @@
   - FloofUndergarmentTopPassenger # Floof
   - FloofUndergarmentBottomPassenger # Floof
   - FloofSocksPassenger # Floof
+  - GroupSpeciesBreathTool # floof
   - GroupTankHarness
   - SurvivalClown
   - ClownJobTrinkets
@@ -286,6 +287,7 @@
   - MimeBackpack
   - MimeOuterClothing
   - MimeBelt
+  - GroupSpeciesBreathTool # floof
   - GroupTankHarness
   - FloofUndergarmentTopPassenger # Floof
   - FloofUndergarmentBottomPassenger # Floof
@@ -785,6 +787,10 @@
   - Survival
   - ReporterJobTrinkets
   - GroupSpeciesBreathTool
+  - FloofUndergarmentTopPassenger # Floof
+  - FloofUndergarmentBottomPassenger # Floof
+  - FloofSocksPassenger # Floof
+
 
 - type: roleLoadout
   id: JobPsychologist

--- a/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/_DV/Loadouts/loadout_groups.yml
@@ -356,6 +356,7 @@
 
 - type: loadoutGroup
   id: GroupSpeciesBreathToolCorpsman
+  parent: [GroupSpeciesBreathTool] # floofstation
   name: loadout-group-breath-tool
   minLimit: 1
   maxLimit: 1

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -21,28 +21,28 @@
 - type: loadout
   id: ClothingHeadHatWelding
   equipment:
-    eyes: ClothingHeadHatWelding
+    head: ClothingHeadHatWelding
 
 - type: loadout
   id: ClothingHeadHatWeldingMaskPainted
   equipment:
-    eyes: ClothingHeadHatWeldingMaskPainted
+    head: ClothingHeadHatWeldingMaskPainted
 
 - type: loadout
   id: ClothingHeadHatWeldingMaskFlame
   equipment:
-    eyes: ClothingHeadHatWeldingMaskFlame
+    head: ClothingHeadHatWeldingMaskFlame
 
 - type: loadout
   id: ClothingHeadHatWeldingMaskFlameBlue
   equipment:
-    eyes: ClothingHeadHatWeldingMaskFlameBlue
+    head: ClothingHeadHatWeldingMaskFlameBlue
 
 # emotional support collar
 - type: loadout
   id: ClothingNeckCollarEmotionalSupportStationEngineer
   equipment:
-    neck: ClothingNeckCollarEmotionalSupportStationEngineer
+    head: ClothingNeckCollarEmotionalSupportStationEngineer
 
 # top undergarment
 


### PR DESCRIPTION
## About the PR
Some more loadout fixes, the never ending yaml battle.

- moved engineering's welding masks to the right slot when chosen
- vox specific breath mask options given to clown, corpsman and mime
- Gives reporter undergarment selection

## Why / Balance
Some more issues to fix

## Technical details
yaml

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Moved engineering's welding masks to the right equipment slot when chosen.
- fix: Vox specific breath mask options given to clown, corpsman and mime
- fix: Gives reporter undergarment selection
