### PR TITLE
Temporarily Disabled the Dog Accent

### DIFF
--- a/Resources/Prototypes/_Floof/Traits/speech.yml
+++ b/Resources/Prototypes/_Floof/Traits/speech.yml
@@ -1,6 +1,6 @@
 ## If you add a new trait, make sure to add the corresponding component to the whitelist in \Resources\Prototypes\Entities\Mobs\Player\clone.yml so it gets copied to clones correctly!
 
-- type: trait
+- #type: trait # Euphoria - Disabled accent due to racism issues related to East Adian bigotry, we don't know how to change the accent itself yet.
   id: DogAccent
   name: trait-dog-accent-name
   description: trait-dog-accent-desc


### PR DESCRIPTION
## About the PR
Commented out the Dog Accent due to discussions in https://discord.com/channels/1255902263667331193/1536272628682203206/1536272628682203206 until somebody smarter than we are rewrites the accent.

## Why / Balance
The thread talks about a lot of issues with the accent being racist against eastern asian people, being similar to the "engrish" harmful stereotype.

## Technical details
Commented it out in speech.yml, when the accent gets fixed the pound symbol can be removed to re-add the accent.

## Media
<img width="531" height="587" alt="image" src="https://github.com/user-attachments/assets/6276a47e-8b00-4020-a416-cb06fc797f0c" />
<img width="535" height="595" alt="image" src="https://github.com/user-attachments/assets/e27cb5f1-7f39-4d02-8cad-cb412b2d5e33" />
<img width="511" height="333" alt="image" src="https://github.com/user-attachments/assets/45fb136a-3a4a-4ea1-adf4-9bf39fbcd882" />


<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
It's giving us an error, which we probably messed something up, but the server and client launch just fine. The Error maybe won't matter if the accent gets fixed within the next month? But also, scary red text.
**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- remove: Dog Accent has been temporarily disabled due to harmful stereotypes. It will be re-enabled when fixed.
