### PR TITLE
More Civil Antag stuff

### DIFF
--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -9,7 +9,7 @@ namespace Content.Server.GameTicking.Rules;
 
 /// <summary>
 /// System that responds to AntagSelectEntityEvent, gets the player's currently selected character, spawns
-/// it in the same way regular players are spawned, and sets args.Entity to the result. This is dinstinct functionality from 
+/// it in the same way regular players are spawned, and sets args.Entity to the result. This is dinstinct functionality from
 /// <see cref="AntagLoadProfileRuleSystem"/> in that while that system gets the appearance of the player's character,
 /// this one is for when you want the whole character, name, traits, and all.
 /// </summary>
@@ -27,26 +27,26 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
 
     private void OnSelectEntity(Entity<AntagLoadPlayerCharacterRuleComponent> ent, ref AntagSelectEntityEvent args)
     {
-        if (args.Handled) //If something already handled this, don't handle it! 
+        if (args.Handled) //If something already handled this, don't handle it!
             return;
 
-	//Get the player's selected character or, if the session is null, whatever the fuck.
-	var character = args.Session != null
-	    ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
-	    : HumanoidCharacterProfile.RandomWithSpecies();
+        //Get the player's selected character or, if the session is null, whatever the fuck.
+        var character = args.Session != null
+            ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
+            : HumanoidCharacterProfile.RandomWithSpecies();
 
-	//Spawn it like it was a player
-	//It seems this function technically spawns the entity somewhere first,
-	//but the only purpose of this system is to hand over an entity to
-	//AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
-	var spawnedCharacter = _ent.System<StationSpawningSystem>()
-	    .SpawnPlayerMob(Transform(ent.Owner).Coordinates, null, character, null);
-	
+        //Spawn it like it was a player
+        //It seems this function technically spawns the entity somewhere first,
+        //but the only purpose of this system is to hand over an entity to
+        //AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
+        var spawnedCharacter = _ent.System<StationSpawningSystem>()
+            .SpawnPlayerMob(Transform(ent.Owner).Coordinates, null, character, null);
+
         //Create and raise this event so the character is given their traits
         var spawnedEvent = new GhostRoleSpawnerUsedEvent(ent.Owner, spawnedCharacter, character, args.Session);
         RaiseLocalEvent(spawnedCharacter, spawnedEvent, true);
 
-	//Finally, hand over the player's character to the event raiser 
-	args.Entity = spawnedCharacter;
+        //Finally, hand over the player's character to the event raiser
+        args.Entity = spawnedCharacter;
     }
 }

--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -3,6 +3,7 @@ using Content.Server.GameTicking.Rules.Components;
 using Content.Server.Preferences.Managers;
 using Content.Shared.Preferences;
 using Content.Server.Station.Systems;
+using Content.Server.Ghost.Roles.Events;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -28,9 +29,6 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
     {
         if (args.Handled) //If something already handled this, don't handle it! 
             return;
-	    
-	var uid = ent.Owner;
-
 
 	//Get the player's selected character or, if the session is null, whatever the fuck.
 	var character = args.Session != null
@@ -41,7 +39,14 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
 	//It seems this function technically spawns the entity somewhere first,
 	//but the only purpose of this system is to hand over an entity to
 	//AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
-	args.Entity = _ent.System<StationSpawningSystem>()
-	    .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
+	var spawnedCharacter = _ent.System<StationSpawningSystem>()
+	    .SpawnPlayerMob(Transform(ent.Owner).Coordinates, null, character, null);
+	
+        //Create and raise this event so the character is given their traits
+        var spawnedEvent = new GhostRoleSpawnerUsedEvent(ent.Owner, spawnedCharacter, character, args.Session);
+        RaiseLocalEvent(spawnedCharacter, spawnedEvent, true);
+
+	//Finally, hand over the player's character to the event raiser 
+	args.Entity = spawnedCharacter;
     }
 }

--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -1,19 +1,13 @@
 using Content.Server.Antag;
 using Content.Server.GameTicking.Rules.Components;
-using Content.Server.Humanoid;
 using Content.Server.Preferences.Managers;
-using Content.Shared.Humanoid;
-using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
-using Robust.Shared.Prototypes;
 using Content.Server.Station.Systems;
 
 namespace Content.Server.GameTicking.Rules;
 
 public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoadPlayerCharacterRuleComponent>
 {
-    [Dependency] private readonly HumanoidAppearanceSystem _humanoid = default!;
-    [Dependency] private readonly IPrototypeManager _proto = default!;
     [Dependency] private readonly IServerPreferencesManager _prefs = default!;
     [Dependency] private readonly IEntityManager _ent = default!;
 
@@ -29,17 +23,19 @@ public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoa
         if (args.Handled) //If something already handled this, don't handle it! 
             return;
 	    
-        var uid = ent.Owner;
-        var component = ent.Comp;
-        
-        //Get the player's selected character or, if the session is null, whatever the fuck.
-        var character = args.Session != null
-            ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
-            : HumanoidCharacterProfile.RandomWithSpecies();
+	var uid = ent.Owner;
 
-        //Spawn it like it was a player
-        //Where does this spawn it at first? Hell if I know. It ends up where it's supposed to be anyways.
-        args.Entity = _ent.System<StationSpawningSystem>()
-            .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
+
+	//Get the player's selected character or, if the session is null, whatever the fuck.
+	var character = args.Session != null
+	    ? _prefs.GetPreferences(args.Session.UserId).SelectedCharacter as HumanoidCharacterProfile
+	    : HumanoidCharacterProfile.RandomWithSpecies();
+
+	//Spawn it like it was a player
+	//It seems this function technically spawns the entity somewhere first,
+	//but the only purpose of this system is to hand over an entity to
+	//AntagSelectEntityEvent. This doesn't matter in any case, but irks me.
+	args.Entity = _ent.System<StationSpawningSystem>()
+	    .SpawnPlayerMob(Transform(uid).Coordinates, null, character, null);
     }
 }

--- a/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
+++ b/Content.Server/_Floof/GameTicking/Rules/AntagLoadPlayerCharacterRuleSystem.cs
@@ -6,6 +6,12 @@ using Content.Server.Station.Systems;
 
 namespace Content.Server.GameTicking.Rules;
 
+/// <summary>
+/// System that responds to AntagSelectEntityEvent, gets the player's currently selected character, spawns
+/// it in the same way regular players are spawned, and sets args.Entity to the result. This is dinstinct functionality from 
+/// <see cref="AntagLoadProfileRuleSystem"/> in that while that system gets the appearance of the player's character,
+/// this one is for when you want the whole character, name, traits, and all.
+/// </summary>
 public sealed class AntagLoadPlayerCharacterRuleSystem : GameRuleSystem<AntagLoadPlayerCharacterRuleComponent>
 {
     [Dependency] private readonly IServerPreferencesManager _prefs = default!;

--- a/Resources/Locale/en-US/_Floof/mind/role-types.ftl
+++ b/Resources/Locale/en-US/_Floof/mind/role-types.ftl
@@ -1,0 +1,3 @@
+role-type-generic-employee-name = Employee: Non-Station
+role-type-donkco-employee-name = Employee: Donk Co!
+role-type-solarian-allience-employee-name = Employee: Solarian Alliance

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -26,7 +26,7 @@
     - id: SpiderClownSpawn
     - id: SpiderSpawn
     - id: VentClog
-    - id: AntagFoodCriticSpawn # Euphoria - Dunno where exactly to put this so it's here for now, this wasn't a thought-out decision to put it here specifically so if you feel like it should be somewhere else, be my guest.
+    - id: FoodCriticSpawn # Euphoria - Dunno where exactly to put this so it's here for now, this wasn't a thought-out decision to put it here specifically so if you feel like it should be somewhere else, be my guest.
 
 - type: entityTable
   id: BasicAntagEventsTable

--- a/Resources/Prototypes/_Floof/Gamerules/events.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/events.yml
@@ -1,7 +1,7 @@
 
 - type: entity
   parent: BaseGameRule
-  id: AntagFoodCriticSpawn
+  id: FoodCriticSpawn
   components:
   - type: StationEvent
     weight: 8
@@ -20,7 +20,7 @@
   - type: AntagSelection
     agentName: food-critic-round-end-agent-name
     definitions:
-    - spawnerPrototype: SpawnPointGhostAntagFoodCritic
+    - spawnerPrototype: SpawnPointFoodCritic
       min: 1
       max: 1
       pickPlayer: false

--- a/Resources/Prototypes/_Floof/Gamerules/events.yml
+++ b/Resources/Prototypes/_Floof/Gamerules/events.yml
@@ -25,8 +25,8 @@
       max: 1
       pickPlayer: false
       startingGear: FoodCriticGear
-      #roleLoadout:
-      #- RoleSurvivalSpaceNinja
+      roleLoadout:
+      - RoleSurvivalStandard
       briefing:
         text: food-critic-role-greeting
         color: Lime

--- a/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
+++ b/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
@@ -60,7 +60,7 @@
 - type: entity
   categories: [ HideSpawnMenu, Spawner ]
   parent: BaseAntagSpawner
-  id: SpawnPointGhostAntagFoodCritic
+  id: SpawnPointFoodCritic
   components:
   - type: GhostRole
     name: ghost-role-information-food-critic-name

--- a/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
+++ b/Resources/Prototypes/_Floof/Roles/Ghost/food_critic.yml
@@ -35,6 +35,7 @@
   - type: MindRole
     antagPrototype: FoodCriticAntagPrototype
     subtype: role-subtype-food-critic
+    roleType: EmployeeDonkco
     #exclusiveAntag: true #Uncommenting this breaks everything as of July 2nd 2026
   - type: FoodCriticRole
 

--- a/Resources/Prototypes/_Floof/Roles/role_types.yml
+++ b/Resources/Prototypes/_Floof/Roles/role_types.yml
@@ -1,0 +1,5 @@
+- type: roleType
+  id: EmployeeDonkco
+  name: role-type-donkco-employee-name
+  color: '#ffff00'
+  symbol: "D"


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
<!-- If you are new to the Panta Rhei repository, please read the [Contributing Guidelines](https://github.com/Floof-Station/Panta-Rhei/blob/master/CONTRIBUTING.md) -->
Alright, here, the final of like, 4 PRs I've made surrounding the Food Critic//civil antags. For now. Probably. I think.

Finally, after 3 months of food critics spawning wherever they damn well pleased, there's an `AntagStationSpawnRule`. which gets a random latejoin spawnpoint and puts them there. If there is none, it puts them on any random tile on a station like `AntagRandomSpawnRule` does. I can't imagine why there would ever be no latejoin spawnpoints in-game, but i didn't want it to error-out so easily. I would have made it so that one could specify a preferred map and it would adhere to the player's selected character's spawn preferences, but this is simpler.

In addition, I changed the Food Critic to use that rule instead of `AntagRandomSpawnRule` so they won't pop in just anywhere anymore, and polished and commented and re-commented some things. 

Nothing functional or player-facing has changed except for the new spawn rule and the Food Critic using it. 

## Why / Balance
<!-- If this PR affects balance, discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, the Food Critic and other theoretical roles like it (SOSHA is just a week away, I swear. I keep missing the lore committee meetings that I'd want to present SOSHA lore at) would simply appear somewhere random on the station with absolutely no limits as to where that could be. It could be in the TEG, the vault, someone's room while they're [Content removed for violating community guidelines], literally anywhere. Not a huge problem, but I feel like it could ruin someone's half hour. Until now, the only antag spawn rules that exist were made for a horrible creatures who wish only death and destruction, not polite culinary connoisseurs or safety inspectors. Now antags can easily appear as if they just got off a shuttle or are leaving their room instead of like they just clawed their way out of the sewers.

## Technical details
<!-- If your PR contains major codebase changes, include a summary of code changes for easier review. -->
Not much to say here that hasn't been said already, but apparently Wizden is planning to overhaul the antag systems dramatically enough that any new antags will create technical debt, so all this will probably have to be come back to in like, maybe a year. By merging this you are taking on a bit of technical debt. I plan and hope to still be around and contributing here when that comes down, and to deal with that myself, but I'd understand not being keen on relying on someone's promise that they'll _definitely_ deal with something in a year and a half. 

Also, please ignore everything having to do with Org files. I was using them to write design and feature documentation alongside the code for contributors who were new to prototyping, in a similar vein to the Wizden dev wiki but hopefully better, but I have been informed that that is a "maintenance burden", so they were deleted. I left their corpses in the git history in case I found the energy to work on them anyway, but I didn't and I probably never will. I don't feel like touching them in any way now. 

## Media
<details> <summary><h3>Click to show</h3></summary> <p>

<!-- This is default collapsed, readers click to expand it and see all your media -->
[![Example Media Embed](https://example.com/thisimageisntreal.png)](https://github.com/user-attachments/assets/ec2516b3-f912-4a12-aa69-0798b1d4d6eb)

</p></details>

## Requirements
<!-- Confirm the following by placing an X in the brackets: [X] -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Licensing:
<!-- This is for the benefit of other forks wishing to port features from DeltaV
Our repository is AGPL, meaning projects using the MIT license would have to ask for permission from the PR author (ideally that's you, reading this) before being allowed to port it over
This just saves them the trouble. Note that AGPL or MIT licensing is only applicable to SOFTWARE, and that assets such as textures and audio have their own licensing scheme that is defined in the codebase itself. -->
- [X] I confirm that I am the creator of the content in this PR, and allow licensing it under the following license(s), or that the original author has given me permission to do so:

  - [X] MIT (https://github.com/Floof-Station/Panta-Rhei/blob/master/LICENSE-MIT.txt) <!-- This one is required to contribute to Floofstation -->
    <!-- Feel free to add more licenses as you see fit -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
None.

**Changelog**
<!-- See https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html#changelog for guidelines. -->
:cl:
- tweak: Food Critic ghost role spawns in the same places that station crew do when latejoining.
