### PR TITLE
Fix For Certain Ghost Roles Spawning Without Proper Names

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -52,9 +52,7 @@
         - Syndicate
       mindRoles:
       - MindRoleRecruiter
-  - type: AntagLoadProfileRule #Euphoria | Using this for spawning antag instead of AntagSpawner
-    speciesOverride: Human
-    speciesOverrideBlacklist: 
+  - type: AntagLoadPlayerCharacterRule #Euphoria | Using this for spawning antag instead of AntagSpawner
 
 - type: entity
   parent: BaseUnknownShuttleRule
@@ -99,9 +97,7 @@
         - Syndicate
       mindRoles:
       - MindRoleSynthesis
-  - type: AntagLoadProfileRule #Euphoria | Using this for spawning antag instead of AntagSpawner
-    speciesOverride: Human
-    speciesOverrideBlacklist: 
+  - type: AntagLoadPlayerCharacterRule #Euphoria | Using this for spawning antag instead of AntagSpawner
 
 - type: entity
   parent: BaseUnknownShuttleRule
@@ -146,9 +142,7 @@
         - Syndicate
       mindRoles:
       - MindRoleArmsdealer
-  - type: AntagLoadProfileRule #Euphoria | Using this for spawning antag instead of AntagSpawner
-    speciesOverride: Human
-    speciesOverrideBlacklist: 
+  - type: AntagLoadPlayerCharacterRule #Euphoria | Using this for spawning antag instead of AntagSpawner
 
 # Hitman (for the admeme spawn)
 - type: entity
@@ -195,6 +189,4 @@
       #  randomizeName: false
       mindRoles:
       - MindRoleHitman
-  - type: AntagLoadProfileRule #Euphoria | Using this for spawning antag instead of AntagSpawner
-    speciesOverride: Human
-    speciesOverrideBlacklist: 
+  - type: AntagLoadPlayerCharacterRule #Euphoria | Using this for spawning antag instead of AntagSpawner


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Hitman (ghost role), Synthesis Specialist, Syndicate Arms Dealer, and Syndicate Recruiter were changed to no longer be force to be random humans. The method used to change them also made it so they didn't get traits, and used default Urist names. 
This PR changes their spawn method. They now have proper names, and @deltaSpawn0040 said they're working on changing the spawn method so they get traits too. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ghost roles were spawning with names like Urist McTajaran. This is suboptimal. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Yml changes. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="698" height="558" alt="image" src="https://github.com/user-attachments/assets/adac541a-13e6-4b7d-b5e6-f47991c09559" />

<img width="713" height="610" alt="image" src="https://github.com/user-attachments/assets/2cd96b15-5b1a-45d8-802f-58ab22bf8abf" />

<img width="813" height="658" alt="image" src="https://github.com/user-attachments/assets/b90534db-0f42-4edf-9f36-0beff68c48cf" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Fixed Hitman (ghost role), Synthesis Specialist, Syndicate Arms Dealer, and Syndicate Recruiter spawning with default Urist names.
