### PR TITLE
Remove Conflict Between Negative Stamina Traits

### DIFF
--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -142,7 +142,6 @@
   conflicts:
   - Vigor
   - Lethargy
-  - Weakness
   conditions:
   - !type:HasCompCondition
     component: BorgChassis
@@ -159,7 +158,6 @@
   cost: -5 # Getting stunned from 1-2 stunbaton or disabler hits is worth a lot.
   conflicts:
   - Vigor
-  - Lethargy
   - Weakness
   conditions:
   - !type:HasCompCondition


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
There are 3 stamina traits. One increase stamina, one decreases it by 20%, one decreases it by 50%.
I made it so the two that decrease stamina do not conflict with each other.
If I'm doing the math right, if you take both traits, you will have 40% of the normal stamina mount. A loss of 60%. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
People have been asking for this since they want to be able to make their characters even weaker and more pathetic. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
<img width="1351" height="840" alt="image" src="https://github.com/user-attachments/assets/e71ca16a-9b1f-4a67-b94a-8f7f9be780d1" />

<img width="698" height="691" alt="image" src="https://github.com/user-attachments/assets/680c7ecd-ce55-4010-ae9d-5e0db3ec64bb" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Removed the conflict between the two negative stamina traits, Lethargy and Weakness. Now you can take both and be even more pathetic. 