### PR TITLE
E-Sword Research

### DIFF
--- a/Resources/Locale/en-US/research/technologies.ftl
+++ b/Resources/Locale/en-US/research/technologies.ftl
@@ -41,6 +41,7 @@ research-technology-advanced-shuttle-weapon = Advanced Shuttle Weapons
 research-technology-thermal-weaponry = Thermal Weaponry
 research-technology-dual-wielding-technology = Dual Wielding Technology
 research-technology-extended-pistol-magazines = Extended Pistol Magazines
+research-technology-energy-sword-research = Energy Sword Research
 
 research-technology-basic-robotics = Basic Robotics
 research-technology-basic-anomalous-research = Basic Anomalous Research

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -77,7 +77,7 @@
 
 - type: entity
   name: energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseSyndicateContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseSecurityContraband]
   id: EnergySword
   description: A very loud & dangerous sword with a beam made of pure, concentrated plasma. Cuts through unarmored targets like butter.
   components:
@@ -264,7 +264,7 @@
 
 - type: entity
   name: energy cutlass
-  parent: [BaseMeleeWeaponEnergy, BaseMajorContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseSecurityContraband]
   id: EnergyCutlass
   description: An exotic energy weapon, brutal blade crackling with crudely harnessed plasma. # DeltaV - nicer description.
   components:
@@ -296,7 +296,7 @@
 
 - type: entity
   name: double-bladed energy sword
-  parent: [BaseMeleeWeaponEnergy, BaseSyndicateContraband]
+  parent: [BaseMeleeWeaponEnergy, BaseSecurityContraband]
   id: EnergySwordDouble
   description: Syndicate Command Interns thought that having one blade on the energy sword was not enough. This can be stored in pockets.
   components:

--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -150,6 +150,9 @@
   - WeaponXrayCannon
   - WeaponTemperatureGun
   - WeaponLaserSvalinn # Euphoria
+  - EnergySword # Euphoria
+  - EnergyCutlass # Euphoria
+  - EnergySwordDouble # Euphoria
 
 - type: latheRecipePack
   id: SecurityDisablers

--- a/Resources/Prototypes/_Floof/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_Floof/Recipes/Lathes/security.yml
@@ -8,3 +8,42 @@
     Glass: 120
     Steel: 500
     Plastic: 140
+
+- type: latheRecipe
+  id: EnergySword
+  result: EnergySword
+  completetime: 60
+  materials:
+    Steel: 500
+    Plastic: 500
+    Glass: 500
+    Gold: 500
+    Plasma: 1500
+    Plasteel: 1000
+    Diamond: 200
+
+- type: latheRecipe
+  id: EnergyCutlass
+  result: EnergyCutlass
+  completetime: 60
+  materials:
+    Steel: 500
+    Plastic: 500
+    Glass: 500
+    Gold: 500
+    Plasma: 1500
+    Plasteel: 1000
+    Diamond: 200
+
+- type: latheRecipe
+  id: EnergySwordDouble
+  result: EnergySwordDouble
+  completetime: 60
+  materials:
+    Steel: 500
+    Plastic: 500
+    Glass: 500
+    Gold: 500
+    Plasma: 1500
+    Plasteel: 1000
+    Diamond: 400

--- a/Resources/Prototypes/_Floof/Research/research.yml
+++ b/Resources/Prototypes/_Floof/Research/research.yml
@@ -26,3 +26,17 @@
   - MagazinePistolHighCapacity
   - MagazinePistolHighCapacityRubber
   - MagazinePistolHighCapacityPractice
+
+- type: technology
+  id: EnergySwordResearch
+  name: research-technology-energy-sword-research
+  icon:
+    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+    state: icon
+  discipline: Arsenal
+  tier: 3
+  cost: 25000
+  recipeUnlocks:
+  - EnergySword
+  - EnergyCutlass
+  - EnergySwordDouble

--- a/Resources/Prototypes/_Floof/Research/research.yml
+++ b/Resources/Prototypes/_Floof/Research/research.yml
@@ -31,7 +31,7 @@
   id: EnergySwordResearch
   name: research-technology-energy-sword-research
   icon:
-    sprite: Objects/Weapons/Guns/Battery/svalinn.rsi
+    sprite: Objects/Weapons/Melee/e_sword.rsi
     state: icon
   discipline: Arsenal
   tier: 3


### PR DESCRIPTION
## About the PR
This PR adds a Tier 3 Arsenal Research for Energy Swords.

## Why / Balance
Energy Swords are rather weak in DV's fork. (IE, only reflects energy bolts, advanced trudgeon does way more damage)
The recipes added in this PR require diamonds which give more use for diamonds (other then selling) and makes constructing them fairly expensive.

**Changelog**
:cl:
- add: Added Energy Sword research.