### PR TITLE
Update Rules, Remove Random Romerol from puddles and toilets

### DIFF
--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
@@ -207,10 +207,10 @@ public sealed class OracleSystem : EntitySystem
     {
         if (!_solutionSystem.TryGetSolution(uid, OracleComponent.SolutionName, out var fountainSol))
             return;
-
-        var allReagents = _prototypeManager.EnumeratePrototypes<ReagentPrototype>()
-            .Where(x => !x.Abstract)
-            .Select(x => x.ID).ToList();
+        //Euphoria - remove chance at forbidden reagents
+        //var allReagents = _prototypeManager.EnumeratePrototypes<ReagentPrototype>()
+        //    .Where(x => !x.Abstract)
+        //    .Select(x => x.ID).ToList();
 
         var amount = 20 + _random.Next(1, 30) + _glimmerSystem.Glimmer / 10f;
         amount = (float) Math.Round(amount);
@@ -219,7 +219,7 @@ public sealed class OracleSystem : EntitySystem
         var reagent = "";
 
         if (_random.Prob(0.2f))
-            reagent = _random.Pick(allReagents);
+            reagent = _random.Pick(component.RewardReagents); //Euphoria - no chance at romerol. I know Mnemo, this is a terrible way to solve this, but I am tired
         else
             reagent = _random.Pick(component.RewardReagents);
 

--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
@@ -207,10 +207,10 @@ public sealed class OracleSystem : EntitySystem
     {
         if (!_solutionSystem.TryGetSolution(uid, OracleComponent.SolutionName, out var fountainSol))
             return;
-        //Euphoria - remove chance at forbidden reagents
-        //var allReagents = _prototypeManager.EnumeratePrototypes<ReagentPrototype>()
-        //    .Where(x => !x.Abstract)
-        //    .Select(x => x.ID).ToList();
+
+        var allReagents = _prototypeManager.EnumeratePrototypes<ReagentPrototype>()
+            .Where(x => !x.Abstract)
+            .Select(x => x.ID).ToList();
 
         var amount = 20 + _random.Next(1, 30) + _glimmerSystem.Glimmer / 10f;
         amount = (float) Math.Round(amount);
@@ -219,7 +219,7 @@ public sealed class OracleSystem : EntitySystem
         var reagent = "";
 
         if (_random.Prob(0.2f))
-            reagent = _random.Pick(component.RewardReagents); //Euphoria - no chance at romerol. I know Mnemo, this is a terrible way to solve this, but I am tired
+            reagent = _random.Pick(allReagents);
         else
             reagent = _random.Pick(component.RewardReagents);
 

--- a/Resources/Prototypes/_DV/Entities/Effects/puddles.yml
+++ b/Resources/Prototypes/_DV/Entities/Effects/puddles.yml
@@ -111,7 +111,7 @@
     - UnstableMutagen
     - MindbreakerToxin
     - Histamine
-    - Romerol
+    #- Romerol #Euphoria, no zombies
     - SalicylicAcid
 
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Furniture/toilet.yml
@@ -86,7 +86,7 @@
     - Cognizine
     - Nocturine
     - UnstableMutagen
-    - Romerol
+    #- Romerol #Euphoria, no zombs
     # Blood
     - Blood
     - Slime

--- a/Resources/ServerInfo/Guidebook/_Floof/ServerRules/CoreRules/RuleC7DeathandNewLife.xml
+++ b/Resources/ServerInfo/Guidebook/_Floof/ServerRules/CoreRules/RuleC7DeathandNewLife.xml
@@ -1,13 +1,11 @@
 <Document>
   [color=#ffff00][head=3]Section 7: Death and New Life[/head][/color]
 
-  [color=#a4885c]7.1[/color] Characters maintain all memory up until death.
+  [color=#a4885c]7.1[/color] Upon death, characters lose all memories five minutes prior to dying.
 
-  [color=#a4885c]7.2[/color] Upon death, characters lose all memories five minutes prior to dying.
+  [color=#a4885c]7.2[/color] Characters’ perception during a critical state is impaired (no distinct names, faces, objects, locations).
 
-  [color=#a4885c]7.3[/color] Characters’ perception during a critical state is impaired (no distinct names, faces, objects, locations).
+  [color=#a4885c]7.3[/color] If a player is brought back to life by means of cloning, they lose all the memories that have been acquired so far into shift.
 
-  [color=#a4885c]7.4[/color] If a player is brought back to life by means of cloning, they lose all the memories that have been acquired so far into shift.
-
-  [color=#a4885c]7.5[/color] If your character dies or enters cryostasis beyond the point of no return, you normally cannot respawn as the same character. Seek permission from an admin if you need or wish to do so.
+  [color=#a4885c]7.4[/color] If your character dies or enters cryostasis beyond the point of no return, you normally cannot respawn as the same character. Seek permission from an admin if you need or wish to do so.
 </Document>


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Removed rule 7.1 as it was left in by accident, and remove random spawns of romerol. This also includes preventing ANY reagent from generating with the oracle.

## Why / Balance
Romerol is counter against the kind of gameplay we have here.

## Technical details
Its bad. I remove the allReagents filter and replace it with "RewardReagents". It essentially means you always get a reward reagent.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- remove: Romerol is no longer a fill option for random toilets and puddle spawns.
- remove: Removed rule 7.1. It was left in by accident, having meant to be replaced by 7.2
