### PR TITLE
Fix Trait Conflicts Not Actually Conflicting In Trait Menu

### DIFF
--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -6,16 +6,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -41,16 +42,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -71,16 +73,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -99,16 +102,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -128,16 +132,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -156,16 +161,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -184,16 +190,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodBlack
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodBlack
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -208,16 +215,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodWhite
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodWhite
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -236,16 +244,17 @@
   category: BonusPhysical
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
-  conflicts:
-  - ReplaceBloodRed
-  - ReplaceBloodAmmonia
-  - ReplaceBloodCopper
-  - ReplaceBloodInsect
-  - ReplaceBloodSap
-  - ReplaceBloodSlime
-  - ReplaceBloodYellow
-  - ReplaceBloodBlack
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - ReplaceBloodRed
+    - ReplaceBloodAmmonia
+    - ReplaceBloodCopper
+    - ReplaceBloodInsect
+    - ReplaceBloodSap
+    - ReplaceBloodSlime
+    - ReplaceBloodYellow
+    - ReplaceBloodBlack
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -260,10 +269,11 @@
   description: trait-healing-plus-desc
   category: BonusPhysical
   cost: 4
-  conflicts:
-  - HealingMinus
-  - HealingPlus2
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - HealingMinus
+    - HealingPlus2
   - !type:HasCompCondition
     component: Hunger
   - !type:HasCompCondition
@@ -295,10 +305,11 @@
   description: trait-healing-plus-2-desc
   category: BonusPhysical
   cost: 8
-  conflicts:
-  - HealingMinus
-  - HealingPlus
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - HealingMinus
+    - HealingPlus
   - !type:HasCompCondition
     component: Hunger
   - !type:HasCompCondition
@@ -332,10 +343,11 @@
   description: trait-healing-minus-desc
   category: DisabilitiesPhysical
   cost: -1
-  conflicts:
-  - HealingPlus
-  - HealingPlus2
   conditions:
+  - !type:OneOfSpeciesCondition
+    conflicts:
+    - HealingPlus
+    - HealingPlus2
   - !type:HasCompCondition
     component: Hunger
   - !type:HasCompCondition

--- a/Resources/Prototypes/_Euphoria/Traits/physical.yml
+++ b/Resources/Prototypes/_Euphoria/Traits/physical.yml
@@ -7,7 +7,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodAmmonia
     - ReplaceBloodCopper
@@ -43,7 +43,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodCopper
@@ -74,7 +74,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -103,7 +103,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -133,7 +133,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -162,7 +162,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -191,7 +191,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -216,7 +216,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -245,7 +245,7 @@
   cost: 0 # Almost entirely cosmetic
   usesSlots: false
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - ReplaceBloodRed
     - ReplaceBloodAmmonia
@@ -270,7 +270,7 @@
   category: BonusPhysical
   cost: 4
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - HealingMinus
     - HealingPlus2
@@ -306,7 +306,7 @@
   category: BonusPhysical
   cost: 8
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - HealingMinus
     - HealingPlus
@@ -344,7 +344,7 @@
   category: DisabilitiesPhysical
   cost: -1
   conditions:
-  - !type:OneOfSpeciesCondition
+  - !type:TraitDependencyCondition
     conflicts:
     - HealingPlus
     - HealingPlus2

--- a/Resources/Prototypes/_Floof/Traits/Languages/foreigner.yml
+++ b/Resources/Prototypes/_Floof/Traits/Languages/foreigner.yml
@@ -6,10 +6,12 @@
   category: Languages
   cost: -2
   priority: -1 # Give way for natural language traits
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - Foreigner
     - Muted # If you are muted, losing the ability to speak the common tongue has literally no effect
-  conditions:
+    - ForeignOrigin
   - !type:HasCompCondition
     component: LanguageKnowledge
   effects:
@@ -25,9 +27,11 @@
   category: Languages
   cost: -4
   priority: -1 # Give way for natural language traits
-  conflicts:
-    - ForeignerLight
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - ForeignerLight
+    - ForeignOrigin
   - !type:HasCompCondition
     component: LanguageKnowledge
   effects:
@@ -42,10 +46,11 @@
   category: Languages
   cost: -1
   priority: 1
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - Foreigner
     - ForeignerLight
-  conditions:
   - !type:HasCompCondition
     component: LanguageKnowledge
   effects:

--- a/Resources/Prototypes/_Floof/Traits/Lewd/organ_upgrades.yml
+++ b/Resources/Prototypes/_Floof/Traits/Lewd/organ_upgrades.yml
@@ -7,8 +7,10 @@
   category: Lewd
   cost: 0
   usesSlots: false
-  conflicts:
-  - QuadrupleLewdProduction
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - QuadrupleLewdProduction
   effects:
   - !type:ModifyLewdOrgansEffect
     target: All # Todo: specialized traits?
@@ -22,8 +24,10 @@
   category: Lewd
   cost: 1
   usesSlots: false
-  conflicts:
-  - DoubleLewdProduction
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - DoubleLewdProduction
   effects:
   - !type:ModifyLewdOrgansEffect
     target: All
@@ -39,8 +43,10 @@
   category: Lewd
   cost: 0
   usesSlots: false
-  conflicts:
-  - QuadrupleLewdProductionCapacity
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - QuadrupleLewdProductionCapacity
   effects:
   - !type:ModifyLewdOrgansEffect
     target: All
@@ -54,8 +60,10 @@
   category: Lewd
   cost: 1
   usesSlots: false
-  conflicts:
-  - DoubleLewdProductionCapacity
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - DoubleLewdProductionCapacity
   effects:
   - !type:ModifyLewdOrgansEffect
     target: All
@@ -71,8 +79,10 @@
   category: Lewd
   cost: 0
   usesSlots: false
-  conflicts:
-  - LewdDepositionCapacity40
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - LewdDepositionCapacity40
   effects:
   - !type:ModifyLewdOrgansEffect
     target: # Only these two support deposition
@@ -88,8 +98,10 @@
   category: Lewd
   cost: 1
   usesSlots: false
-  conflicts:
-  - LewdDepositionCapacity20
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - LewdDepositionCapacity20
   effects:
   - !type:ModifyLewdOrgansEffect
     target: # Only these two support deposition
@@ -107,8 +119,10 @@
   category: Lewd
   cost: 0
   usesSlots: false
-  conflicts:
-  - LewdDepositionCapacity20
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - LewdDepositionCapacity20 # Come back to this later. Why conflict with the 20 and not the 40?
   effects:
   - !type:ModifyLewdOrgansEffect
     target: All

--- a/Resources/Prototypes/_Floof/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Floof/Traits/disabilities.yml
@@ -5,6 +5,9 @@
   category: Skills
   cost: 2 # Has pros and cons, not sure
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Heavyweight
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -18,8 +21,6 @@
   effects:
   - !type:ModifyDensityEffect
     factor: 0.6
-  conflicts:
-    - Heavyweight
 
 - type: trait
   id: Heavyweight
@@ -28,6 +29,9 @@
   category: Skills
   cost: 2 # Has pros and cons, not sure
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Lightweight
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -37,8 +41,6 @@
     - Harpy # Doesn't really make sense with their wings and flight ability
     - Diona # Trees are heavy as it is.
     - Chitinid # Ants got weight.
-  conflicts:
-    - Lightweight
   effects:
   - !type:ModifyDensityEffect
     factor: 1.4

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -5,9 +5,11 @@
   description: trait-description-CyberEyesFlare
   category: Cybernetics
   cost: 8
-  conflicts:
-  - Blindness
-  - PoorVision
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Blindness
+    - PoorVision
   effects:
   - !type:AddCompsEffect
     components:
@@ -21,10 +23,11 @@
   name: trait-name-CyberEyesNightVision
   description: trait-description-CyberEyesNightVision
   cost: 8
-  conflicts:
-  - Blindness
-  - PoorVision
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Blindness
+    - PoorVision
   - !type:HasJobCondition
     invert: true
     job: Prisoner
@@ -46,9 +49,10 @@
   name: trait-name-CyberEyesSecurity
   description: trait-description-CyberEyesSecurity
   cost: 4
-  conflicts:
-  - CyberEyesOmni
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - CyberEyesOmni
   - !type:InDepartmentCondition
     department: Security
   effects:
@@ -64,7 +68,9 @@
   name: trait-name-CyberEyesMedical
   description: trait-description-CyberEyesMedical
   cost: 4
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - CyberEyesOmni
   effects:
   - !type:AddCompsEffect
@@ -85,10 +91,11 @@
   name: trait-name-CyberEyesOmni
   description: trait-description-CyberEyesOmni
   cost: 6
-  conflicts:
-  - CyberEyesMedical
-  - CyberEyesSecurity
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - CyberEyesMedical
+    - CyberEyesSecurity
   - !type:InDepartmentCondition
     department: Command
   effects:
@@ -497,9 +504,10 @@
   description: trait-glassjaw-desc
   category: Skills
   cost: -2
-  conflicts:
-    - Tenacity
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Tenacity
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -517,7 +525,9 @@
   description: trait-willtodie-desc
   category: Skills
   cost: -1
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - WillToLive
   effects:
   - !type:ModifyCritDeadThresholdEffect
@@ -529,11 +539,11 @@
   description: trait-tenacity-desc
   category: Skills
   cost: 3
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - GlassJaw
     - BrittleBones
-    - Tenacity
-  conditions:
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -551,7 +561,9 @@
   description: trait-willtolive-desc
   category: Skills
   cost: 2
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - WillToDie
     - Redshirt
     - IllFated
@@ -565,9 +577,10 @@
   description: trait-brittlebone-desc
   category: Skills
   cost: -10
-  conflicts:
-    - Tenacity
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Tenacity
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -585,9 +598,10 @@
   description: trait-frail-desc
   category: Skills
   cost: -5
-  conflicts:
-    - Tenacity
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Tenacity
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -605,7 +619,9 @@
   description: trait-illfated-desc
   category: Skills
   cost: -3
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - WillToLive
   effects:
   - !type:ModifyCritDeadThresholdEffect

--- a/Resources/Prototypes/_Floof/Traits/physical.yml
+++ b/Resources/Prototypes/_Floof/Traits/physical.yml
@@ -1,4 +1,4 @@
-﻿# =================     Bionics    ================== #
+# =================     Bionics    ================== #
 - type: trait
   id: CyberEyesFlare
   name: trait-name-CyberEyesFlare
@@ -116,11 +116,11 @@
   description: trait-vigor-desc
   category: Skills
   cost: 4 # I don't think it's extremely useful in combat, but it can help you survive one extra stunbaton hit.
-  conflicts:
-  - Vigor
-  - Lethargy
-  - Weakness
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Lethargy
+    - Weakness
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -139,11 +139,10 @@
   description: trait-lethargy-desc
   category: DisabilitiesPhysical
   cost: -2
-  conflicts:
-  - Vigor
-  - Lethargy
-  - Weakness
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Vigor
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -157,11 +156,10 @@
   description: trait-weakness-desc
   category: DisabilitiesPhysical
   cost: -5 # Getting stunned from 1-2 stunbaton or disabler hits is worth a lot.
-  conflicts:
-  - Vigor
-  - Lethargy
-  - Weakness
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Vigor
   - !type:HasCompCondition
     component: BorgChassis
     invert: true
@@ -177,15 +175,16 @@
   description: trait-talons-desc
   category: BonusPhysical
   cost: 0
-  conflicts:
-    - Claws
   conditions:
-    - !type:OneOfSpeciesCondition
-      invert: true
-      species:
-        - Harpy # Harpies already have talons
-        - Arachnid # Apparently they have a "piercing" bite
-        - Feroxi # Floof - They bite. Piercing damage. Nuff said.
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Claws
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+      - Harpy # Harpies already have talons
+      - Arachnid # Apparently they have a "piercing" bite
+      - Feroxi # Floof - They bite. Piercing damage. Nuff said.
   effects:
     - !type:ModifyUnarmedTraitEffect
       soundHit:
@@ -202,20 +201,21 @@
   description: trait-claws-desc
   category: BonusPhysical
   cost: 0
-  conflicts:
-    - Talons
   conditions:
-    - !type:OneOfSpeciesCondition
-      invert: true
-      species:
-        - Felinid # Felinids already have cat claws.
-        - Tajaran # Tajaran also have cat claws
-        - Reptilian # Reptilians also have cat claws.
-        - Shadekin # Shadowkins also have claws.
-        # - Vulpkanin # Vulpkanin have "Blunt" claws. One could argue this trait "Sharpens" their claws.
-        - Rodentia # Floof - Rodentia already has it
-        - Resomi # Floof - they have claws after port of Goob changes
-        - Feroxi # Floof - They bite. Nuff said.
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Talons
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+      - Felinid # Felinids already have cat claws.
+      - Tajaran # Tajaran also have cat claws
+      - Reptilian # Reptilians also have cat claws.
+      - Shadekin # Shadowkins also have claws.
+      # - Vulpkanin # Vulpkanin have "Blunt" claws. One could argue this trait "Sharpens" their claws.
+      - Rodentia # Floof - Rodentia already has it
+      - Resomi # Floof - they have claws after port of Goob changes
+      - Feroxi # Floof - They bite. Nuff said.
   effects:
     - !type:ModifyUnarmedTraitEffect
       soundHit:
@@ -232,19 +232,20 @@
   description: trait-natural-weapon-removal-desc
   category: BonusPhysical
   cost: 0
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - Talons
     - Claws
-  conditions:
-    - !type:OneOfSpeciesCondition
-      invert: true
-      species:
-        - Human
-        - Oni
-        - SlimePerson
-        - Diona
-        - Arachne
-        - IPC # Other species could justify getting this trait for Blunt stamina damage,
+  - !type:OneOfSpeciesCondition
+    invert: true
+    species:
+      - Human
+      - Oni
+      - SlimePerson
+      - Diona
+      - Arachne
+      - IPC # Other species could justify getting this trait for Blunt stamina damage,
               # but 6 blunt -> 5 blunt is a straight up downgrade.
   effects:
     - !type:ModifyUnarmedTraitEffect
@@ -275,11 +276,12 @@
   description: trait-coldtolerance-desc
   category: Skills
   cost: 1
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - ColdIntolerance
     - ColdIntoleranceAdvanced
     #- ColdToleranceAdvanced
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which already have huge tolerance
@@ -304,11 +306,12 @@
   description: trait-coldtoleranceadvanced-desc
   category: Skills
   cost: 2
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - ColdIntolerance
     - ColdIntoleranceAdvanced
     #- ColdTolerance
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which already have extreme tolerance
@@ -333,11 +336,12 @@
   description: trait-heattolerance-desc
   category: Skills
   cost: 1
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - HeatIntolerance
     - HeatIntoleranceAdvanced
     #- HeatToleranceAdvanced
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which already have this tolerance or something better (only reptilian?)
@@ -359,11 +363,12 @@
   description: trait-heattoleranceadvanced-desc
   category: Skills
   cost: 2
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - HeatIntolerance
     - HeatIntoleranceAdvanced
     #- HeatTolerance
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which already have this tolerance or something better (only reptilian?)
@@ -385,11 +390,12 @@
   description: trait-coldintolerance-desc
   category: Skills
   cost: -1
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - ColdTolerance
     - ColdToleranceAdvanced
     #- ColdIntoleranceAdvanced
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which would put them in danger at room temperature (maybe reptilian)
@@ -414,11 +420,12 @@
   description: trait-coldintoleranceadvanced-desc
   category: Skills
   cost: -2
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - ColdTolerance
     - ColdToleranceAdvanced
     #- ColdIntolerance
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which would put them in danger at room temperature (reptilian)
@@ -443,11 +450,12 @@
   description: trait-heatintolerance-desc
   category: Skills
   cost: -1
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - HeatTolerance
     - HeatToleranceAdvanced
     #- HeatIntoleranceAdvanced
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   effects:
@@ -460,11 +468,12 @@
   description: trait-heatintoleranceadvanced-desc
   category: Skills
   cost: -2
-  conflicts:
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
     - HeatTolerance
     - HeatToleranceAdvanced
     #- HeatIntolerance
-  conditions:
   - !type:HasCompCondition
     component: Temperature
   - !type:OneOfSpeciesCondition # Don't give it to species which would put them in danger of regular room temperature.

--- a/Resources/Prototypes/_Floof/Traits/skills.yml
+++ b/Resources/Prototypes/_Floof/Traits/skills.yml
@@ -47,10 +47,11 @@
   description: trait-spearmaster-desc
   category: Skills
   cost: 0
-  conflicts:
-  - Swashbuckler
-  - WeaponsGeneralist
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Swashbuckler
+    - WeaponsGeneralist
   - !type:OneOfSpeciesCondition
     species:
     - Oni
@@ -71,10 +72,11 @@
   description: trait-swashbuckler-desc
   category: Skills
   cost: 0
-  conflicts:
-  - Spearmaster
-  - WeaponsGeneralist
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Spearmaster
+    - WeaponsGeneralist
   - !type:OneOfSpeciesCondition
     species:
     - Oni
@@ -95,10 +97,11 @@
   description: trait-weaponsgeneralist-desc
   category: Skills
   cost: 0
-  conflicts:
-  - Spearmaster
-  - Swashbuckler
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - Spearmaster
+    - Swashbuckler
   - !type:OneOfSpeciesCondition
     species:
     - Oni
@@ -122,9 +125,10 @@
   description: trait-description-OniShooting
   category: Skills
   cost: -6
-  conflicts:
-  - BadShooting
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - BadShooting
   - !type:OneOfSpeciesCondition
     invert: true
     species:
@@ -145,9 +149,10 @@
   description: trait-description-BadShooting
   category: Skills
   cost: -2
-  conflicts:
-  - OniShooting
   conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - OniShooting
   - !type:OneOfSpeciesCondition
     invert: true
     species:

--- a/Resources/Prototypes/_Starlight/Traits/disabilities.yml
+++ b/Resources/Prototypes/_Starlight/Traits/disabilities.yml
@@ -4,6 +4,12 @@
   description: trait-highlightsensitivity-desc
   category: DisabilitiesPhysical # Euph
   cost: -1
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - ExtremeLightSensitivity
+  - !type:IsSpeciesCondition
+    species: Shadekin
   effects:
     - !type:OverrideCompsEffect
       components:
@@ -13,11 +19,6 @@
             0.8: Annoying
             5: High
             10: Extreme
-  conditions:
-    - !type:IsSpeciesCondition
-      species: Shadekin
-  conflicts:
-    - ExtremeLightSensitivity
 
 - type: trait
   id: ExtremeLightSensitivity
@@ -25,6 +26,12 @@
   description: trait-extremelightsensitivity-desc
   category: DisabilitiesPhysical # Euph
   cost: -2
+  conditions:
+  - !type:TraitDependencyCondition
+    conflicts:
+    - HighLightSensitivity
+  - !type:IsSpeciesCondition
+    species: Shadekin
   effects:
     - !type:OverrideCompsEffect
       components:
@@ -34,8 +41,3 @@
             0.7: Annoying
             0.8: High
             5: Extreme
-  conditions:
-    - !type:IsSpeciesCondition
-      species: Shadekin
-  conflicts:
-    - HighLightSensitivity


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Adjusted most of our traits to go from just
`conflicts`
to 
```
conditions:
- !type:TraitDependencyCondition
  conflicts:
```
Also removed the conflict between the two negative stamina traits, so now you can make yourself even weaker. I had a separate PR for this already up. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Something changed at some point, and our old trait conflict method stopped working. You'd be able to select multiple traits that actually conflict with each other, and it would remove some of your traits as a result when you loaded into the game. 
So now the trait conflicts should work as intended. Nothing should really have changed about them. 
Removing the conflict between the two negative stamina traits was requested by people who want to make themselves more pathetic. 

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
A whole lot of yml changes. Basically the same thing each time, though. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
I can't possibly show all of the possible combinations of conflicts, but here's some of them. Trust that I tested the rest. 

<img width="1035" height="1098" alt="image" src="https://github.com/user-attachments/assets/6b051d6c-2088-4b67-9e9d-d4baa8d269a7" />

<img width="1022" height="1101" alt="image" src="https://github.com/user-attachments/assets/a0029c14-86a0-4566-a5a1-4ec0030516f3" />

<img width="1025" height="1108" alt="image" src="https://github.com/user-attachments/assets/b8124c5e-35e6-4351-8220-292d7bd73d33" />

<img width="1023" height="1104" alt="image" src="https://github.com/user-attachments/assets/88dfed20-a438-47a5-a213-04c827af2477" />

<img width="1018" height="1105" alt="image" src="https://github.com/user-attachments/assets/ff669339-3d7d-4775-a376-f8bf3b753385" />

<img width="1021" height="665" alt="image" src="https://github.com/user-attachments/assets/5b3feeaa-cee4-4b7c-ab8b-547ce026f95e" />


</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:
  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Changed the two negative stamina traits to not conflict with each other. You can make yourself even more pathetic!
- fix: Fixed trait conflicts not working correctly at the trait screen. 
