### PR TITLE
Arachne and Resomi get Survival Boxes

### DIFF
--- a/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
+++ b/Resources/Prototypes/Loadouts/Miscellaneous/survival.yml
@@ -29,8 +29,12 @@
     - Kitsune
     - Avali
     # End DeltaV additions
-    - Shadowkin #floof - specific survival box seems unneeeded
-    - Tajaran #floof
+    # Euphoria additions begin
+    - Shadowkin # specific survival box seems unneeeded
+    - Tajaran
+    - Arachne
+    - Resomi
+    # Euphoria additions end
 
 - type: loadoutEffectGroup
   id: EffectSpeciesVox


### PR DESCRIPTION
## About the PR
Resomi and Arachne both did not start with survival boxes.

## Why / Balance
Every other species gets one including shadowkins so we needed to fix this

## Technical details
Yamly.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Arachne and Resomi should now start with survival boxes.
