### PR TITLE
remove construction constraints on ALL atmos devices

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -537,7 +537,8 @@
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit - RPD consistency
+  # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasVentPump
   - GasVentPumpAlt1
@@ -552,7 +553,8 @@
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasPassiveVent
   - GasPassiveVentAlt1
@@ -567,7 +569,8 @@
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasVentScrubber
   - GasVentScrubberAlt1
@@ -582,7 +585,8 @@
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasOutletInjector
   - GasOutletInjectorAlt1
@@ -598,7 +602,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressurePump
   - GasPressurePumpAlt1
@@ -614,7 +619,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressurePump
   - GasPressurePumpAlt1
@@ -630,7 +636,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressurePump
   - GasPressurePumpAlt1
@@ -645,7 +652,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVolumePump
   - GasVolumePumpAlt1
@@ -661,7 +669,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVolumePump
   - GasVolumePumpAlt1
@@ -677,7 +686,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVolumePump
   - GasVolumePumpAlt1
@@ -692,7 +702,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveGate
   - GasPassiveGateAlt1
@@ -708,7 +719,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveGate
   - GasPassiveGateAlt1
@@ -724,7 +736,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveGate
   - GasPassiveGateAlt1
@@ -739,7 +752,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressureRegulator
   - GasPressureRegulatorAlt1
@@ -755,7 +769,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressureRegulator
   - GasPressureRegulatorAlt1
@@ -771,7 +786,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressureRegulator
   - GasPressureRegulatorAlt1
@@ -786,7 +802,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasValve
   - GasValveAlt1
@@ -802,7 +819,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasValve
   - GasValveAlt1
@@ -818,7 +836,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasValve
   - GasValveAlt1
@@ -833,7 +852,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - SignalControlledValve
   - SignalControlledValveAlt1
@@ -849,7 +869,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
   alternativePrototypes:
   - SignalControlledValve
   - SignalControlledValveAlt1
@@ -865,7 +886,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
   alternativePrototypes:
   - SignalControlledValve
   - SignalControlledValveAlt1
@@ -880,7 +902,8 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
 
 - type: construction
   id: GasDualPortVentPump
@@ -921,7 +944,8 @@
   canBuildInImpassable: false
   mirror: GasFilterFlipped
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
 
 - type: construction
   id: GasFilterFlipped
@@ -934,7 +958,8 @@
   canBuildInImpassable: false
   mirror: GasFilter
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixer
@@ -946,7 +971,8 @@
   canBuildInImpassable: false
   mirror: GasMixerFlipped
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
 
 - type: construction
   id: GasMixerFlipped
@@ -959,7 +985,8 @@
   canBuildInImpassable: false
   mirror: GasMixer
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
 
 - type: construction
   id: PressureControlledValve
@@ -970,7 +997,8 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   conditions:
-    - !type:NoUnstackableInTile
+    # Euphoria edit
+    # - !type:NoUnstackableInTile
 
 # INTERCOM
 - type: construction

--- a/Resources/Prototypes/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/Recipes/Construction/utilities.yml
@@ -536,8 +536,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit - RPD consistency
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasVentPump
@@ -552,8 +552,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasPassiveVent
@@ -568,8 +568,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasVentScrubber
@@ -584,8 +584,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers # Funky
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes: # Funky
   - GasOutletInjector
@@ -601,8 +601,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressurePump
@@ -618,8 +618,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressurePump
@@ -635,8 +635,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressurePump
@@ -651,8 +651,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVolumePump
@@ -668,8 +668,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVolumePump
@@ -685,8 +685,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVolumePump
@@ -701,8 +701,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveGate
@@ -718,8 +718,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveGate
@@ -735,8 +735,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveGate
@@ -751,8 +751,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressureRegulator
@@ -768,8 +768,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressureRegulator
@@ -785,8 +785,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPressureRegulator
@@ -801,7 +801,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
   alternativePrototypes:
@@ -818,7 +818,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
   alternativePrototypes:
@@ -835,7 +835,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
   alternativePrototypes:
@@ -851,8 +851,8 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - SignalControlledValve
@@ -868,7 +868,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
   alternativePrototypes:
@@ -885,7 +885,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
   alternativePrototypes:
@@ -901,7 +901,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: SnapgridCenter
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
 
@@ -943,7 +943,7 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   mirror: GasFilterFlipped
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
 
@@ -957,7 +957,7 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   mirror: GasFilter
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
 
@@ -970,7 +970,7 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   mirror: GasMixerFlipped
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
 
@@ -984,7 +984,7 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   mirror: GasMixer
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
 
@@ -996,7 +996,7 @@
   category: construction-category-atmospherics # DeltaV - Moving Atmos Recipes to Atmospherics Category
   placementMode: SnapgridCenter
   canBuildInImpassable: false
-  conditions:
+  # conditions:
     # Euphoria edit
     # - !type:NoUnstackableInTile
 

--- a/Resources/Prototypes/_Funkystation/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_Funkystation/Recipes/Construction/utilities.yml
@@ -60,7 +60,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit - RPD consistency
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentPump
   - GasVentPumpAlt1
@@ -76,7 +77,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentPump
   - GasVentPumpAlt1
@@ -92,7 +94,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveVent
   - GasPassiveVentAlt1
@@ -108,7 +111,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveVent
   - GasPassiveVentAlt1
@@ -124,7 +128,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentScrubber
   - GasVentScrubberAlt1
@@ -140,7 +145,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentScrubber
   - GasVentScrubberAlt1
@@ -156,7 +162,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasOutletInjector
   - GasOutletInjectorAlt1
@@ -172,7 +179,8 @@
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
   conditions:
-  - !type:NoUnstackableInTile
+  # Euphoria edit
+  # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasOutletInjector
   - GasOutletInjectorAlt1

--- a/Resources/Prototypes/_Funkystation/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_Funkystation/Recipes/Construction/utilities.yml
@@ -59,8 +59,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit - RPD consistency
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentPump
@@ -76,8 +76,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentPump
@@ -93,8 +93,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveVent
@@ -110,8 +110,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasPassiveVent
@@ -127,8 +127,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentScrubber
@@ -144,8 +144,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasVentScrubber
@@ -161,8 +161,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasOutletInjector
@@ -178,8 +178,8 @@
   category: construction-category-atmospherics
   placementMode: AlignAtmosPipeLayers
   canBuildInImpassable: false
-  conditions:
   # Euphoria edit
+  # conditions:
   # - !type:NoUnstackableInTile
   alternativePrototypes:
   - GasOutletInjector


### PR DESCRIPTION
## About the PR
This PR *removes* all restrictions enforced on queueing and building additional atmos devices via the construction menu, bringing players up to mapper parity when Atmos is involved.

## Why / Balance
Device stacking has always been a divisive topic in the community, and it was possible for as long as Wizden's construction ghosts and systems could overlap across multiple players or even latencies. Since the former is a hot topic for exploitation and the RPD makes it seem that the former is happening *despite* Funkystation (our RPD's **original** fork - holy *shit* there is so much baggage) originally allowing device stacking to the extent the RPD permitted, I am removing the barrier and letting Engineering run wild.

Euphoria isn't a gameplay-heavy fork, so this is hopefully a reasonable enough fix to delete the gray area entirely. It also simplifies admin work.

## Technical details
<details><p>
PipeRestrictOverlapSystem (regular) is a serverside system that unanchors every atmos pipe whose one of 12 directions (effectively) conflict with another anchored pipe. This system governs ***all*** placement methods across *every* overlap-restricted entity on the same tile and was added by Wizden so that two pipe nodes cannot have the same layer on the same side in an overlapping configuration. Starlight's version of this system (did we seriously merge "EntitiySystems" as a folder) is a rewrite, but as of now it's a nonfunctioning dud. Both would theoretically work and *have* on Wizden, Starlight *and* Funky, Wizden code notably allowing cursed concoctions to exist only insofar as they didn't have common layers, or were placed by a force-anchoring condition like being Entity Spawn menu-created.

However, NoUnstackableInTile was built **far** earlier when atmos was single-layer - at the time, the restriction made absolute sense because the only *productive* way to have an amount of devices on the same layer was to have one of them be entirely obscured, going in the opposite direction, the likes. The most correct solution would be to rework it to respect PipeRestrictOverlapSystem's context but that's where *upstream* would actually want to weigh in more. I trust both Starlight and Wizden *much* more in their cohesion, so the simplest solution is to simply make our atmos ignore stacking as a shared primitive until either of the two much more coherent forks makes up their mind on how to redesign the entire system.  
Similarly, having the *RPD* enforce NoUnstackableInTile is not a direction I'm interested with because it's not going to be a complete constraint. Remember, that condition *still falters* under the condition multiple players, the Entity Spawn menu, or literally anything else spawning an anchored gas pump decide to do it in a way the overlap restriction system *already declares legal.* I don't want to see any more complaints that "X fork's atmos is better" when the issue was "a gajillion communities defined their exploit line differently."</p></details>

This PR does not affect subframe designs.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm I am the creator of the content in this PR, and allow licensing it under the following license:
  - [X] CC0-1.0 (https://creativecommons.org/publicdomain/zero/1.0/)

## Breaking changes
N/A

**Changelog**
:cl: router
- fix: Fixed the long-standing issue of RPD placement never aligning with construction. Atmos devices can now be placed anywhere, whether they stick depends on whether you're already using one of their layers or not.