### PR TITLE
Revenant can be exorcised by anyone with a bible

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/revenant.yml
@@ -65,7 +65,7 @@
       settings: default
   - type: GhostTakeoverAvailable
   - type: Revenant
-    exorcismRequiresBibleUser: true # Imp - Escape hatch, change to false if revenant becomes too OP
+    exorcismRequiresBibleUser: false # Euphoria false<true # Imp - Escape hatch, change to false if revenant becomes too OP
     grindingRequiresSalt: false # Imp - Escape hatch, change to false if revenant becomes too OP # DeltaV - turn false while grinding system is broken
     # spawnOnDeathPrototype: EctoplasmRevenant # DeltaV - different prototype that contains more ectoplasm reagent for normality crystals, commented out
     malfunctionWhitelist:


### PR DESCRIPTION
## About the PR
Exorcising the revenant does not require a holy character.

## Why / Balance
It's too easy for there to be no roundstart holy character on-shift, or for them to be otherwise unavailable. Grinding with salt never worked (it looks for the salt tag on solid items in the grinder, which is something that doesn't exist), and even if it did, is too fiddly and slow a process, making the revenant effectively immortal as long as they choose not to engage the crew near where the grinder is. This allows anyone promoted into an acting chaplain position, either formally or informally, to do the job.

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

https://github.com/user-attachments/assets/47f340f3-5848-4a11-bcc7-885091b55934

</p></details>

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Licensing:
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt)

**Changelog**
:cl:
- tweak: Anyone with a bible can exorcise a revenant
