### PR TITLE
IPC oilpack

### DIFF
--- a/Resources/Locale/en-US/_Euphoria/stack/healing.ftl
+++ b/Resources/Locale/en-US/_Euphoria/stack/healing.ftl
@@ -1,0 +1,1 @@
+stack-bloodpack-oil = oil pack

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -202,7 +202,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockRoboticsFilled
-  cost: 1600
+  cost: 1700 # Euph
   category: cargoproduct-category-name-epistemics
   group: market
 

--- a/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_vending.yml
@@ -202,7 +202,7 @@
     sprite: Objects/Specific/Service/vending_machine_restock.rsi
     state: base
   product: CrateVendingMachineRestockRoboticsFilled
-  cost: 1700 # Euph
+  cost: 1800 # Euph
   category: cargoproduct-category-name-epistemics
   group: market
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/robotics.yml
@@ -16,6 +16,9 @@
     Hemostat: 2
     Cautery: 2
     # End DeltaV additions
+    # Begin Euphoria additions
+    BloodpackOil: 6 # For IPC, extra stock since there's usually only one robo-vend per map.
+    # End Euphoria additions
     NitrousOxideTankFilled: 2
     ClothingMaskBreathMedical: 5
     ClothingHeadHatWeldingMaskFlame: 2 # DeltaV - Changed from 1 to 2

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/healing.yml
@@ -13,8 +13,9 @@
     - Robotic
     damage:
       types:
-        Bloodloss: -5 # Since IPCs do not naturally heal from bloodloss
-    modifyBloodLevel: 15 #restores about 5% blood per use on standard humanoids.
+        Bloodloss: -10 # Since IPCs do not naturally heal from bloodloss
+    modifyBloodLevel: 30 # about 1/0 of the blood pool of an average humanoid
+    delay: 6 # about 2x than long as normal ones
   - type: Stack
     stackType: BloodpackOil
     count: 10

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/healing.yml
@@ -19,6 +19,8 @@
   - type: Stack
     stackType: BloodpackOil
     count: 10
+  - type: StackPrice
+    price: 2 # I suppose oil is more common than blood. This is mainly to avoid exploding the cost of the robotech restock.
 
 - type: entity
   parent: BloodpackOil

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/Medical/healing.yml
@@ -1,3 +1,34 @@
+# ================================================================================================
+# Topicals
+
+# Placeholder oilpack because i can't be fucked to port the ones from FarHorizons (which require changes to the healing system and more)
+- type: entity
+  name: oil pack
+  description: Contains a small amount of space lubricant that can substitute normal IPC oil.
+  parent: Bloodpack
+  id: BloodpackOil
+  components:
+  - type: Healing
+    damageContainers:
+    - Robotic
+    damage:
+      types:
+        Bloodloss: -5 # Since IPCs do not naturally heal from bloodloss
+    modifyBloodLevel: 15 #restores about 5% blood per use on standard humanoids.
+  - type: Stack
+    stackType: BloodpackOil
+    count: 10
+
+- type: entity
+  parent: BloodpackOil
+  id: BloodpackOil1
+  suffix: Single
+  components:
+  - type: Stack
+    count: 1
+
+# ================================================================================================
+# Pills
 - type: entity
   name: Libidozenithizine pill
   parent: Pill
@@ -23,7 +54,7 @@
           reagents:
             - ReagentId: Libidozenithizine # This will most likely kill you
               Quantity: 50
-            
+
 - type: entity
   parent: PresentRandom
   id: RhinoPillbox

--- a/Resources/Prototypes/_Euphoria/Stacks/Specific/healing.yml
+++ b/Resources/Prototypes/_Euphoria/Stacks/Specific/healing.yml
@@ -1,0 +1,6 @@
+# I'm not bothering adding new sprites
+- type: stack
+  parent: Bloodpack
+  id: BloodpackOil
+  name: stack-bloodpack-oil
+  spawn: BloodpackOil


### PR DESCRIPTION
## About the PR
Adds a new item to the robotech deluxe that can heal bloodloss on IPCs. Takes 6 seconds to apply, add 30 units of blood (oil), and heal 10 bloodloss (since ipcs can't natually heal it).

I couldn't find a proper sprite, and we don't have the bloodpack rework that FH does (maybe coming in a future upstream merge? definitely not part of the nubody merge), so it just uses default bloodpack sprites for now.


## Media
Tested on the upstream merge branch, should be the same here unless tests say otherwise:
<img width="699" height="314" alt="image" src="https://github.com/user-attachments/assets/4b541551-058f-4d1f-b2b8-049ebc7746e1" />
<img width="580" height="316" alt="image" src="https://github.com/user-attachments/assets/aa2f7467-eea8-4747-b88f-ea212a97e8fb" />


## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

**Changelog**
:cl:
- add: The RoboTech Deluxe now contains oil packs, which can be used to restore oil level and heal bloodloss on IPCs.