### PR TITLE
Minor upstream merge fixes

### DIFF
--- a/Content.Shared/Humanoid/HumanoidProfileSystem.cs
+++ b/Content.Shared/Humanoid/HumanoidProfileSystem.cs
@@ -32,6 +32,7 @@ public sealed class HumanoidProfileSystem : EntitySystem
         ent.Comp.Species = profile.Species;
         ent.Comp.Sex = profile.Sex;
         ent.Comp.Height = profile.Height; // DeltaV
+        ent.Comp.CustomSpecieName = profile.Customspeciename; // Euph
         Dirty(ent);
 
         var sexChanged = new SexChangedEvent(ent.Comp.Sex, profile.Sex);
@@ -55,7 +56,9 @@ public sealed class HumanoidProfileSystem : EntitySystem
     private void OnExamined(Entity<HumanoidProfileComponent> ent, ref ExaminedEvent args)
     {
         var identity = Identity.Entity(ent, EntityManager);
-        var species = ent.Comp.CustomSpecieName != null ? ent.Comp.CustomSpecieName.ToLower() : GetSpeciesRepresentation(ent.Comp.Species).ToLower(); // Euph - csn
+        var species = !string.IsNullOrEmpty(ent.Comp.CustomSpecieName) // Euph - csn
+            ? ent.Comp.CustomSpecieName.ToLower()
+            : GetSpeciesRepresentation(ent.Comp.Species).ToLower();
         var age = GetAgeRepresentation(ent.Comp.Species, ent.Comp.Age);
 
         args.PushText(Loc.GetString("humanoid-appearance-component-examine", ("user", identity), ("age", age), ("species", species)));

--- a/Content.Shared/_Floof/Lewd/Systems/LewdOrganSystem.cs
+++ b/Content.Shared/_Floof/Lewd/Systems/LewdOrganSystem.cs
@@ -51,8 +51,7 @@ public sealed class LewdOrganSystem : EntitySystem
         if (_net.IsClient) // Client-side BodySystem spams mechanism attachments/removals whenever entities move in and out of PVS
             return;
 
-        // TODO: we're not checking if it's in a valid slot? I'm not sure if it's an issue, but if it is, idk how to check
-        AttachOrgan(ent, args.Target);
+        OrganAttached(ent, args.Target);
     }
 
     private void OnLewdRemoved(Entity<LewdOrganComponent> ent, ref OrganGotRemovedEvent args)
@@ -60,7 +59,7 @@ public sealed class LewdOrganSystem : EntitySystem
         if (_net.IsClient) // Client-side BodySystem spams mechanism attachments/removals whenever entities move in and out of PVS
             return;
 
-        DetachOrgan(ent, args.Target);
+        OrganDetached(ent, args.Target);
     }
 
     private void OnLewdExamine(Entity<LewdMobDataComponent> ent, ref GetVerbsEvent<ExamineVerb> args)
@@ -126,8 +125,6 @@ public sealed class LewdOrganSystem : EntitySystem
     /// </summary>
     public void UpdateOrgan(Entity<LewdOrganComponent> organ, EntityUid body)
     {
-        DebugTools.Assert(CompOrNull<OrganComponent>(organ)?.Body == body);
-
         // Original implementation removed and re-added the organ, which seemed to detach the solution from the mob and not add it back.
         // This approach just tries to update the relevant components without removing it.
         var bodyData = EnsureComp<LewdMobDataComponent>(body);
@@ -209,12 +206,12 @@ public sealed class LewdOrganSystem : EntitySystem
         return false;
     }
 
-    private void AttachOrgan(Entity<LewdOrganComponent> organ, EntityUid body)
+    private void OrganAttached(Entity<LewdOrganComponent> organ, EntityUid body)
     {
         UpdateOrgan(organ, body);
     }
 
-    private void DetachOrgan(Entity<LewdOrganComponent> ent, EntityUid body)
+    private void OrganDetached(Entity<LewdOrganComponent> ent, EntityUid body)
     {
         var bodyData = EnsureComp<LewdMobDataComponent>(body);
         var organData = ent.Comp.Data;


### PR DESCRIPTION
## About the PR
- Fixes a bug in the humanoid profile system that caused all entities to have an empty string as their species representation
- Removes a "organ.Body = body" debug assert in the lewd organ system because as it turns out, this field doesn't get assigned until after OrganGotInsertedEvent is fully raised (which is dumb but w/e, i'm not messing with the upstream body system)
- Changes the names of two methods in the lewd organ system as they were highly misleading


## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<img width="303" height="268" alt="image" src="https://github.com/user-attachments/assets/e224d186-0845-4a1a-b54f-bd2ad14e72ee" />

<img width="382" height="263" alt="image" src="https://github.com/user-attachments/assets/65052532-cc0e-4a97-8640-ac6a24cf1a6f" />

</p></details>

**Changelog**
:cl:
- fix: Fixed species names not displaying.
