### PR TITLE
Make space cleaner evaporate

### DIFF
--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -42,6 +42,7 @@
   recognizable: true
   boilingPoint: 147.0 # Made this up, loosely based on bleach
   meltingPoint: -11.0
+  evaporationSpeed: 0.1 # Euph - make space cleaner slowly evaporate because otherwise it can only be mopped up
   tileReactions:
     - !type:CleanTileReaction {}
     - !type:CleanDecalsReaction {}


### PR DESCRIPTION
## About the PR
Puddles of space cleaner will continue to react violently with potassium while being unable to be removed by anything other than a mop. This PR fixes it.

**Changelog**
:cl:
- tweak: Puddles of space cleaner will now slowly evaporate.
