### PR TITLE
Bring Your Bag From Home

### DIFF
--- a/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/courierdrobe.yml
+++ b/Resources/Prototypes/_DV/Catalog/VendingMachines/Inventories/courierdrobe.yml
@@ -24,5 +24,4 @@
     ClothingOuterDevy: 2
     ClothingOuterExpressBuffCourierCoat: 2
     ClothingShoesCourierDevy: 2
-    ClothingBackpackDuffelCourierDevy: 2
     # Floofstation additions end


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Removes the Express Trunk from the CourierDrobe. The Trunk can now only be gotten by bringing it from Courier loadout.

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This extra big storage was added for Couriers to assist with things like moving large packages. How it ended up being used was as the go to bag for LOs and salvagers. The mail room and drobe were getting round start raided basically every shift.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
One line deletion from a Euphoria marked area.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
Did to the CourierDrobe what Mega Man X did to Flame Mammoth with the Boomerang Cutter:
<img width="421" height="920" alt="image" src="https://github.com/user-attachments/assets/7cee5360-4555-45fb-92c9-5ec64394cb56" />
Still here at least:
<img width="503" height="445" alt="image" src="https://github.com/user-attachments/assets/bcefa07c-a236-42c4-9e91-0901735f286d" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
N/A

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl: sprkl
- remove: Express Space Courier Trunk removed from CourierDrobe. Now only available in Courier loadout.