### PR TITLE
More Books for Archivist

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -122,6 +122,12 @@
     spawned:
     - id: FoodMeatDragon
       amount: 2
+    - id: AncientBookDamagedRare #Euphoria - Sometimes drops a Rare Book on butcher, for Archivists. 10000 Research Points if restored
+      min: 0
+      max: 1
+    - id: AncientBookDamagedUncommon # Euphoria - drops some uncommon books on butcher, 5000 points each
+      min: 1
+      max: 3
   - type: InteractionPopup
     successChance: 0.25 # It's no goose, but you better smell like carp.
     interactSuccessString: petting-success-dragon

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -123,11 +123,11 @@
     - id: FoodMeatDragon
       amount: 2
     - id: AncientBookDamagedRare #Euphoria - Sometimes drops a Rare Book on butcher, for Archivists. 10000 Research Points if restored
-      min: 0
-      max: 1
+      amount: 0
+      maxAmount: 2
     - id: AncientBookDamagedUncommon # Euphoria - drops some uncommon books on butcher, 5000 points each
-      min: 1
-      max: 3
+      amount: 1
+      maxAmount: 3
   - type: InteractionPopup
     successChance: 0.25 # It's no goose, but you better smell like carp.
     interactSuccessString: petting-success-dragon

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -154,14 +154,14 @@
     - id: CosmicCultMindSink
       amount: 1
     - id: AncientBookDamagedRare #Euphoria - Drops multiple ruined books on butcher, for Archivists to process. Should be a range of 16000 to 46000 research per Colossus depending on RNG. 10000 Research Points per rare book
-      min: 1
-      max: 2
+      amount: 1
+      maxAmount: 2
     - id: AncientBookDamagedUncommon # Euphoria - 5000 research per uncommon book
-      min: 1
-      max: 4
+      amount: 1
+      maxAmount: 4
     - id: AncientBookDamagedCommon # Euphoria - 1000 research per common book
-      min: 1
-      max: 6
+      amount: 1
+      maxAmount: 6
   - type: PointLight
     color: "#42a4ae"
     radius: 4

--- a/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Mobs/colossus.yml
@@ -153,6 +153,15 @@
     spawned:
     - id: CosmicCultMindSink
       amount: 1
+    - id: AncientBookDamagedRare #Euphoria - Drops multiple ruined books on butcher, for Archivists to process. Should be a range of 16000 to 46000 research per Colossus depending on RNG. 10000 Research Points per rare book
+      min: 1
+      max: 2
+    - id: AncientBookDamagedUncommon # Euphoria - 5000 research per uncommon book
+      min: 1
+      max: 4
+    - id: AncientBookDamagedCommon # Euphoria - 1000 research per common book
+      min: 1
+      max: 6
   - type: PointLight
     color: "#42a4ae"
     radius: 4

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/glimmer_creatures.yml
@@ -107,6 +107,12 @@
           Ectoplasm:
             min: 2
             max: 3
+          AncientBookDamagedUncommon: #Euphoria - Drops books for Archivists to research, letting Epi do a little bit of research during higher glimmer amounts instead of being almost entirely paused. Uncommon Books give 5000 points
+            min: 0
+            max: 1
+          AncientBookDamagedCommon: # Euphoria - Common books give 1000 points each
+            min: 1
+            max: 3
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
   - type: Damageable

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -119,11 +119,11 @@
     - id: Ectoplasm
       amount: 1
     - id: AncientBookDamagedUncommon # Euphoria: Drops a guaranteed Uncommon book on butcher, with a chance for a second one, for Archivists. 5000 research per book
-      min: 1
-      max: 2
+      amount: 1
+      maxAmount: 2
     - id: AncientBookDamagedCommon # Euphoria - sometimes drops extra Common books. 1000 points per book
-      min: 0
-      max: 2
+      amount: 0
+      maxAmount: 2
   - type: Prying
     pryPowered: true
     force: true

--- a/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/NPCs/skia.yml
@@ -118,6 +118,12 @@
     spawned:
     - id: Ectoplasm
       amount: 1
+    - id: AncientBookDamagedUncommon # Euphoria: Drops a guaranteed Uncommon book on butcher, with a chance for a second one, for Archivists. 5000 research per book
+      min: 1
+      max: 2
+    - id: AncientBookDamagedCommon # Euphoria - sometimes drops extra Common books. 1000 points per book
+      min: 0
+      max: 2
   - type: Prying
     pryPowered: true
     force: true


### PR DESCRIPTION
## About the PR
Part of the planned Archivist Expansion. This PR adds a lot more sources for books for Archivists!

## Why / Balance
Archivist relying solely on Salvage for books means that books are very rare. If it was purely a "bonus" (similar to Bluespace Beakers for Chem), this would be fine, but Archivist's gameplay is pretty much entirely reliant on Salvage's generosity. This also provides extra research for Epistemics when certain threats have been handled.

Wisps drop books on death, while Dragons, Colossi, and Skia drop books when butchered. 

Lore/Vibes/Worldbuilding wise, there's talks about renaming and/or respriting Ruined Books which would also help fit into these changes (while also opening up opportunities for stuff like Ninjas or Asakim also dropping these "books" on death). That isn't going to be part of this PR.

## Technical details
It's all YAML. We considered adding it to the Revenant, but we couldn't find an easy way to add it without opening up a "Revenant Farm" situation.

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
Salvage/Dungeon dragons don't drop books as far as we can tell, for some reason. The extra influx of research points will make it easier for Epistemics to finish the research server each shift. 

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Archivists now have extra sources for books to restore!
- add: Colossi, Space Dragons, and Skia drop Ruined Books when butchered
- add: Glimmer Wisps drop Ruined Books when killed
