### PR TITLE
Clumsy Traits

### DIFF
--- a/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
+++ b/Resources/Locale/en-US/_Floof/traits/physical_traits.ftl
@@ -143,3 +143,9 @@ trait-messy-smoker-popup = You feel the need to spit from what you are smoking..
 
 trait-jump-ability-name = Pounce
 trait-jump-ability-description = Being nature's most fearsome predator, you developed the ability to pounce forward in the direction of your gaze.
+
+trait-slight-clumsy-name = Clumsy
+trait-slightly-clumsy-description = You have a nack for accidentally stubbing your toe or not jumping high enough to jump over a counter often hurting your self in an embracing way...
+
+trait-very-clumsy-name = Very Clumsy
+trait-very-clumsy-description = You have poor hand eye coordination and often mess up climbing over things, shooting weaponry and using electronics....

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -746,3 +746,49 @@
       jumpDistance: 3
       canCollide: true # you may be pouncing but its funny watching poeple flop over
       action: ActionPounce
+
+- type: trait
+  id: SlightlyClumsy
+  name: trait-slight-clumsy-name
+  description: trait-slightly-clumsy-description
+  category: DisabilitiesPhysical
+  cost: -1
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - VeryClumsy
+  effects:
+  - !type:AddCompsEffect
+    components:
+    - type: Clumsy
+      clumsyDefib: false
+      clumsyHypo: false
+      clumsyGuns: false # we let them shoot with this
+
+- type: trait
+  id: VeryClumsy
+  name: trait-very-clumsy-name
+  description: trait-very-clumsy-description
+  category: DisabilitiesPhysical
+  cost: -4
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - SlightlyClumsy
+  - !type:OneOfSpeciesCondition # oni cant shoot guns so feel like we should prevent them from taking this
+    invert: true
+    species:
+    - Oni
+  effects:
+  - !type:AddCompsEffect
+    components:
+    - type: Clumsy
+      gunShootFailDamage:
+        types:
+          Blunt: 5
+          Piercing: 4
+          Heat: 3
+      catchingFailDamage:
+        types:
+          Blunt: 1
+      clumsyGunShootCheck: 0.2 # 80% chance of success

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -754,6 +754,9 @@
   category: DisabilitiesPhysical
   cost: -1
   conditions:
+  - !type:HasJobCondition # we dont want clowns taking this
+    job: Clown
+    invert: true
   - !type:TraitDependencyCondition
     conflicts:
     - VeryClumsy
@@ -772,6 +775,9 @@
   category: DisabilitiesPhysical
   cost: -4
   conditions:
+  - !type:HasJobCondition # we dont want clowns taking this
+    job: Clown
+    invert: true
   - !type:TraitDependencyCondition
     conflicts:
     - SlightlyClumsy


### PR DESCRIPTION
## About the PR
Adds two new traits, slightly and very clumsy.

Slightly clumsy only stops you from vaulting and catching sometimes.

Very clumsy will do the above and can trigger on defib usage, hypo usage and while shooting guns.

## Why / Balance
Its silly so why the heck not.

## Technical details
Some good ol yaml, i wrote the descriptions quickly so feel free to suggest changes.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="1384" height="396" alt="image" src="https://github.com/user-attachments/assets/683fbd57-2930-4293-aa73-0a16177aef0e" />
<img width="684" height="251" alt="image" src="https://github.com/user-attachments/assets/a48c9c17-75a8-40d6-a01f-a44e5a6131a5" />

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [x] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- add: Added two clumsy traits.
