### PR TITLE
Oracle can no longer select Romerol

### DIFF
--- a/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
+++ b/Content.Server/Nyanotrasen/Research/Oracle/OracleSystem.cs
@@ -209,7 +209,7 @@ public sealed class OracleSystem : EntitySystem
             return;
 
         var allReagents = _prototypeManager.EnumeratePrototypes<ReagentPrototype>()
-            .Where(x => !x.Abstract)
+            .Where(x => !x.Abstract && x.ID != "Romerol") //Euphoria - We can't have Romerol be a possibility
             .Select(x => x.ID).ToList();
 
         var amount = 20 + _random.Next(1, 30) + _glimmerSystem.Glimmer / 10f;


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Makes the Oracle's ability to generate random reagents no longer able to generate Romerol specifically.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Can't have Romerol.

But specifically, I was told by someone that they didn't like the quick and dirty fix that's going to be done, because it doesn't allow the Oracle to generate any chemicals but those in `RewardReagents`, so no vodka or watermelon juice or such. So here's a different quick and dirty fix to consider as an alternative to that. It might be better, it might be worse. Y'all can be the judge.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
It's a very simple and stupid change. It adds an additional requirement to the pattern-matching statement feeding into `allReagents` telling it not to select prototypes with the ID "Romerol". I checked the resulting list and it seems to work, and I think with how pattern matching works and how often it happens, the performance impact of the additional check should be negligible. That's just a guess, though.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
I do not believe this could break anything.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Oracle can no longer dispense Romerol.
