### PR TITLE
Requested changes for admin messages

### DIFF
--- a/Content.Server/Administration/ServerApi.cs
+++ b/Content.Server/Administration/ServerApi.cs
@@ -460,7 +460,7 @@ public sealed partial class ServerApi : IPostInjectInit
                 }
 
                 var serverBwoinkSystem = _entitySystemManager.GetEntitySystem<BwoinkSystem>();
-                var message = new SharedBwoinkSystem.BwoinkTextMessage(player.UserId, SharedBwoinkSystem.SystemUserId, body.Text);
+                var message = new SharedBwoinkSystem.BwoinkTextMessage(player.UserId, SharedBwoinkSystem.SystemUserId, body.Text, adminOnly: body.AdminOnly); //Frontier
                 serverBwoinkSystem.OnWebhookBwoinkTextMessage(message, body);
 
                 // Respond with OK

--- a/Content.Server/_NF/Administration/BwoinkData.cs
+++ b/Content.Server/_NF/Administration/BwoinkData.cs
@@ -10,6 +10,7 @@ public sealed class BwoinkActionBody
     public required Guid Guid { get; init; }
     public bool UserOnly { get; init; }
     public required bool WebhookUpdate { get; init; }
+    public bool AdminOnly { get; init; } //Frontier
     public required string RoleName { get; init; }
     public required string RoleColor { get; init; }
 }


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Requested change from Joel for ahelp messages. Taken from https://github.com/new-frontiers-14/frontier-station-14/pull/3073

## Why / Balance
It ties in to a webhook to indicate a message should only be for admins.

## Technical details
Essentially it allows admins to add comments through discord without needing to go through the client.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
![Example Media Embed](https://example.com/thisimageisntreal.png)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
I wasn't able to confirm if this breaks anything related to cwoinks. Its to be seen.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Admin only to a bwoink message for admins to send through comments to a player through discord.
