### PR TITLE
Make Pens Embbed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/pen.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/pen.yml
@@ -40,6 +40,14 @@
         - ItemMask
         restitution: 0.3
         friction: 0.2
+  # Euphoria additions
+  - type: EmbeddableProjectile
+    offset: 0.3,0.0
+    removalTime: 1.0
+    sound: /Audio/Weapons/punch3.ogg # funny sound
+  - type: ThrowingAngle
+    angle: 315
+  - type: LandAtCursor
 
 - type: entity
   parent: Pen


### PR DESCRIPTION
## About the PR
We used to have it so when you threw a pen at something it would embbed and we lost that with the rebase so i added it back.

## Why / Balance
It makes me laugh a lot and i miss it.

## Technical details
adds a few comps to the pen base.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Pens can be thrown at people again and get stuck in them.
