### PR TITLE
Improvements/fixes for Civil Antag code and Food Critic prototypes.

### DIFF
--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Server.GameTicking.Rules;
 
 /// <summary>
 /// System that responds to AntagSelectEntityEvent, gets the player's currently selected character, spawns
-/// it in the same way regular players are spawned, and sets args.Entity to the result. This is dinstinct functionality from 
+/// it in the same way regular players are spawned, and sets args.Entity to the result. This is dinstinct functionality from
 /// <see cref="AntagLoadProfileRuleSystem"/> in that while that system gets the appearance of the player's character,
 /// this one is for when you want the whole character, name, traits, and all.
 /// </summary>
@@ -27,26 +27,26 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
 
     private void OnSelectEntity(Entity<AntagLoadPlayerCharacterRuleComponent> ent, ref AntagSelectEntityEvent args)
     {
-        if (args.Handled) //If something already handled this, don't handle it! 
+        if (args.Handled) //If something already handled this, don't handle it!
             return;
 
-	//Get the player's selected character or, if the session is null, whatever the fuck.
-	var character = args.Session != null
-	    ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
-	    : HumanoidCharacterProfile.RandomWithSpecies();
+        //Get the player's selected character or, if the session is null, whatever the fuck.
+        var character = args.Session != null
+            ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
+            : HumanoidCharacterProfile.RandomWithSpecies();
 
-	//Spawn it like it was a player
-	//It seems this function technically spawns the entity somewhere first,
-	//but the only purpose of this system is to hand over an entity to
-	//AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
-	var spawnedCharacter = _ent.System<StationSpawningSystem>()
-	    .SpawnPlayerMob(Transform(ent.Owner).Coordinates, null, character, null);
-	
+        //Spawn it like it was a player
+        //It seems this function technically spawns the entity somewhere first,
+        //but the only purpose of this system is to hand over an entity to
+        //AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
+        var spawnedCharacter = _ent.System<StationSpawningSystem>()
+            .SpawnPlayerMob(Transform(ent.Owner).Coordinates, null, character, null);
+
         //Create and raise this event so the character is given their traits
         var spawnedEvent = new GhostRoleSpawnerUsedEvent(ent.Owner, spawnedCharacter, character, args.Session);
         RaiseLocalEvent(spawnedCharacter, spawnedEvent, true);
 
-	//Finally, hand over the player's character to the event raiser 
-	args.Entity = spawnedCharacter;
+        //Finally, hand over the player's character to the event raiser
+        args.Entity = spawnedCharacter;
     }
 }

--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Preferences.Managers;
 using Content.Shared.Preferences;
 using Content.Server.Station.Systems;
+using Content.Server.Ghost.Roles.Events;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -28,9 +29,6 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
     {
         if (args.Handled) //If something already handled this, don't handle it! 
             return;
-	    
-	var uid = ent.Owner;
-
 
 	//Get the player's selected character or, if the session is null, whatever the fuck.
 	var character = args.Session != null
@@ -41,7 +39,14 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
 	//It seems this function technically spawns the entity somewhere first,
 	//but the only purpose of this system is to hand over an entity to
 	//AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
-	args.Entity = _ent.System<StationSpawningSystem>()
-	    .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
+	var spawnedCharacter = _ent.System<StationSpawningSystem>()
+	    .SpawnPlayerMob(Transform(ent.Owner).Coordinates, null, character, null);
+	
+        //Create and raise this event so the character is given their traits
+        var spawnedEvent = new GhostRoleSpawnerUsedEvent(ent.Owner, spawnedCharacter, character, args.Session);
+        RaiseLocalEvent(spawnedCharacter, spawnedEvent, true);
+
+	//Finally, hand over the player's character to the event raiser 
+	args.Entity = spawnedCharacter;
     }
 }

--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -1,19 +1,13 @@
 using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
-using Content.Server.Humanoid;
 using Content.Server.Preferences.Managers;
-using Content.Shared.Humanoid;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
-using Robust.Shared.Prototypes;
 using Content.Server.Station.Systems;
 
 namespace Content.Server.GameTicking.Rules;
 
 public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoadPlayerCharacterRuleComponent>
 {
-    [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IServerPreferencesManager _prefs = default!;
     [Dependency] private readonly IEntityManager _ent = default!;
 
@@ -29,17 +23,19 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
         if (args.Handled) //If something already handled this, don't handle it! 
             return;
 	    
-        var uid = ent.Owner;
-        var component = ent.Comp;
-        
-        //Get the player's selected character or, if the session is null, whatever the fuck.
-        var character = args.Session != null
-            ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
-            : HumanoidCharacterProfile.RandomWithSpecies();
+	var uid = ent.Owner;
 
-        //Spawn it like it was a player
-        //Where does this spawn it at first? Hell if I know. It ends up where it's supposed to be anyways.
-        args.Entity = _ent.System<StationSpawningSystem>()
-            .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
+
+	//Get the player's selected character or, if the session is null, whatever the fuck.
+	var character = args.Session != null
+	    ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
+	    : HumanoidCharacterProfile.RandomWithSpecies();
+
+	//Spawn it like it was a player
+	//It seems this function technically spawns the entity somewhere first,
+	//but the only purpose of this system is to hand over an entity to
+	//AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
+	args.Entity = _ent.System<StationSpawningSystem>()
+	    .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
     }
 }

--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -6,6 +6,12 @@ using Content.Server.Station.Systems;
 
 namespace Content.Server.GameTicking.Rules;
 
+/// <summary>
+/// System that responds to AntagSelectEntityEvent, gets the player's currently selected character, spawns
+/// it in the same way regular players are spawned, and sets args.Entity to the result. This is dinstinct functionality from 
+/// <see cref="AntagLoadProfileRuleSystem"/> in that while that system gets the appearance of the player's character,
+/// this one is for when you want the whole character, name, traits, and all.
+/// </summary>
 public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoadPlayerCharacterRuleComponent>
 {
     [Dependency] private readonly IServerPreferencesManager _prefs = default!;

--- a/Resources/Locale/en-US/_Floof/mind/role-types.ftl
+++ b/Resources/Locale/en-US/_Floof/mind/role-types.ftl
@@ -1,0 +1,3 @@
+role-type-generic-employee-name = Employee: Non-Station
+role-type-donkco-employee-name = Employee: Donk Co!
+role-type-solarian-allience-employee-name = Employee: Solarian Alliance

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -26,7 +26,7 @@
     - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
-    - id: AntagFoodCriticSpawn # Euphoria - Dunno where exactly to put this so it's here for now, this wasn't a thought-out decision to put it here specifically so if you feel like it should be somewhere else, be my guest.
+    - id: FoodCriticSpawn # Euphoria - Dunno where exactly to put this so it's here for now, this wasn't a thought-out decision to put it here specifically so if you feel like it should be somewhere else, be my guest.
 
 - type: entityTable
   id: BasicAntagEventsTable

--- a/Resources/Prototypes/_Floof/Gamerules/events.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/events.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   parent: BaseGameRule
-  id: AntagFoodCriticSpawn
+  id: FoodCriticSpawn
   components:
   - type: StationEvent
     weight: 8
@@ -20,7 +20,7 @@
   - type: AntagSelection
     agentName: food-critic-round-end-agent-name
     definitions:
-    - spawnerPrototype: SpawnPointGhostAntagFoodCritic
+    - spawnerPrototype: SpawnPointFoodCritic
       min: 1
       max: 1
       pickPlayer: false

--- a/Resources/Prototypes/_Floof/Gamerules/events.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/events.yml
@@ -25,8 +25,8 @@
       max: 1
       pickPlayer: false
       startingGear: FoodCriticGear
-      #roleLoadout:
-      #- RoleSurvivalSpaceNinja
+      roleLoadout:
+      - RoleSurvivalStandard
       briefing:
         text: food-critic-role-greeting
         color: Lime

--- a/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
+++ b/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
@@ -60,7 +60,7 @@
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
   parent: BaseAntagSpawner
-  id: SpawnPointGhostAntagFoodCritic
+  id: SpawnPointFoodCritic
   components:
   - type: GhostRole
     name: ghost-role-information-food-critic-name

--- a/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
+++ b/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
@@ -35,6 +35,7 @@
   - type: MindRole
     antagPrototype: FoodCriticAntagPrototype
     subtype: role-subtype-food-critic
+    roleType: EmployeeDonkco
     #exclusiveAntag: true #Uncommenting this breaks everything as of July 2nd 2026
   - type: FoodCriticRole
 

--- a/Resources/Prototypes/_Floof/Roles/role_types.yml
+++ b/Resources/Prototypes/_Floof/Roles/role_types.yml
@@ -1,0 +1,5 @@
+- type: roleType
+  id: EmployeeDonkco
+  name: role-type-donkco-employee-name
+  color: '#ffff00'
+  symbol: "D"


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
This is a bundle of improvements to the content in [my last Civil Antag/Food Critic PR](https://github.com/Floof-Station/Panta-Rhei/pull/900). Here's a summary of the fixes:

In-game:
- Using `AntagLoadPlayerCharacterRule` now gives the player's character their selected traits. (More in the Technical details section)
- The Food Critic's character menu now says that they are an employee of Donk Co! instead of a scary Solo Antagonist. 
- Vox Food Critics will now spawn with the proper Nitrogen gear. This was unfortunately omitted at first.

Technical:
- Changed the IDs of several Food-Critic-related prototypes to not include the word "antag", as that was just in there to differentiate those prototypes from the ones that were for the old regular Food Critic ghost role, which no longer exist.
- More detailed comments and a summary added to `AntagLoadPlayerCharacterRule`
- Unneeded dependencies removed from `AntagLoadPlayerCharacterRule`


## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Whether `AntagLoadPlayerCharacterRule` gave characters their traits was overlooked when I made that system. I thought the normal spawning behavior would do it, but it actually needed either `OnPlayerSpawnComplete` or `OnGhostRoleSpawnerUsed` to be raised. So, I changed `AntagLoadPlayerCharacterRule` to raise the latter before ending.

Significant amount of thanks to @kivdon for finding out it didn't apply people's traits this morning. I would not have given it a second thought if not for them.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Chronic pain is now the right of all Food Critics.
<img width="2253" height="1450" alt="image" src="https://github.com/user-attachments/assets/6f6eeb68-78d8-46c1-a07d-352c8712ee5d" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
This shouldn't break anything.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Various Food Critic improvements.
