### PR TITLE
Mining Survival Voucher Includes Medical Tracking Implanter

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/mining_voucher.yml
+++ b/Resources/Prototypes/_DV/Catalog/mining_voucher.yml
@@ -45,6 +45,7 @@
   - ClothingBeltSalvageWebbing
   - ShelterCapsule
   - NFWeaponHoloflareGun
+  - MedicalTrackingImplanter
 
 # TODO: mining drone
 #- type: thiefBackpackSet

--- a/Resources/Prototypes/_DV/Catalog/mining_voucher.yml
+++ b/Resources/Prototypes/_DV/Catalog/mining_voucher.yml
@@ -45,7 +45,7 @@
   - ClothingBeltSalvageWebbing
   - ShelterCapsule
   - NFWeaponHoloflareGun
-  - MedicalTrackingImplanter
+  - MedicalTrackingImplanter #Euphoria | Description mentioned having this, but it wasn't actually included. It seems neat, so I included it. 
 
 # TODO: mining drone
 #- type: thiefBackpackSet


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
The "Survival" choice on the Mining Voucher now includes a medical tracking implanter.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The description of it mentions including a medical tracking implanter, but it did not. It now does. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
The unchanged description of this selection on the voucher:
<img width="753" height="97" alt="image" src="https://github.com/user-attachments/assets/0868cb12-88ca-4376-ae8b-5f02c780e0c5" />

<img width="481" height="55" alt="image" src="https://github.com/user-attachments/assets/e38cc7db-2a48-44de-9660-64042559b11f" />

The implanter was given:
<img width="530" height="789" alt="image" src="https://github.com/user-attachments/assets/4840ffbe-d2e3-4fdb-8605-2466073a5224" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Salvage's "Survival" selection on the mining voucher mentioned including a medical tracking implanter, but it did not. It now does.
