### PR TITLE
Fix RevealRevenantOnCollide copying fixture shapes by-ref

### DIFF
--- a/Content.Server/_Impstation/Revenant/EntitySystems/RevealRevenantOnCollideSystem.cs
+++ b/Content.Server/_Impstation/Revenant/EntitySystems/RevealRevenantOnCollideSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._Floof.HeightAdjust;
 using Content.Shared.Revenant.EntitySystems;
 using Content.Shared.Revenant.Components;
 using Content.Shared.Physics;
@@ -12,6 +13,7 @@ public sealed partial class RevealRevenantOnCollideSystem : SharedRevealRevenant
 {
     [Dependency] private readonly FixtureSystem _fixtures = default!;
     [Dependency] private readonly CollisionWakeSystem _collisionWake = default!;
+    [Dependency] private readonly FixtureHelperSystem _fixtureHelpers = default!; // Euph
 
     private const string FixtureId = "revenantReveal";
 
@@ -26,8 +28,9 @@ public sealed partial class RevealRevenantOnCollideSystem : SharedRevealRevenant
     private IPhysShape GetOrCreateShape(EntityUid uid, FixturesComponent? fixtures = null)
     {
         if (Resolve(uid, ref fixtures))
-            if (fixtures.Fixtures.TryGetValue("fix1", out var fix))
-                return fix.Shape;
+            // Euph - changed to explicit create a copy
+            if (fixtures.Fixtures.TryGetValue("fix1", out var fix) && _fixtureHelpers.TryCopyShape(fix.Shape, out var shapeCopy))
+                return shapeCopy;
 
         return new PhysShapeCircle(0.35f);
     }

--- a/Content.Shared/_Floof/HeightAdjust/FixtureHelperSystem.cs
+++ b/Content.Shared/_Floof/HeightAdjust/FixtureHelperSystem.cs
@@ -1,12 +1,15 @@
+using System.Diagnostics.CodeAnalysis;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Collision.Shapes;
 using Robust.Shared.Physics.Systems;
+using Robust.Shared.Serialization.Manager;
 
 namespace Content.Shared._Floof.HeightAdjust;
 
 public class FixtureHelperSystem : EntitySystem
 {
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
+    [Dependency] private readonly ISerializationManager _serialization = default!;
 
     /// <summary>
     ///     Multiplies the radii of all fixtures of the given entity by the specified value.
@@ -33,5 +36,24 @@ public class FixtureHelperSystem : EntitySystem
         }
 
         return count;
+    }
+
+    public bool TryCopyShape(IPhysShape valueShape, [NotNullWhen(true)] out IPhysShape? shapeCopy)
+    {
+        shapeCopy = valueShape switch
+        {
+            PhysShapeCircle circle => new PhysShapeCircle(circle.Radius, circle.Position),
+            // There is no way to set the fields of PhysShapeAABB from code, I'm not even kidding
+            PhysShapeAabb aab => _serialization.CreateCopy(aab, notNullableOverride: true),
+            _ => null,
+        };
+
+        if (shapeCopy == null)
+        {
+            Log.Error($"Cannot copy shape of type {valueShape.GetType()}");
+            return false;
+        }
+
+        return true;
     }
 }

--- a/Content.Shared/_Floof/HeightAdjust/FixtureHelperSystem.cs
+++ b/Content.Shared/_Floof/HeightAdjust/FixtureHelperSystem.cs
@@ -24,10 +24,18 @@ public class FixtureHelperSystem : EntitySystem
             return 0;
 
         var count = 0;
+        var uniqueShapes = new HashSet<IPhysShape>();
         foreach (var (key, fix) in ent.Comp.Fixtures)
         {
             if (fix.Shape is not PhysShapeCircle circle || circle.Radius <= 0.01f)
                 continue;
+
+            // Sanity check
+            if (!uniqueShapes.Add(fix.Shape))
+            {
+                Log.Warning($"Entity {ToPrettyString(ent)} has two or more fixtures that reference the same IPhysShape object. This can cause errors.");
+                continue;
+            }
 
             // Can we avoid the costly SetRadius in batch fixture updates like this?
             // Setting fixture.Radius and calling FixtureUpdate would be an option, but it's internal API
@@ -45,6 +53,8 @@ public class FixtureHelperSystem : EntitySystem
             PhysShapeCircle circle => new PhysShapeCircle(circle.Radius, circle.Position),
             // There is no way to set the fields of PhysShapeAABB from code, I'm not even kidding
             PhysShapeAabb aab => _serialization.CreateCopy(aab, notNullableOverride: true),
+            // Same here
+            PolygonShape polygon => _serialization.CreateCopy(polygon, notNullableOverride: true),
             _ => null,
         };
 

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -312,9 +312,8 @@
   - type: CanDoCPR # DeltaV - Addition of CPR
   - type: PotentialPsionic # DeltaV - organic species can all be psionic
   - type: FootPrints # Floof
-  #Euph - disable RevealRevenantOnCollide for mobs. It increases radius on mobs, and thus they cannot fit through doors.
-  #- type: RevealRevenantOnCollide # DeltaV - passing through people reveal revenant
-  #  revealTime: 1
+  - type: RevealRevenantOnCollide # DeltaV - passing through people reveal revenant
+    revealTime: 1
 
 - type: entity
   save: false


### PR DESCRIPTION
## About the PR
RevealRevenantOnCollideSystem was copying fixture shapes by-ref, causing two fixtures to reference the same IPhysShape object, which was causing FixturesAffectedByHeightSystem to scale the same fixture shapes twice. Consequently, with this bug fixed, we can re-enable RevealRevenantOnCollide on player mobs (which is needed because revenant can now perform melee attacks)

I love RT tooling. There's no method to copy a fixture shape. There's no way to set PhysShapeAABB properties from C#.


## Media
All resulting textures of a max-height oni are below 0.5m in radius

<img width="1281" height="747" alt="image" src="https://github.com/user-attachments/assets/25e93e0b-ac0b-4617-b8c3-e9848e9a1967" />



**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- fix: Revenants will now reveal themselves when colliding with species mobs (this feature was perviously disabled due to a bug)
