### PR TITLE
Allow Sec to Purchase More Weapons

### DIFF
--- a/Resources/Prototypes/_Euphoria/Catalog/Cargo/armory.yml
+++ b/Resources/Prototypes/_Euphoria/Catalog/Cargo/armory.yml
@@ -1,0 +1,19 @@
+﻿- type: cargoProduct
+  id: ArmoryVulcan
+  icon:
+    sprite: _DV/Objects/Weapons/Guns/Rifles/vulcan.rsi
+    state: icon
+  product: CrateArmoryVulcan
+  cost: 17500
+  category: cargoproduct-category-name-armory
+  group: market
+
+- type: cargoProduct
+  id: ArmorySubMachineGunPatos
+  icon:
+    sprite: _DV/Objects/Weapons/Guns/SMGs/patos.rsi
+    state: icon
+  product: CrateArmoryPatos
+  cost: 9000
+  category: cargoproduct-category-name-armory
+  group: market

--- a/Resources/Prototypes/_Euphoria/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Euphoria/Catalog/Fills/Crates/armory.yml
@@ -1,0 +1,29 @@
+﻿- type: entity
+  parent: [ CrateWeaponSecure, BaseSecurityContraband ]
+  id: CrateArmoryVulcan
+  name: Vulcan crate
+  description: Contains two Vulcans with four mags. Requires Armory access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: WeaponRifleVulcan
+          amount: 2
+        - id: MagazineLightRifle
+          amount: 4
+
+- type: entity
+  parent: [ CrateWeaponSecure, BaseSecurityContraband ]
+  id: CrateArmoryPatos
+  name: Patos crate
+  description: Contains two Patos with four mags. Requires Armory access to open.
+  components:
+  - type: EntityTableContainerFill
+    containers:
+      entity_storage: !type:AllSelector
+        children:
+        - id: WeaponSubMachineGunPatos
+          amount: 2
+        - id: MagazinePistolHighCapacity
+          amount: 4


### PR DESCRIPTION
## About the PR
Saw a thread asking for the Vulcan and Patos to be buyable so sure why not, we need departments spending their funds anyway.

## Why / Balance
They were not buyable and have to be currently hard mapped, this will allow them to purchase the crates with out these needing to be mapped.

Prices are negotiable i just kinda did a little testing and thought yeah these match other weapons enough to set their prices they way i did.

## Technical details
The yaml warrior strikes again.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="608" height="820" alt="image" src="https://github.com/user-attachments/assets/bfd3ad3f-63f7-4124-b449-5ec40ae385ca" />
</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Security can now purchase Vulcan and Patos gun crates for the armory.