### PR TITLE
Nuero target list

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -256,24 +256,11 @@
     - RoboNeuroticistPlutoniumCoreStealObjective
     - RoboNeuroticistUploadAILawObjective
     - RoboNeuroticistKillObjective #Euphoria | Giving a mass amount of targets to list everyone that qualifies on station
-    - RoboNeuroticistKillObjective #This objective is assigned 20 times as that will realistically catch everyone
-    - RoboNeuroticistKillObjective #that has opted into the conditions to be a target for the neuro. This means that
-    - RoboNeuroticistKillObjective #every nuero has a handy list of EVERYONE who is a valid target, and thus knows
-    - RoboNeuroticistKillObjective #who not to gib or RR in an attempt to borg them. This is being done this way
-    - RoboNeuroticistKillObjective #as it will minimally affect code that comes in from upstream.
     - RoboNeuroticistKillObjective
     - RoboNeuroticistKillObjective
     - RoboNeuroticistKillObjective
     - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
-    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective #Euphoria | End
   - type: AntagSelection
     agentName: roboneuroticist-round-end-agent-name
     definitions:

--- a/Resources/Prototypes/_DV/GameRules/events.yml
+++ b/Resources/Prototypes/_DV/GameRules/events.yml
@@ -242,6 +242,7 @@
     reoccurrenceDelay: 30
     duration: null # so it shows up in round end
     maxOccurrences: 1
+    earliestStart: 30 # Euphoria | No showing up round start
   - type: RuleGrids
   - type: LoadMapRule
     gridPath: /Maps/_DV/Shuttles/Event/haibu.yml # was /Maps/_DV/Shuttles/Admin/roboneuroticist_ship.yml
@@ -250,10 +251,29 @@
   - type: AntagObjectives
     objectives:
     - RoboNeuroticistSurviveObjective
-    - RoboNeuroticistBorgObjective
+    #- RoboNeuroticistBorgObjective #Euphoria | No borging random crew
     - RoboNeuroticistKillObjective
     - RoboNeuroticistPlutoniumCoreStealObjective
     - RoboNeuroticistUploadAILawObjective
+    - RoboNeuroticistKillObjective #Euphoria | Giving a mass amount of targets to list everyone that qualifies on station
+    - RoboNeuroticistKillObjective #This objective is assigned 20 times as that will realistically catch everyone
+    - RoboNeuroticistKillObjective #that has opted into the conditions to be a target for the neuro. This means that
+    - RoboNeuroticistKillObjective #every nuero has a handy list of EVERYONE who is a valid target, and thus knows
+    - RoboNeuroticistKillObjective #who not to gib or RR in an attempt to borg them. This is being done this way
+    - RoboNeuroticistKillObjective #as it will minimally affect code that comes in from upstream.
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
+    - RoboNeuroticistKillObjective
   - type: AntagSelection
     agentName: roboneuroticist-round-end-agent-name
     definitions:

--- a/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
+++ b/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
@@ -35,7 +35,8 @@
   parent: [ BaseRoboNeuroticistObjective, BaseKillObjective ]
   id: RoboNeuroticistKillObjective
   name: Condemn them to Metal
-  description: Your dossier indicates that there is one very appealing neural pattern on the crew. Turn them into a Cyborg.
+  #description: Your dossier indicates that there is one very appealing neural pattern on the crew. Turn them into a Cyborg. #Euphoria
+  description: Your dossier indicates that there is a very appealing neural pattern on the crew. Turn them into a Cyborg. #Euphoria
   components:
   - type: Objective
     unique: true
@@ -49,7 +50,8 @@
     - !type:BodyMindFilter
       whitelist:
         components:
-        - CommandStaff
+        - Unborgable # Euphoria | Nuero gets a list of valid targets
+      inverted: true # Euphoria
     - !type:ObjectiveImmuneFilter
     # Euphoria - Make RR objective targets opt in only
     - !type:MarkedMindFilter

--- a/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
+++ b/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
@@ -39,7 +39,7 @@
   description: Your dossier indicates that there is a very appealing neural pattern on the crew. Turn them into a Cyborg. #Euphoria
   components:
   - type: Objective
-    unique: true
+    unique: false # Euphoria | Changed to be non-unique
     icon:
       sprite: Objects/Weapons/Guns/Pistols/viper.rsi
       state: icon
@@ -56,6 +56,11 @@
     # Euphoria - Make RR objective targets opt in only
     - !type:MarkedMindFilter
       objType: Remove
+    # Euphoria - Can't have multiple objectives to kill the same person.
+    - !type:TargetObjectiveMindFilter
+      blacklist:
+        components:
+        - KillPersonCondition
   - type: KillPersonCondition
     requireDead: true
 

--- a/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
+++ b/Resources/Prototypes/_DV/Objectives/roboneuroticist.yml
@@ -35,8 +35,7 @@
   parent: [ BaseRoboNeuroticistObjective, BaseKillObjective ]
   id: RoboNeuroticistKillObjective
   name: Condemn them to Metal
-  #description: Your dossier indicates that there is one very appealing neural pattern on the crew. Turn them into a Cyborg. #Euphoria
-  description: Your dossier indicates that there is a very appealing neural pattern on the crew. Turn them into a Cyborg. #Euphoria
+  description: Your dossier indicates that there is a very appealing neural pattern on the crew. Turn them into a Cyborg. # Euphoria - rob-neuroticist can have multiple targets
   components:
   - type: Objective
     unique: false # Euphoria | Changed to be non-unique


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
This PR alters the objectives and target selection of the robo-nuero. The borg everyone objective is removed. The borg a specific person objective has had its filtering changed to grab only people that have Marked for Removal AND do not have Machine Incompatible. They are given this objective twenty times to build a list of, most likely, every eligible target for borging.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This role causes consent issues around borging and round removal every time it is played. The objectives are re-aligned to fit expectations.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
YML changes.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
I had media. I had my scenarios typed out and included a picture of the antag summary screen for each one. Unfortunately my computer couldn't take everything I was doing at once and I lost the browser along with all information I'd already set up for this PR.

Scenarios tested that I had pictures for:
- 3 crew. One with Unborgable and Removal. One with Removal. One with Kill. It correctly assigned to the one with just Removal across multiple tests.
- 2 crew. Both with Removal. No Unborgable. Correctly assigned each crew as a target once across multiple tests.

I do not have the time or fortitude at this point to reload up four clients and a server to recreate these pictures.
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [See Media Section] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
Not a break, but a possible expansion for the future would be setting up a new BorgTargetCondition so traitor kill objectives don't effect the targeting on this objective.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- remove: Robo-neuro will no longer be told to borg everyone.
- tweak: Robo-neuro will receive objectives for all eligible targets for borging.