### PR TITLE
Makes Foxfires Force Followable

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Specific/Species/kitsune.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Specific/Species/kitsune.yml
@@ -45,3 +45,6 @@
       - !type:DoActsBehavior
         acts: ["Destruction"]
   - type: InteractionOutline
+  - type: Tag # Euphoria
+    tags:
+    - ForceableFollow


### PR DESCRIPTION
## About the PR
Adds ForceableFollow Tag to Foxfire

## Why / Balance
Thematic and cool.

**Changelog**
:cl:
- tweak: Allows Foxfires to follow you. (The same way a ghost plushie works.)
