### PR TITLE
Add corpsman medical pouch and recolour syndicate medical pouch

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -85,6 +85,7 @@
   - PowerCageSmall
   - TelescopicShield
   #- ClothingBackpackHarmpack # DeltaV - HARMPACKS deemed harmful
+  - SecurityMedicalPouch # Euphoria
 
 - type: latheRecipePack
   id: SecurityBoards

--- a/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/_Euphoria/Entities/Objects/Specific/chemistry.yml
@@ -1,0 +1,58 @@
+- type: entity
+  name: corpsman medical pouch
+  id: SecurityMedicalPouch
+  parent: [ MedicalPouch ]
+  description: A small pouch in security colours for pills, bottles, autoinjectors, and syringes.
+  components:
+  - type: Sprite
+    sprite: _NF/Objects/Storage/Pouches/pouch_small.rsi
+    layers:
+    - state: base
+      color: "#353535"
+    - state: closed
+      map: [ "closeLayer" ]
+      color: "#353535"
+    - state: open
+      map: [ "openLayer" ]
+      color: "#353535"
+      visible: false
+    - state: inside
+      map: ["insideLayer"]
+      visible: false
+    - state: fill-chem-1
+      map: [ "pouchFill1" ]
+      visible: false
+    - state: fill-chem-2
+      map: [ "pouchFill2" ]
+      visible: false
+    - state: fill-chem-3
+      map: [ "pouchFill3" ]
+      visible: false
+    - state: fill-chem-4
+      map: [ "pouchFill4" ]
+      visible: false
+    - state: decal-line-01
+      map: [ "decal1" ]
+      color: "#2f74b8"
+    - state: decal-med-cross
+      map: [ "decal2" ]
+      color: "#860000"
+  - type: Clothing
+    sprite: _NF/Objects/Storage/Pouches/pouch_small.rsi
+    clothingVisuals:
+      belt:
+      - state: equipped-BELT
+        color: "#353535"
+      pocket:
+      - state: equipped-BELT
+        color: "#353535"
+  - type: Item
+    size: Small
+    sprite: _NF/Objects/Storage/Pouches/pouch_small.rsi
+    inhandVisuals:
+      left:
+      - state: inhand-left
+        color: "#353535"
+      right:
+      - state: inhand-right
+        color: "#353535"

--- a/Resources/Prototypes/_Euphoria/Recipes/Lathes/chemistry.yml
+++ b/Resources/Prototypes/_Euphoria/Recipes/Lathes/chemistry.yml
@@ -1,0 +1,6 @@
+﻿- type: latheRecipe
+  id: SecurityMedicalPouch
+  result: SecurityMedicalPouch
+  completetime: 3
+  materials:
+    Cloth: 200

--- a/Resources/Prototypes/_Euphoria/Research/civilianservices.yml
+++ b/Resources/Prototypes/_Euphoria/Research/civilianservices.yml
@@ -11,3 +11,4 @@
   cost: 5000
   recipeUnlocks:
   - MedicalPouch
+  - SecurityMedicalPouch

--- a/Resources/Prototypes/_NF/Entities/Objects/Specific/chemistry.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Specific/chemistry.yml
@@ -80,13 +80,13 @@
     sprite: _NF/Objects/Storage/Pouches/pouch_small.rsi
     layers:
     - state: base
-      color: "#3e3e48"
+      color: "#ca4545"
     - state: closed
       map: [ "closeLayer" ]
-      color: "#3e3e48"
+      color: "#ca4545"
     - state: open
       map: [ "openLayer" ]
-      color: "#3e3e48"
+      color: "#ca4545"
       visible: false
     - state: inside
       map: ["insideLayer"]
@@ -105,7 +105,7 @@
       visible: false
     - state: decal-line-01
       map: [ "decal1" ]
-      color: "#ca4545"
+      color: "#3e3e48"
     - state: decal-med-cross
       map: [ "decal2" ]
       color: "#ede984"
@@ -114,20 +114,20 @@
     clothingVisuals:
       belt:
       - state: equipped-BELT
-        color: "#3e3e48"
+        color: "#ca4545"
       pocket:
       - state: equipped-BELT
-        color: "#3e3e48"
+        color: "#ca4545"
   - type: Item
     size: Small
     sprite: _NF/Objects/Storage/Pouches/pouch_small.rsi
     inhandVisuals:
       left:
       - state: inhand-left
-        color: "#3e3e48"
+        color: "#ca4545"
       right:
       - state: inhand-right
-        color: "#3e3e48"
+        color: "#ca4545"
   - type: Storage
     grid:
     - 0,0,4,2 #syndie stuffs always bigger


### PR DESCRIPTION
## About the PR
Added corpsman's medical pouch, craftable in the security techfab. Recoloured syndicate medical pouch to emphasise red over black.

## Why / Balance
With black-security and the syndicate hardsuits, red is the colour that makes the syndicate stand out most.
The corpsman deserves a security-branded medical pouch. One possible concern is that this now gives non-corpsman security members the ability to craft their own medical pouch, but this was deemed preferable over allowing medical staff to craft the corpsman's pouch.

It's also deemed a minor issue, since it's not truly useful without the tiny-sized medical supplies that fit in it, such as auto-injectors or chem bottles that the security department (sans the corpsman) have limited to.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="163" height="148" alt="corpsman-medical-pouch" src="https://github.com/user-attachments/assets/b01b2ee2-1d2b-4b05-a0d7-ca51a7597653" />
<img width="163" height="148" alt="syndicate-medical-pouch" src="https://github.com/user-attachments/assets/81ada924-4dce-4a2d-ba23-1168930cad97" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->

**Changelog**
:cl:
- add: Medical pouch in corpsman's colours.
