### PR TITLE
Mantis Loadout Fixes

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
@@ -23,8 +23,8 @@
         # - id: ClothingHandsGlovesForensic # Deltav - Detective is in charge of investigating crimes.
         - id: ClothingHeadHatFezMantis
         # - id: ClothingOuterCoatMantis
-        - id: ClothingOuterWinterCoatMantis # Euphoria - Uncommented
-        - id: ClothingEyesGlassesSunglasses
+        - id: ClothingOuterWinterCoatMantis
+        - id: ClothingEyesGlassesSunglasses # Euphoria - Uncommented
         - id: PillMindbreakerToxin # DeltaV - non-loadout mindbreaker available
           amount: 2
         # Insulative headgear

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
@@ -24,7 +24,7 @@
         - id: ClothingHeadHatFezMantis
         # - id: ClothingOuterCoatMantis
         - id: ClothingOuterWinterCoatMantis
-        # - id: ClothingEyesGlassesSunglasses
+        - id: ClothingEyesGlassesSunglasses
         - id: PillMindbreakerToxin # DeltaV - non-loadout mindbreaker available
           amount: 2
         # Insulative headgear

--- a/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
+++ b/Resources/Prototypes/Nyanotrasen/Catalog/Fills/Lockers/epistemics.yml
@@ -23,7 +23,7 @@
         # - id: ClothingHandsGlovesForensic # Deltav - Detective is in charge of investigating crimes.
         - id: ClothingHeadHatFezMantis
         # - id: ClothingOuterCoatMantis
-        - id: ClothingOuterWinterCoatMantis
+        - id: ClothingOuterWinterCoatMantis # Euphoria - Uncommented
         - id: ClothingEyesGlassesSunglasses
         - id: PillMindbreakerToxin # DeltaV - non-loadout mindbreaker available
           amount: 2

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -18,7 +18,7 @@
   groups:
   - GroupTankHarness
   - MantisHead
-  - Glasses # Euphoria
+  - MantisGlasses # Euphoria
   - ScientistNeck # Euphoria
   - MantisJumpsuit
   - ScientistBackpack

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -18,6 +18,7 @@
   groups:
   - GroupTankHarness
   - MantisHead
+  - Glasses # Euphoria
   - ScientistNeck # Euphoria
   - MantisJumpsuit
   - ScientistBackpack

--- a/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/Nyanotrasen/Loadouts/role_loadouts.yml
@@ -18,7 +18,7 @@
   groups:
   - GroupTankHarness
   - MantisHead
-  - MantisGlasses # Euphoria
+  - Glasses # Euphoria
   - ScientistNeck # Euphoria
   - MantisJumpsuit
   - ScientistBackpack

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -27,8 +27,8 @@
 - type: startingGear
   id: ForensicMantisGear
   equipment:
-#    id: PsionicMantisPDA
-#    eyes: ClothingEyesGlassesSunglasses
+#    id: PsionicMantisPDA # Euphoria - Commented out
+#    eyes: ClothingEyesGlassesSunglasses # Euphoria - Commented out
     ears: ClothingHeadsetScience # DeltaV - Mantis is part of Epistemics
     belt: ClothingBeltMantis
   storage:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -28,7 +28,7 @@
   id: ForensicMantisGear
   equipment:
     id: PsionicMantisPDA
-    eyes: ClothingEyesGlassesSunglasses
+#    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetScience # DeltaV - Mantis is part of Epistemics
     belt: ClothingBeltMantis
   storage:
@@ -44,7 +44,7 @@
   job: ForensicMantis
   equipment:
     id: PsionicMantisPDA
-#    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetScience
     belt: ClothingBeltMantis
     head: ClothingHeadHatFezMantis

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -28,7 +28,7 @@
   id: ForensicMantisGear
   equipment:
     id: PsionicMantisPDA
-    eyes: ClothingEyesGlassesSunglasses
+#    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetScience # DeltaV - Mantis is part of Epistemics
     belt: ClothingBeltMantis
   storage:

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -27,7 +27,7 @@
 - type: startingGear
   id: ForensicMantisGear
   equipment:
-    id: PsionicMantisPDA
+#    id: PsionicMantisPDA
 #    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetScience # DeltaV - Mantis is part of Epistemics
     belt: ClothingBeltMantis

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -44,7 +44,7 @@
   job: ForensicMantis
   equipment:
     id: PsionicMantisPDA
-    eyes: ClothingEyesGlassesSunglasses
+#    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetScience
     belt: ClothingBeltMantis
     head: ClothingHeadHatFezMantis

--- a/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
+++ b/Resources/Prototypes/Nyanotrasen/Roles/Jobs/Epistemics/forensicmantis.yml
@@ -28,7 +28,7 @@
   id: ForensicMantisGear
   equipment:
     id: PsionicMantisPDA
-#    eyes: ClothingEyesGlassesSunglasses
+    eyes: ClothingEyesGlassesSunglasses
     ears: ClothingHeadsetScience # DeltaV - Mantis is part of Epistemics
     belt: ClothingBeltMantis
   storage:

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
@@ -91,7 +91,7 @@
   minLimit: 0
   maxLimit: 1
   loadouts:
-  - ClothingUniformMantisEpiThong
+  - UniformMantisEpiThong
 
 - type: loadoutGroup
   id: FloofSocksMantis

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
@@ -100,14 +100,6 @@
   maxLimit: 1
   loadouts:
   - ClothingUnderSocksMantisEpi
-
-- type: loadoutGroup
-  id: MantisGlasses
-  parent: [Glasses]
-  minLimit: 0
-  maxLimit: 1
-  loadouts:
-  - ClothingEyesGlassesSunglasses
 # ======================================================== #
 # chaplain additions
 - type: loadoutGroup

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
@@ -100,6 +100,14 @@
   maxLimit: 1
   loadouts:
   - ClothingUnderSocksMantisEpi
+
+- type: loadoutGroup
+  id: MantisGlasses
+  parent: [Glasses]
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+  - ClothingEyesGlassesSunglasses
 # ======================================================== #
 # chaplain additions
 - type: loadoutGroup

--- a/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Groups/epistemics.yml
@@ -91,11 +91,11 @@
   minLimit: 0
   maxLimit: 1
   loadouts:
-  - UniformChaplainThong
+  - ClothingUniformMantisEpiThong
 
 - type: loadoutGroup
   id: FloofSocksMantis
-  parent: [FloofUndergarmentBottomScientist]
+  parent: [FloofSocksScientist]
   minLimit: 0
   maxLimit: 1
   loadouts:

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Science/mantis.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Science/mantis.yml
@@ -33,8 +33,3 @@
   equipment:
     undergarmentSocks: ClothingUnderSocksMantisEpi
 
-# glasses
-- type: loadout
-  id: ClothingEyesGlassesSunglasses
-  equipment:
-    undergarmentSocks: ClothingEyesGlassesSunglasses

--- a/Resources/Prototypes/_Floof/Loadouts/Jobs/Science/mantis.yml
+++ b/Resources/Prototypes/_Floof/Loadouts/Jobs/Science/mantis.yml
@@ -33,3 +33,8 @@
   equipment:
     undergarmentSocks: ClothingUnderSocksMantisEpi
 
+# glasses
+- type: loadout
+  id: ClothingEyesGlassesSunglasses
+  equipment:
+    undergarmentSocks: ClothingEyesGlassesSunglasses


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Mantis given glasses and socks loadout options, fixed error that resulted in Mantis always spawning with two PDAs.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Just bugfixes, mantis keeps sunglasses but they now spawn in their locker.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Just YML changes.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Mantis loadout now has glasses and socks.
- fix: Mantis no longer spawns with two PDAs.
