### PR TITLE
Increase Musician job slots 1->2

### DIFF
--- a/Resources/Prototypes/_Floof/Maps/amber.yml
+++ b/Resources/Prototypes/_Floof/Maps/amber.yml
@@ -89,7 +89,7 @@
           Passenger: [ -1, -1 ]
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
-          Musician: [ 1, 1 ]
+          Musician: [ 1, 2 ] # FloofStation, was 1, 1
           Reporter: [ 1, 1 ]
           #Anomaly: [ 4, 4 ] # Floofstation
           # #silicon

--- a/Resources/Prototypes/_Floof/Maps/arena.yml
+++ b/Resources/Prototypes/_Floof/Maps/arena.yml
@@ -70,7 +70,7 @@
             HeadOfPersonnel: [ 1, 1 ]
             Janitor: [ 2, 2 ]
             Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
             Reporter: [ 2, 2 ]
             ServiceWorker: [ 1, 3 ]
           #science

--- a/Resources/Prototypes/_Floof/Maps/asterisk.yml
+++ b/Resources/Prototypes/_Floof/Maps/asterisk.yml
@@ -39,7 +39,7 @@
             Chef: [ 1, 2 ]
             Clown: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
             Janitor: [ 1, 2 ]
             Mime: [ 1, 1 ]
           #engineering

--- a/Resources/Prototypes/_Floof/Maps/edge.yml
+++ b/Resources/Prototypes/_Floof/Maps/edge.yml
@@ -40,7 +40,7 @@
             Chef: [ 2, 3 ]
             Clown: [ 1, 1 ]
             Reporter: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
             Janitor: [ 2, 3 ]
             Mime: [ 1, 1 ]
           #engineering

--- a/Resources/Prototypes/_Floof/Maps/fland.yml
+++ b/Resources/Prototypes/_Floof/Maps/fland.yml
@@ -85,7 +85,7 @@
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
 #            Anomaly: [ 4, 4 ] # Floofstation
             # Justice added by FloofStation
             ChiefJustice: [ 1, 1 ] #FloofStation

--- a/Resources/Prototypes/_Floof/Maps/lighthouse.yml
+++ b/Resources/Prototypes/_Floof/Maps/lighthouse.yml
@@ -40,7 +40,7 @@
           Chef: [ 1, 2 ]
           Clown: [ 1, 1 ]
           Reporter: [ 0, 2 ]
-          Musician: [ 1, 1 ]
+          Musician: [ 1, 2 ] # FloofStation, was 1, 1
           Janitor: [ 1, 2 ]
           Mime: [ 1, 1 ]
         #engineering

--- a/Resources/Prototypes/_Floof/Maps/meta.yml
+++ b/Resources/Prototypes/_Floof/Maps/meta.yml
@@ -84,7 +84,7 @@
           Passenger: [ -1, -1 ]
           Clown: [ 1, 1 ]
           Mime: [ 1, 1 ]
-          Musician: [ 1, 1 ]
+          Musician: [ 1, 2 ] # FloofStation, was 1, 1
 #          Anomaly: [ 4, 4 ] # Floofstation
           # Silicon
           StationAi: [ 1, 1 ] #Floofstation - uncomment when we want enabled

--- a/Resources/Prototypes/_Floof/Maps/pebble.yml
+++ b/Resources/Prototypes/_Floof/Maps/pebble.yml
@@ -37,7 +37,7 @@
             Boxer: [ 2, 2 ]
             Chef: [ 2 , 2 ]
             Clown: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
             Janitor: [ 1, 2 ]
             Mime: [ 1, 1 ]
           #engineering

--- a/Resources/Prototypes/_Floof/Maps/radstation.yml
+++ b/Resources/Prototypes/_Floof/Maps/radstation.yml
@@ -82,7 +82,7 @@
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
             Reporter: [ 2, 2 ]
             Psychologist: [ 1, 1 ]
             #justice

--- a/Resources/Prototypes/_Floof/Maps/shoukou.yml
+++ b/Resources/Prototypes/_Floof/Maps/shoukou.yml
@@ -41,7 +41,7 @@
           Chef: [ 1, 1 ]
           Clown: [ 1, 1 ]
           Janitor: [ 2, 2 ]
-          Musician: [ 1, 1]
+          Musician: [ 1, 2 ] # FloofStation, was 1, 1
           Mime: [ 1, 1 ]
           Captain: [ 1, 1 ]
           Librarian: [ 1, 1 ]

--- a/Resources/Prototypes/_Floof/Maps/train.yml
+++ b/Resources/Prototypes/_Floof/Maps/train.yml
@@ -83,7 +83,7 @@
             Passenger: [ -1, -1 ]
             Clown: [ 1, 1 ]
             Mime: [ 1, 1 ]
-            Musician: [ 1, 1 ]
+            Musician: [ 1, 2 ] # FloofStation, was 1, 1
             Reporter: [ 1, 1 ]
             #justice added by FloofStation
             ChiefJustice: [ 1, 1 ] #FloofStation


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Simple. Increases musician slots from 1 to 2.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Increases the chances for a musician to be in the musician spot instead of hijacking the role and go to dorms.
Also, people wanted to have more access to super synthetizers, this is another way.
**Unintended effects may include two musicians in one dorm room.**

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Changed 1's to 2's. YML only.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Increased Musician job slots from 1 to 2 in most stations.

