### PR TITLE
Fix rubber ammunition magazine visuals

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -15,3 +15,15 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+  # Euphoria start: Fix rubber magazine variant visuals
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-mag
+      - state: inhand-left-stripe
+        color: "#206eef"
+      right:
+      - state: inhand-right-mag
+      - state: inhand-right-stripe
+        color: "#206eef"
+  # Euphoria end

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -15,6 +15,18 @@
       map: ["enum.GunVisualLayers.Base"]
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
+  # Euphoria start: Fix rubber magazine variant visuals
+  - type: Item
+    inhandVisuals:
+      left:
+      - state: inhand-left-mag
+      - state: inhand-left-stripe
+        color: "#206eef"
+      right:
+      - state: inhand-right-mag
+      - state: inhand-right-stripe
+        color: "#206eef"
+  # Euphoria end
 
 - type: entity
   parent: MagazineUniversalMagnum

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -14,17 +14,17 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: stripe
-      color: "#dbdbdb"
+      color: "#206eef" # Euphoria: Fix rubber magazine variant visuals (#206eef<#dbdbdb)
   - type: Item
     inhandVisuals:
       left:
       - state: inhand-left-mag
       - state: inhand-left-stripe
-        color: "#dbdbdb"
+        color: "#206eef" # Euphoria: Fix rubber magazine variant visuals (#206eef<#dbdbdb)
       right:
       - state: inhand-right-mag
       - state: inhand-right-stripe
-        color: "#dbdbdb"
+        color: "#206eef" # Euphoria: Fix rubber magazine variant visuals (#206eef<#dbdbdb)
 
 - type: entity
   id: MagazinePistolHighCapacityIncendiary
@@ -99,8 +99,16 @@
     inhandVisuals:
       left:
       - state: inhand-left-mag
+      # Euphoria start: Fix rubber magazine variant visuals
+      - state: inhand-left-stripe
+        color: "#206eef"
+      # Euphoria end
       right:
       - state: inhand-right-mag
+      # Euphoria start: Fix rubber magazine variant visuals
+      - state: inhand-right-stripe
+        color: "#206eef"
+      # Euphoria end
 
 - type: entity
   parent: BaseMagazinePistolSubMachineGun
@@ -121,8 +129,16 @@
     inhandVisuals:
       left:
       - state: inhand-left-mag
+      # Euphoria start: Fix rubber magazine variant visuals
+      - state: inhand-left-stripe
+        color: "#206eef"
+      # Euphoria end
       right:
       - state: inhand-right-mag
+      # Euphoria start: Fix rubber magazine variant visuals
+      - state: inhand-right-stripe
+        color: "#206eef"
+      # Euphoria end
 
 # .38 special
 

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
@@ -15,10 +15,18 @@
     - state: mag-1
       map: ["enum.GunVisualLayers.Mag"]
     - state: stripe
-      color: "#dbdbdb"
+      color: "#206eef" # Euphoria: Fix rubber magazine variant visuals (#206eef<#dbdbdb)
   - type: Item
     inhandVisuals:
       left:
       - state: inhand-left-mag
+      # Euphoria start: Fix rubber magazine variant visuals
+      - state: inhand-left-stripe
+        color: "#206eef"
+      # Euphoria end
       right:
       - state: inhand-right-mag
+      # Euphoria start: Fix rubber magazine variant visuals
+      - state: inhand-right-stripe
+        color: "#206eef"
+      # Euphoria end


### PR DESCRIPTION
## About the PR
Fix the missing or incorrect visuals of most rubber bullet magazines

## Why / Balance
This brings these magazines in-line with their peers and makes them swiftly identifiable.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="260" height="181" alt="magazine-rifle-rubber" src="https://github.com/user-attachments/assets/b66c8949-4c64-477b-a225-e7ae40570ecb" />
<img width="242" height="185" alt="magazine-magnum-rubber" src="https://github.com/user-attachments/assets/985f0c0b-6508-4635-9082-bf21171cc314" />
<img width="271" height="197" alt="magazine-pistol-rubber" src="https://github.com/user-attachments/assets/4b5ab393-7cf1-4b4d-a202-7382708bc519" />

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->

**Changelog**
:cl:
- fix: Fixed visuals of rubber magazines for most magazine types.
